### PR TITLE
Aggressive lmr

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -11,11 +11,11 @@ PEXT   = -DUSE_PEXT -mbmi2
 
 # Flags
 STD    = -std=gnu11
-LIBS   = -pthread
+LIBS   = -pthread -lm
 WARN   = -Wall -Wextra -Wshadow
 OPTIM  = -O3 -march=native -flto
 
-CFLAGS = $(STD) $(WARN) $(LIBS) $(OPTIM)
+CFLAGS = $(STD) $(WARN) $(OPTIM)
 PFLAGS = $(STD) $(WARN) $(LIBS) -O0 -march=native -pg -p
 
 # PGO
@@ -26,31 +26,31 @@ PGOUSE = -fprofile-use=$(PGODIR)
 
 # For OpenBench
 bench-basic:
-	gcc $(CFLAGS) $(SRC)         -o $(EXE)
+	gcc $(CFLAGS) $(SRC) $(LIBS)         -o $(EXE)
 
 bench-pext:
-	gcc $(CFLAGS) $(SRC) $(PEXT) -o $(EXE)
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) -o $(EXE)
 
 bench-pgo:
-	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
 	$(EXE)-temp.exe bench 8
-	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOUSE) -o $(EXE)
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOUSE) -o $(EXE)
 	rmdir /s /q "../pgo"
 	del /f "$(EXE)-temp.exe"
 
 # For normal use
 dev:
-	gcc $(CFLAGS) $(SRC) $(PEXT) $(DEV)    -o "$(EXE)-dev"
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(DEV)    -o "$(EXE)-dev"
 
 pext:
-	gcc $(CFLAGS) $(SRC) $(PEXT)           -o "$(OUT)$(EXE)-pext"
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT)           -o "$(OUT)$(EXE)-pext"
 
 pgo:
-	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
 	$(EXE)-temp.exe bench 8
-	gcc $(CFLAGS) $(SRC) $(PEXT) $(PGOUSE) -o "$(OUT)$(EXE)-pext-pgo.exe"
+	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOUSE) -o "$(OUT)$(EXE)-pext-pgo.exe"
 	rmdir /s /q "../pgo"
 	del /f "$(EXE)-temp.exe"
 
 gprof:
-	gcc $(PFLAGS) $(SRC) $(PEXT)           -o "$(OUT)$(EXE)-prof"
+	gcc $(PFLAGS) $(SRC) $(LIBS) $(PEXT)           -o "$(OUT)$(EXE)-prof"

--- a/src/types.h
+++ b/src/types.h
@@ -9,6 +9,10 @@
 #include "defs.h"
 
 
+#define MIN(A, B) ((A) < (B) ? (A) : (B))
+#define MAX(A, B) ((A) > (B) ? (A) : (B))
+
+
 typedef uint64_t bitboard;
 
 enum Limit { MAXGAMEMOVES     = 512,


### PR DESCRIPTION
Allow LMR to reduce depth by more than 1. Reduction increases with higher depth and the more moves have already been tried. 

ELO   | 48.44 +- 15.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1155 W: 433 L: 273 D: 449
http://chess.grantnet.us/viewTest/3688/

ELO   | 21.32 +- 9.76 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2545 W: 743 L: 587 D: 1215
http://chess.grantnet.us/viewTest/3689/