### PR TITLE
Check only for same turn to move

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -53,10 +53,10 @@ static int PickNextMove(MoveList *list) {
 // Check if current position is a repetition
 static bool IsRepetition(const Position *pos) {
 
-	for (int index = pos->hisPly - pos->fiftyMove; index < pos->hisPly - 1; ++index) {
-
-		assert(index >= 0 && index < MAXGAMEMOVES);
-		if (pos->posKey == pos->history[index].posKey)
+	for (int i = pos->hisPly - 2; i >= pos->hisPly - pos->fiftyMove; i -= 2) {
+ 
+		assert(i >= 0 && i < MAXGAMEMOVES);
+		if (pos->posKey == pos->history[i].posKey)
 			return true;
 	}
 


### PR DESCRIPTION
Tiny speedup of IsRepetition by incrementing by 2 and traversing positions backwards from the end:
- A position with the same hash but the other side to move (every other position) should in a perfect world never happen, but even if it did, it wouldn't signify a repetition.
- Short repetitions near the end of a PV are probably more common than long cycles of shuffling, so looking at the most recent positions first will be slightly faster, slightly more often. When there is no repetition this shouldn't affect performance at all.

Test should have used lower bounds like -4, 0:

ELO   | 1.20 +- 3.33 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -0.40 (-2.94, 2.94) [-1.50, 4.50]
Games | N: 31250 W: 11743 L: 11635 D: 7872