### PR TITLE
MovePicker

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -12,8 +12,8 @@
 #include "validate.h"
 
 
-// Checks whether a move is psuedo-legal (assuming it is psuedo-legal in some position)
-bool MoveIsPsuedoLegal(const Position *pos, const int move) {
+// Checks whether a move is pseudo-legal (assuming it is pseudo-legal in some position)
+bool MoveIsPseudoLegal(const Position *pos, const int move) {
 
 	const int from  = FROMSQ(move);
 	const int to    = TOSQ(move);

--- a/src/move.h
+++ b/src/move.h
@@ -34,7 +34,7 @@
 #define MOVE_IS_CAPTURE 0x10F000
 
 
-bool MoveIsPsuedoLegal(const Position *pos, const int move);
+bool MoveIsPseudoLegal(const Position *pos, const int move);
 char *MoveToStr(const int move);
 int ParseMove(const char *ptrChar, Position *pos);
 #ifdef DEV

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -1,0 +1,91 @@
+// movepicker.c
+
+#include "move.h"
+#include "movegen.h"
+#include "movepicker.h"
+#include "types.h"
+
+
+// Return the next best move
+static int PickNextMove(MoveList *list, int ttMove) {
+
+    if (list->next == list->count)
+        return NOMOVE;
+
+    int bestMove;
+	int bestScore = 0;
+	unsigned int moveNum = list->next++;
+	unsigned int bestNum = moveNum;
+
+	for (unsigned int i = moveNum; i < list->count; ++i)
+		if (list->moves[i].score > bestScore) {
+			bestScore = list->moves[i].score;
+			bestNum   = i;
+		}
+
+	assert(moveNum < list->count);
+	assert(bestNum < list->count);
+	assert(bestNum >= moveNum);
+
+	bestMove = list->moves[bestNum].move;
+	list->moves[bestNum] = list->moves[moveNum];
+
+	if (bestMove == ttMove)
+		return PickNextMove(list, ttMove);
+
+	return bestMove;
+}
+
+// Returns the next move to try in a position
+int NextMove(MovePicker *mp) {
+
+    int move;
+
+    // Switch on stage, falls through to the next stage
+    // if a move isn't returned in the current stage.
+    switch (mp->stage) {
+
+        case TTMOVE:
+            mp->stage++;
+            if (MoveIsPsuedoLegal(mp->pos, mp->ttMove))
+                return mp->ttMove;
+
+            // fall through
+        case GEN_NOISY:
+            GenNoisyMoves(mp->pos, mp->list);
+            mp->stage++;
+
+            // fall through
+        case NOISY:
+            if (mp->list->next < mp->list->count) {
+                move = PickNextMove(mp->list, mp->ttMove);
+                if (move)
+                    return move;
+            }
+            mp->stage++;
+
+            // fall through
+        case GEN_QUIET:
+            if (mp->onlyNoisy) {
+                mp->stage = DONE;
+                return NOMOVE;
+            }
+            GenQuietMoves(mp->pos, mp->list);
+            mp->stage++;
+
+            // fall through
+        case QUIET:
+
+            if (mp->list->next < mp->list->count) {
+                move = PickNextMove(mp->list, mp->ttMove);
+                if (move)
+                    return move;
+            }
+            mp->stage = DONE;
+            return NOMOVE;
+
+        default:
+            assert(0);
+            return NOMOVE;
+        }
+}

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -23,13 +23,10 @@ static int PickNextMove(MoveList *list, int ttMove) {
 			bestNum   = i;
 		}
 
-	assert(moveNum < list->count);
-	assert(bestNum < list->count);
-	assert(bestNum >= moveNum);
-
 	bestMove = list->moves[bestNum].move;
 	list->moves[bestNum] = list->moves[moveNum];
 
+    // Avoid returning the ttMove again
 	if (bestMove == ttMove)
 		return PickNextMove(list, ttMove);
 
@@ -47,7 +44,7 @@ int NextMove(MovePicker *mp) {
 
         case TTMOVE:
             mp->stage++;
-            if (MoveIsPsuedoLegal(mp->pos, mp->ttMove))
+            if (MoveIsPseudoLegal(mp->pos, mp->ttMove))
                 return mp->ttMove;
 
             // fall through
@@ -57,11 +54,10 @@ int NextMove(MovePicker *mp) {
 
             // fall through
         case NOISY:
-            if (mp->list->next < mp->list->count) {
-                move = PickNextMove(mp->list, mp->ttMove);
-                if (move)
+            if (mp->list->next < mp->list->count)
+                if ((move = PickNextMove(mp->list, mp->ttMove)))
                     return move;
-            }
+
             mp->stage++;
 
             // fall through
@@ -75,12 +71,10 @@ int NextMove(MovePicker *mp) {
 
             // fall through
         case QUIET:
-
-            if (mp->list->next < mp->list->count) {
-                move = PickNextMove(mp->list, mp->ttMove);
-                if (move)
+            if (mp->list->next < mp->list->count)
+                if ((move = PickNextMove(mp->list, mp->ttMove)))
                     return move;
-            }
+
             mp->stage = DONE;
             return NOMOVE;
 

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -62,10 +62,9 @@ int NextMove(MovePicker *mp) {
 
             // fall through
         case GEN_QUIET:
-            if (mp->onlyNoisy) {
-                mp->stage = DONE;
+            if (mp->onlyNoisy)
                 return NOMOVE;
-            }
+
             GenQuietMoves(mp->pos, mp->list);
             mp->stage++;
 
@@ -75,7 +74,6 @@ int NextMove(MovePicker *mp) {
                 if ((move = PickNextMove(mp->list, mp->ttMove)))
                     return move;
 
-            mp->stage = DONE;
             return NOMOVE;
 
         default:

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -1,0 +1,19 @@
+// movepicker.h
+
+#include "types.h"
+
+
+typedef enum MPStage {
+    TTMOVE, GEN_NOISY, NOISY, GEN_QUIET, QUIET, DONE = -1
+} MPStage;
+
+typedef struct MovePicker {
+    Position *pos;
+    MoveList *list;
+    MPStage stage;
+    int ttMove;
+    bool onlyNoisy;
+} MovePicker;
+
+
+int NextMove(MovePicker *mp);

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -4,7 +4,7 @@
 
 
 typedef enum MPStage {
-    TTMOVE, GEN_NOISY, NOISY, GEN_QUIET, QUIET, DONE = -1
+    TTMOVE, GEN_NOISY, NOISY, GEN_QUIET, QUIET
 } MPStage;
 
 typedef struct MovePicker {


### PR DESCRIPTION
Implemented a movepicker so the move from TT can be tried before generating any moves, and all noisy moves tried before quiet moves are generated. Has a small impact on move ordering. Increases nps by a fair bit.

Might want to try killer moves before generating the other quiets.

ELO   | 8.48 +- 6.00 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8730 W: 3068 L: 2855 D: 2807
http://chess.grantnet.us/viewTest/3609/