### PR TITLE
Pv list on the stack

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -648,30 +648,3 @@ void GenAllMoves(const Position *pos, MoveList *list) {
 
 	assert(MoveListOk(list, pos));
 }
-
-// Checks the given move is legal in the given position
-// bool MoveExists(Position *pos, const int move) {
-
-// 	MoveList list[1];
-
-// 	// Generate all moves in the position
-// 	GenAllMoves(pos, list);
-
-// 	// Loop through them, looking for a match
-// 	for (unsigned int i = 0; i < list->count; ++i) {
-
-// 		if (!(list->moves[i].move == move))
-// 			continue;
-
-// 		// The movegen gens some illegal moves, so we must verify it is legal.
-// 		// If it isn't legal then the given move is not legal in the position.
-// 		// MakeMove takes it back immediately so we just break and return false.
-// 		if (!MakeMove(pos, list->moves[i].move))
-// 			break;
-
-// 		// If it's legal we take it back and return true.
-// 		TakeMove(pos);
-// 		return true;
-// 	}
-// 	return false;
-// }

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -650,28 +650,28 @@ void GenAllMoves(const Position *pos, MoveList *list) {
 }
 
 // Checks the given move is legal in the given position
-bool MoveExists(Position *pos, const int move) {
+// bool MoveExists(Position *pos, const int move) {
 
-	MoveList list[1];
+// 	MoveList list[1];
 
-	// Generate all moves in the position
-	GenAllMoves(pos, list);
+// 	// Generate all moves in the position
+// 	GenAllMoves(pos, list);
 
-	// Loop through them, looking for a match
-	for (unsigned int i = 0; i < list->count; ++i) {
+// 	// Loop through them, looking for a match
+// 	for (unsigned int i = 0; i < list->count; ++i) {
 
-		if (!(list->moves[i].move == move))
-			continue;
+// 		if (!(list->moves[i].move == move))
+// 			continue;
 
-		// The movegen gens some illegal moves, so we must verify it is legal.
-		// If it isn't legal then the given move is not legal in the position.
-		// MakeMove takes it back immediately so we just break and return false.
-		if (!MakeMove(pos, list->moves[i].move))
-			break;
+// 		// The movegen gens some illegal moves, so we must verify it is legal.
+// 		// If it isn't legal then the given move is not legal in the position.
+// 		// MakeMove takes it back immediately so we just break and return false.
+// 		if (!MakeMove(pos, list->moves[i].move))
+// 			break;
 
-		// If it's legal we take it back and return true.
-		TakeMove(pos);
-		return true;
-	}
-	return false;
-}
+// 		// If it's legal we take it back and return true.
+// 		TakeMove(pos);
+// 		return true;
+// 	}
+// 	return false;
+// }

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -8,4 +8,4 @@
 void GenAllMoves(const Position *pos, MoveList *list);
 void GenNoisyMoves(const Position *pos, MoveList *list);
 void GenQuietMoves(const Position *pos, MoveList *list);
-bool MoveExists(Position *pos, const int move);
+// bool MoveExists(Position *pos, const int move);

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -8,4 +8,3 @@
 void GenAllMoves(const Position *pos, MoveList *list);
 void GenNoisyMoves(const Position *pos, MoveList *list);
 void GenQuietMoves(const Position *pos, MoveList *list);
-// bool MoveExists(Position *pos, const int move);

