### PR TITLE
LMR later in pv nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -316,7 +316,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
 	InitNormalMP(&mp, &list, pos, ttMove);
 
-	unsigned int movesTried = 0;
+	int movesTried = 0;
 	const int oldAlpha = alpha;
 	int bestMove = NOMOVE;
 	int bestScore = -INFINITE;
@@ -332,7 +332,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 		movesTried++;
 
 		bool moveIsNoisy = move & MOVE_IS_NOISY;
-		bool doLMR = depth > 2 && movesTried > 1 && pos->ply && !moveIsNoisy;
+		bool doLMR = depth > 2 && movesTried > (1 + 2 * pvNode) && pos->ply && !moveIsNoisy;
 
 		// Reduced depth zero-window search (-1 depth)
 		if (doLMR)

--- a/src/search.c
+++ b/src/search.c
@@ -332,7 +332,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 		movesTried++;
 
 		bool moveIsNoisy = move & MOVE_IS_NOISY;
-		bool doLMR = depth > 2 && movesTried > (1 + 2 * pvNode) && pos->ply && !moveIsNoisy;
+		bool doLMR = depth > 2 && movesTried > (2 + pvNode) && pos->ply && !moveIsNoisy;
 
 		// Reduced depth zero-window search (-1 depth)
 		if (doLMR)

--- a/src/search.c
+++ b/src/search.c
@@ -329,6 +329,8 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 		// Make the next predicted best move, skipping illegal ones
 		if (!MakeMove(pos, move)) continue;
 
+		movesTried++;
+
 		bool moveIsNoisy = move & MOVE_IS_NOISY;
 		bool doLMR = depth > 2 && movesTried > 1 && pos->ply && !moveIsNoisy;
 
@@ -337,17 +339,15 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 			score = -AlphaBeta(-alpha - 1, -alpha, depth - 2, pos, info, &pv_from_here, true);
 
 		// Full depth zero-window search
-		if ((doLMR && score > alpha) || (!doLMR && (!pvNode || movesTried > 0)))
+		if ((doLMR && score > alpha) || (!doLMR && (!pvNode || movesTried > 1)))
 			score = -AlphaBeta(-alpha - 1, -alpha, depth - 1, pos, info, &pv_from_here, true);
 
 		// Full depth alpha-beta window search
-		if (pvNode && ((score > alpha && score < beta) || movesTried == 0))
+		if (pvNode && ((score > alpha && score < beta) || movesTried == 1))
 			score = -AlphaBeta(-beta, -alpha, depth - 1, pos, info, &pv_from_here, true);
 
 		// Undo the move
 		TakeMove(pos);
-
-		movesTried++;
 
 		if (info->stopped)
 			return 0;


### PR DESCRIPTION
Start LMR 1 move later in pv nodes. Also increment movesTried earlier to match sf/ethereal.

ELO   | 3.78 +- 2.98 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30975 W: 9384 L: 9047 D: 12544
http://chess.grantnet.us/viewTest/3676/

ELO   | 3.82 +- 3.08 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26265 W: 7203 L: 6914 D: 12148
http://chess.grantnet.us/viewTest/3678/