### PR TITLE
Incrementally update phase

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -16,6 +16,8 @@ const int pieceBig [PIECE_NB] = { false, false,  true,  true,  true,  true, fals
 const int piecePawn[PIECE_NB] = { false,  true, false, false, false, false, false, false, false,  true, false, false, false, false, false, false };
 const int pieceKing[PIECE_NB] = { false, false, false, false, false, false,  true, false, false, false, false, false, false, false,  true, false };
 
+const int phaseValue[PIECE_NB] = {    0,     0,     1,     1,     2,     4,     0,     0,     0,     0,     1,     1,     2,     4,     0,     0 };
+
 const int mirror_square[64] = {
 	56, 57, 58, 59, 60, 61, 62, 63,
 	48, 49, 50, 51, 52, 53, 54, 55,
@@ -72,6 +74,9 @@ static void UpdatePosition(Position *pos) {
 			// Material score
 			pos->material += PSQT[piece][sq];
 
+			// Phase
+			pos->phase -= phaseValue[piece];
+
 			// Piece list / count
 			pos->pieceList[piece][pos->pieceCounts[piece]] = sq;
 			pos->pieceCounts[piece]++;
@@ -105,10 +110,11 @@ static void ClearPosition(Position *pos) {
 	pos->bigPieces[BLACK] = pos->bigPieces[WHITE] = 0;
 
 	// Misc
-	pos->material = 0;
-	pos->side = BOTH;
-	pos->enPas = NO_SQ;
-	pos->fiftyMove = 0;
+	pos->material   = 0;
+	pos->phase      = 24;
+	pos->side       = BOTH;
+	pos->enPas      = NO_SQ;
+	pos->fiftyMove  = 0;
 	pos->castlePerm = 0;
 
 	// Ply

--- a/src/board.h
+++ b/src/board.h
@@ -12,6 +12,8 @@ const int pieceBig [PIECE_NB];
 const int piecePawn[PIECE_NB];
 const int pieceKing[PIECE_NB];
 
+const int phaseValue[PIECE_NB];
+
 const int mirror_square[64];
 
 bool CheckBoard(const Position *pos);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -238,15 +238,7 @@ int EvalPosition(const Position *pos) {
 
 	// Adjust score by phase
 	const int basePhase = 24;
-	int phase = basePhase;
-	phase -= 1 * pos->pieceCounts[bN]
-		   + 1 * pos->pieceCounts[bB]
-		   + 2 * pos->pieceCounts[bR]
-		   + 4 * pos->pieceCounts[bQ]
-		   + 1 * pos->pieceCounts[wN]
-		   + 1 * pos->pieceCounts[wB]
-		   + 2 * pos->pieceCounts[wR]
-		   + 4 * pos->pieceCounts[wQ];
+	int phase = pos->phase;
 	phase = (phase * 256 + (basePhase / 2)) / basePhase;
 
 	score = ((MgScore(score) * (256 - phase)) + (EgScore(score) * phase)) / 256;

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -48,6 +48,9 @@ static void ClearPiece(const int sq, Position *pos) {
 	// Update material
 	pos->material -= PSQT[piece][sq];
 
+	// Update phase
+	pos->phase += phaseValue[piece];
+
 	// Update various piece lists
 	if (pieceBig[piece])
 		pos->bigPieces[color]--;
@@ -89,6 +92,9 @@ static void AddPiece(const int sq, Position *pos, const int piece) {
 
 	// Update material
 	pos->material += PSQT[piece][sq];
+
+	// Update phase
+	pos->phase -= phaseValue[piece];
 
 	// Update various piece lists
 	if (pieceBig[piece])

--- a/src/types.h
+++ b/src/types.h
@@ -118,6 +118,7 @@ typedef struct {
 	int bigPieces[2];
 
 	int material;
+	int phase;
 
 	int side;
 	int enPas;


### PR DESCRIPTION
Rather than recalculate the phase each call to evaluate() keeping it saved and updating it whenever the number of pieces changes. No functional change.

ELO   | 1.95 +- 4.63 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 12860 W: 3870 L: 3798 D: 5192
http://chess.grantnet.us/viewTest/3686/