--- a/src/search.c
+++ b/src/search.c
@@ -107,14 +107,13 @@ static void PrintThinking(const SearchInfo *info, Position *pos, const PV pv, co
 		printf("nps %" PRId64 " ", ((info->nodes * 1000) / timeElapsed));
 
 	// Hashfull
-	if (info->nodes > (uint64_t)currentDepth)
-		printf("hashfull %d ", HashFull(pos));
+	printf("hashfull %d ", HashFull(pos));
 
 	// Principal variation
 	printf("pv");
-	for (int i = 0; i < pv.length; i++) {
+	for (int i = 0; i < pv.length; i++)
 		printf(" %s", MoveToStr(pv.line[i]));
-	}
+
 	printf("\n");
 
 #ifdef SEARCH_STATS
@@ -242,6 +241,8 @@ static int AlphaBeta(int alpha, const int beta, int depth, Position *pos, Search
 	assert(beta  <=  INFINITE);
 	assert(beta  >= -INFINITE);
 
+	const bool pvNode = alpha != beta - 1;
+
 	PV pv_from_here;
     pv->length = 0;
 
@@ -287,7 +288,8 @@ static int AlphaBeta(int alpha, const int beta, int depth, Position *pos, Search
 	int pvMove = NOMOVE;
 
 	// Probe transposition table
-	if (ProbeHashEntry(pos, &pvMove, &score, alpha, beta, depth)) {
+	if (ProbeHashEntry(pos, &pvMove, &score, alpha, beta, depth)
+		&& (depth == 0 || !pvNode)) {
 #ifdef SEARCH_STATS
 		pos->hashTable->cut++;
 #endif

--- a/src/search.c
+++ b/src/search.c
@@ -84,10 +84,9 @@ static void ClearForSearch(Position *pos, SearchInfo *info) {
 }
 
 // Print thinking
-static void PrintThinking(const SearchInfo *info, Position *pos, const int bestScore, const int currentDepth) {
+static void PrintThinking(const SearchInfo *info, Position *pos, const PV pv, const int bestScore, const int currentDepth) {
 
 	unsigned timeElapsed = GetTimeMs() - info->starttime;
-	int pvMoves;
 
 	printf("info score ");
 
@@ -113,9 +112,8 @@ static void PrintThinking(const SearchInfo *info, Position *pos, const int bestS
 
 	// Principal variation
 	printf("pv");
-	pvMoves = GetPvLine(currentDepth, pos);
-	for (int pvNum = 0; pvNum < pvMoves; ++pvNum) {
-		printf(" %s", MoveToStr(pos->pvArray[pvNum]));
+	for (int i = 0; i < pv.length; i++) {
+		printf(" %s", MoveToStr(pv.line[i]));
 	}
 	printf("\n");
 
@@ -128,20 +126,23 @@ static void PrintThinking(const SearchInfo *info, Position *pos, const int bestS
 }
 
 // Print conclusion of search - best move and ponder move
-static void PrintConclusion(const Position *pos) {
+static void PrintConclusion(const PV pv) {
 
-	const int   bestMove = pos->pvArray[0];
-	const int ponderMove = pos->pvArray[1];
+	const int   bestMove = pv.line[0];
+	const int ponderMove = pv.line[1];
 
 	printf("bestmove %s", MoveToStr(bestMove));
-	if (ponderMove != NOMOVE)
-		printf(" ponder %s\n", MoveToStr(ponderMove));
-	printf("\n");
+	if (pv.length > 1)
+		printf(" ponder %s", MoveToStr(ponderMove));
+	printf("\n\n");
 	fflush(stdout);
 }
 
 // Quiescence
-static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info) {
+static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info, PV *pv) {
+
+	PV pvFromHere;
+    pv->length = 0;
 
 	assert(CheckBoard(pos));
 	assert(beta > alpha);
@@ -193,7 +194,7 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
 
 		// Recursively search the positions after making the moves, skipping illegal ones
 		if (!MakeMove(pos, move)) continue;
-		score = -Quiescence(-beta, -alpha, pos, info);
+		score = -Quiescence(-beta, -alpha, pos, info, &pvFromHere);
 		TakeMove(pos);
 
 		movesTried++;
@@ -203,21 +204,27 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
 
 		if (score > bestScore) {
 
-			// If score beats beta we have a cutoff
-			if (score >= beta) {
-
-	#ifdef SEARCH_STATS
-				if (movesTried == 1) info->fhf++;
-				info->fh++;
-	#endif
-				return score;
-			}
-
 			bestScore = score;
 
 			// If score beats alpha we update alpha
-			if (score > alpha)
+			if (score > alpha) {
 				alpha = score;
+
+				// Update the Principle Variation
+                pv->length = 1 + pvFromHere.length;
+                pv->line[0] = move;
+                memcpy(pv->line + 1, pvFromHere.line, sizeof(int) * pvFromHere.length);
+
+				// If score beats beta we have a cutoff
+				if (score >= beta) {
+
+		#ifdef SEARCH_STATS
+					if (movesTried == 1) info->fhf++;
+					info->fh++;
+		#endif
+					return score;
+				}
+			}
 		}
 	}
 
@@ -225,7 +232,7 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
 }
 
 // Alpha Beta
-static int AlphaBeta(int alpha, const int beta, int depth, Position *pos, SearchInfo *info, const int doNull) {
+static int AlphaBeta(int alpha, const int beta, int depth, Position *pos, SearchInfo *info, PV *pv, const int doNull) {
 
 	assert(CheckBoard(pos));
 	assert(beta > alpha);
@@ -235,12 +242,15 @@ static int AlphaBeta(int alpha, const int beta, int depth, Position *pos, Search
 	assert(beta  <=  INFINITE);
 	assert(beta  >= -INFINITE);
 
+	PV pv_from_here;
+    pv->length = 0;
+
 	MoveList list[1];
 	list->count = list->next = 0;
 
 	// Quiescence at the end of search
 	if (depth <= 0)
-		return Quiescence(alpha, beta, pos, info);
+		return Quiescence(alpha, beta, pos, info, &pv_from_here);
 
 	// Check time situation
 	CheckTime(info);
@@ -317,7 +327,7 @@ static int AlphaBeta(int alpha, const int beta, int depth, Position *pos, Search
 	if (doNull && score >= beta && pos->ply && (pos->bigPieces[pos->side] > 0) && depth >= 4) {
 
 		MakeNullMove(pos);
-		score = -AlphaBeta(-beta, -beta + 1, depth - 4, pos, info, false);
+		score = -AlphaBeta(-beta, -beta + 1, depth - 4, pos, info, &pv_from_here, false);
 		TakeNullMove(pos);
 
 		// Cutoff
@@ -364,11 +374,11 @@ standard_search:
 
 		// Do zero-window searches around alpha on moves other than the PV
 		if (movesTried > 0)
-			score = -AlphaBeta(-alpha - 1, -alpha, depth - 1, pos, info, true);
+			score = -AlphaBeta(-alpha - 1, -alpha, depth - 1, pos, info, &pv_from_here, true);
 
 		// Do normal search on PV, and non-PV if the zero-window indicates it beats PV
 		if ((score > alpha && score < beta) || movesTried == 0)
-			score = -AlphaBeta(-beta, -alpha, depth - 1, pos, info, true);
+			score = -AlphaBeta(-beta, -alpha, depth - 1, pos, info, &pv_from_here, true);
 
 		// Undo the move
 		TakeMove(pos);
@@ -383,25 +393,6 @@ standard_search:
 		// Found a new best move in this position
 		if (score > bestScore) {
 
-			// If score beats beta we have a cutoff
-			if (score >= beta) {
-
-				// Update killers if quiet move
-				if (!(move & MOVE_IS_CAPTURE)) {
-					pos->searchKillers[1][pos->ply] = pos->searchKillers[0][pos->ply];
-					pos->searchKillers[0][pos->ply] = move;
-				}
-
-#ifdef SEARCH_STATS
-				if (movesTried == 1) info->fhf++;
-				info->fh++;
-#endif
-
-				StoreHashEntry(pos, move, score, BOUND_LOWER, depth);
-
-				return score;
-			}
-
 			bestScore = score;
 			bestMove = move;
 
@@ -410,7 +401,31 @@ standard_search:
 
 				alpha = score;
 
-				// Update searchHistory if quiet move
+				// Update the Principle Variation
+                pv->length = 1 + pv_from_here.length;
+                pv->line[0] = move;
+                memcpy(pv->line + 1, pv_from_here.line, sizeof(int) * pv_from_here.length);
+
+				// If score beats beta we have a cutoff
+				if (score >= beta) {
+
+					// Update killers if quiet move
+					if (!(move & MOVE_IS_CAPTURE)) {
+						pos->searchKillers[1][pos->ply] = pos->searchKillers[0][pos->ply];
+						pos->searchKillers[0][pos->ply] = move;
+					}
+
+	#ifdef SEARCH_STATS
+					if (movesTried == 1) info->fhf++;
+					info->fh++;
+	#endif
+
+					StoreHashEntry(pos, move, score, BOUND_LOWER, depth);
+
+					return score;
+				}
+
+				// Update searchHistory if quiet move and not beta cutoff
 				if (!(move & MOVE_IS_CAPTURE))
 					pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth;
 			}
@@ -434,7 +449,7 @@ standard_search:
 }
 
 // Aspiration window
-int AspirationWindow(Position *pos, SearchInfo *info, const int depth, int previousScore) {
+int AspirationWindow(Position *pos, SearchInfo *info, const int depth, int previousScore, PV *pv) {
 
 	// Dynamic bonus increasing initial window and delta
 	const int bonus = (previousScore * previousScore) / 8;
@@ -447,7 +462,7 @@ int AspirationWindow(Position *pos, SearchInfo *info, const int depth, int previ
 	unsigned int fails = 0;
 
 	while (true) {
-		int result = AlphaBeta(alpha, beta, depth, pos, info, true);
+		int result = AlphaBeta(alpha, beta, depth, pos, info, pv, true);
 		// Result within the bounds is accepted as correct
 		if ((result >= alpha && result <= beta) || info->stopped)
 			return result;
@@ -468,6 +483,7 @@ void SearchPosition(Position *pos, SearchInfo *info) {
 
 	int bestScore;
 	unsigned int currentDepth;
+	PV pv;
 
 	ClearForSearch(pos, info);
 
@@ -476,17 +492,21 @@ void SearchPosition(Position *pos, SearchInfo *info) {
 
 		// Search position, using aspiration windows for higher depths
 		if (currentDepth > 6)
-			bestScore = AspirationWindow(pos, info, currentDepth, bestScore);
+			bestScore = AspirationWindow(pos, info, currentDepth, bestScore, &pv);
 		else
-			bestScore = AlphaBeta(-INFINITE, INFINITE, currentDepth, pos, info, true);
+			bestScore = AlphaBeta(-INFINITE, INFINITE, currentDepth, pos, info, &pv, true);
 
 		// Stop search if applicable
 		if (info->stopped) break;
 
 		// Print thinking
-		PrintThinking(info, pos, bestScore, currentDepth);
+		PrintThinking(info, pos, pv, bestScore, currentDepth);
 	}
 
 	// Print conclusion
-	PrintConclusion(pos);
+	PrintConclusion(pv);
+
+#ifdef DEV
+	info->pv = pv;
+#endif
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -227,7 +227,7 @@ void MateInXTest(Position *pos) {
 search:
 				SearchPosition(pos, info);
 
-				bestFound = pos->pvArray[0];
+				bestFound = info->pv.line[0];
 
 				// Check if correct move is found
 				correct = 0;

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -10,42 +10,6 @@
 #include "transposition.h"
 
 
-// Returns principal variation move in the position (if any)
-static int ProbePvMove(const Position *pos) {
-
-	int index = pos->posKey % pos->hashTable->numEntries;
-
-	if (pos->hashTable->TT[index].posKey == pos->posKey)
-		return pos->hashTable->TT[index].move;
-
-	return NOMOVE;
-}
-
-// Fills the pvArray of the position with the PV
-int GetPvLine(const int depth, Position *pos) {
-
-	int move;
-	int count = 0;
-
-	memset(pos->pvArray, 0, sizeof(pos->pvArray));
-
-	do {
-		move = ProbePvMove(pos);
-
-		if (MoveExists(pos, move)) {
-			MakeMove(pos, move);
-			pos->pvArray[count++] = move;
-		} else
-			break;
-
-	} while (move != NOMOVE && count < depth);
-
-	while (pos->ply > 0)
-		TakeMove(pos);
-
-	return count;
-}
-
 // Clears the hash table
 void ClearHashTable(HashTable *table) {
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -13,7 +13,6 @@
 enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 
 
-int  GetPvLine(const int depth, Position *pos);
 void ClearHashTable(HashTable *table);
 void  InitHashTable(HashTable *table, uint64_t MB);
 #ifdef SEARCH_STATS

--- a/src/types.h
+++ b/src/types.h
@@ -60,6 +60,11 @@ enum CastlingRights { WKCA = 1, WQCA = 2, BKCA = 4, BQCA = 8 };
 
 /* Structs */
 
+typedef struct PV {
+    int length;
+    int line[MAXDEPTH];
+} PV;
+
 typedef struct {
 	int move;
 	int score;
@@ -127,7 +132,6 @@ typedef struct {
 	Undo history[MAXGAMEMOVES];
 
 	HashTable hashTable[1];
-	int pvArray[MAXDEPTH];
 
 	int searchHistory[PIECE_NB][64];
 	int searchKillers[2][MAXDEPTH];
@@ -152,6 +156,10 @@ typedef struct {
 	float fh;
 	float fhf;
 	int nullCut;
+#endif
+
+#ifdef DEV
+	PV pv;
 #endif
 
 	char syzygyPath[256];


### PR DESCRIPTION
Collecting PV on the stack rather than getting it from the TT. PV now makes sense in 3-fold repetition scenarios, and is not cut short by TT overwrites.

Due to immediately returning the result of a TT hit even in PV-nodes, there would be no pv collected whenever the pv had already been explored and stored in the TT. To make sure a pv is always collected a TT hit in a PV-node no longer immediately returns, unless it's a frontier node. This change was unexpectedly also a big improvement to playing strength as well.

ELO   | 45.87 +- 15.29 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-5.00, -1.00]
Games | N: 1440 W: 607 L: 418 D: 415
http://chess.grantnet.us/viewTest/3576/