### PR TITLE
Less aggressive LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -28,7 +28,7 @@ static void InitReductions() {
 	for (int depth = 0; depth < 32; ++depth)
 		for (int moves = 0; moves < 32; ++moves)
 			// log((depth * moves^2) / 2) - 2, staying >= 0 always
-			Reductions[depth][moves] = MAX(0, log((depth * pow(moves, 2)) / 2.0) - 2);
+			Reductions[depth][moves] = MAX(0, log((depth * pow(moves, 2)) / 2.5) - 2);
 }
 
 // Check time situation


### PR DESCRIPTION
Reduce a bit less with LMR.

ELO   | 7.21 +- 5.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9065 W: 2352 L: 2164 D: 4549
http://chess.grantnet.us/viewTest/3692/

ELO   | 10.16 +- 6.14 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5505 W: 1316 L: 1155 D: 3034
http://chess.grantnet.us/viewTest/3694/