### PR TITLE
Delta pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -121,6 +121,8 @@ static int Quiescence(int alpha, const int beta, S_BOARD *pos, S_SEARCHINFO *inf
 	int score = EvalPosition(pos);
 	if (score >= beta)
 		return score;
+	if ((score + Q_VAL * 2) < alpha) // Very pessimistic (forced by poor eval) delta pruning
+		return alpha;
 	if (score > alpha)
 		alpha = score;
 


### PR DESCRIPTION
Simple, very pessimistic delta pruning. Cuts nodes in quiescence search where the side to move is down two queens according to eval. Eval doesn't do a good job evaluating potential for pawn promotion or captures so the delta pruning must be very pessimistic to not cut nodes right before such moves.
It still cuts a fair amount of nodes and as such it should be a decent improvement to search speed at a hopefully very low cost (cutting few or no good lines).