### PR TITLE
TunePieceValues

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -34,11 +34,11 @@ typedef enum Piece {
 } Piece;
 
 enum PieceValue {
-	P_MG =  100, P_EG =  100,
-	N_MG =  325, N_EG =  325,
-	B_MG =  325, B_EG =  325,
-	R_MG =  550, R_EG =  550,
-	Q_MG = 1000, Q_EG = 1000
+	P_MG =  100, P_EG =  110,
+	N_MG =  335, N_EG =  350,
+	B_MG =  335, B_EG =  350,
+	R_MG =  550, R_EG =  580,
+	Q_MG = 1000, Q_EG = 1100
 };
 
 enum File { FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NONE };


### PR DESCRIPTION
Increase NB in mg to discourage early 2 N/B for R+P trades, scale up PQR in eg relative to NB as they tend to be stronger in the endgame.

ELO   | 7.54 +- 5.53 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10600 W: 3822 L: 3592 D: 3186
http://chess.grantnet.us/viewTest/3590/