### PR TITLE
Late Move Reduction

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -33,7 +33,7 @@ bench-pext:
 
 bench-pgo:
 	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
-	$(EXE)-temp.exe bench 6
+	$(EXE)-temp.exe bench 8
 	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOUSE) -o $(EXE)
 	rmdir /s /q "../pgo"
 	del /f "$(EXE)-temp.exe"
@@ -47,7 +47,7 @@ pext:
 
 pgo:
 	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
-	$(EXE)-temp.exe bench 6
+	$(EXE)-temp.exe bench 8
 	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOUSE) -o "$(OUT)$(EXE)-pext-pgo.exe"
 	rmdir /s /q "../pgo"
 	del /f "$(EXE)-temp.exe"

--- a/src/move.h
+++ b/src/move.h
@@ -32,6 +32,7 @@
 
 // Move either has enpas flag or a captured piece
 #define MOVE_IS_CAPTURE 0x10F000
+#define MOVE_IS_NOISY   0x1FF000
 
 
 bool MoveIsPseudoLegal(const Position *pos, const int move);

--- a/src/uci.c
+++ b/src/uci.c
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
 		if (argc > 2)
 			benchmark(atoi(argv[2]), pos, info);
 		else
-			benchmark(8, pos, info);
+			benchmark(10, pos, info);
 		return 0;
 	}
 


### PR DESCRIPTION
A pretty simple implementation of LMR with a static 1 ply reduction. Reduces the search tree a lot; depth 8 bench node count is reduced to ~1/7. Increased default depth of bench to 10, and pgo bench depth to 8 to compensate.

ELO   | 45.10 +- 15.76 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1255 W: 495 L: 333 D: 427
http://chess.grantnet.us/viewTest/3665/

ELO   | 63.96 +- 18.78 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 835 W: 333 L: 181 D: 321
http://chess.grantnet.us/viewTest/3666/