### PR TITLE
Platform-independent RNG

### DIFF
--- a/src/hashkeys.c
+++ b/src/hashkeys.c
@@ -1,16 +1,19 @@
 // hashkeys.c
 
-#include <stdlib.h>
-
 #include "types.h"
 
+uint64_t rand64() {
 
-#define RAND_64 ((uint64_t)rand() |	   \
-				 (uint64_t)rand() << 15 | \
-				 (uint64_t)rand() << 30 | \
-				 (uint64_t)rand() << 45 | \
-				 ((uint64_t)rand() & 0xf) << 60)
+    // http://vigna.di.unimi.it/ftp/papers/xorshift.pdf
 
+    static uint64_t seed = 1070372ull;
+
+    seed ^= seed >> 12;
+    seed ^= seed << 25;
+    seed ^= seed >> 27;
+
+    return seed * 2685821657736338717ull;
+}
 
 // Zobrist key tables
 uint64_t PieceKeys[PIECE_NB][64];
@@ -23,25 +26,25 @@ static void InitHashKeys() __attribute__((constructor));
 static void InitHashKeys() {
 
 	// Side to play
-	SideKey = RAND_64;
+	SideKey = rand64();
 
 	// En passant
 	for (int sq = A1; sq <= H8; ++sq)
-			PieceKeys[0][sq] = RAND_64;
+		PieceKeys[0][sq] = rand64();
 
 	// White pieces
 	for (int piece = wP; piece <= wK; ++piece)
 		for (int sq = A1; sq <= H8; ++sq)
-			PieceKeys[piece][sq] = RAND_64;
+			PieceKeys[piece][sq] = rand64();
 
 	// Black pieces
 	for (int piece = bP; piece <= bK; ++piece)
 		for (int sq = A1; sq <= H8; ++sq)
-			PieceKeys[piece][sq] = RAND_64;
+			PieceKeys[piece][sq] = rand64();
 
 	// Castling rights
 	for (int i = 0; i < 16; ++i)
-		CastleKeys[i] = RAND_64;
+		CastleKeys[i] = rand64();
 }
 
 uint64_t GeneratePosKey(const Position *pos) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -38,12 +38,12 @@ void benchmark(int depth, Position *pos, SearchInfo *info) {
 		ClearHashTable(pos->hashTable);
 	}
 
-	int endTime = GetTimeMs();
+	int elapsed = GetTimeMs() - startTime;
 
 	printf("Benchmark complete:\n");
-	printf("Time : %dms\n", endTime - startTime);
+	printf("Time : %dms\n", elapsed);
 	printf("Nodes: %" PRId64 "\n", nodes);
-	printf("NPS  : %" PRId64 "\n", nodes / ((endTime - startTime) / 1000));
+	printf("NPS  : %" PRId64 "\n", 1000 * nodes / (1 + elapsed));
 }
 
 #ifdef DEV

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -60,7 +60,7 @@ void ClearHashTable(HashTable *table) {
 void InitHashTable(HashTable *table, uint64_t MB) {
 
 	// Ignore if already initialized with this size
-	if (table->MB == MB) {
+	if (table->TT != NULL && table->MB == MB) {
 		printf("HashTable already initialized to %" PRIu64 ".\n", MB);
 		fflush(stdout);
 		return;


### PR DESCRIPTION
As rand() works differently on different platforms, bench results varied between linux and windows in some cases. Using the psuedo-RNG from Ethereal, at least for now, fixes the problem.

Also a couple of minor improvements:
- Cleanup bench, also might avoid errors when the bench completes too fast.
- Avoid checking table size, which at that point is uninitialized, the first time TT is initialized.