### PR TITLE
Bench depth 13, pgo 12

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -33,7 +33,7 @@ bench-pext:
 
 bench-pgo:
 	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
-	$(EXE)-temp.exe bench 8
+	$(EXE)-temp.exe bench 12
 	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOUSE) -o $(EXE)
 	rmdir /s /q "../pgo"
 	del /f "$(EXE)-temp.exe"
@@ -47,7 +47,7 @@ pext:
 
 pgo:
 	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOGEN) -o "$(EXE)-temp.exe"
-	$(EXE)-temp.exe bench 8
+	$(EXE)-temp.exe bench 12
 	gcc $(CFLAGS) $(SRC) $(LIBS) $(PEXT) $(PGOUSE) -o "$(OUT)$(EXE)-pext-pgo.exe"
 	rmdir /s /q "../pgo"
 	del /f "$(EXE)-temp.exe"

--- a/src/uci.c
+++ b/src/uci.c
@@ -175,7 +175,7 @@ int main(int argc, char **argv) {
 		if (argc > 2)
 			benchmark(atoi(argv[2]), pos, info);
 		else
-			benchmark(10, pos, info);
+			benchmark(13, pos, info);
 		return 0;
 	}
 


### PR DESCRIPTION
Aggressive LMR reduced node count a lot yet again, so increasing default bench depths to compensate. No functional change.