### PR TITLE
Check extension before quiescence

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -216,6 +216,10 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
     int R;
 
+    // Extend search if in check
+    const bool inCheck = SqAttacked(pos->kingSq[pos->side], !pos->side, pos);
+    if (inCheck) depth++;
+
     // Quiescence at the end of search
     if (depth <= 0)
         return Quiescence(alpha, beta, pos, info, &pv_from_here);
@@ -246,10 +250,6 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         if (alpha >= beta)
             return alpha;
     }
-
-    // Extend search if in check
-    const bool inCheck = SqAttacked(pos->kingSq[pos->side], !pos->side, pos);
-    if (inCheck) depth++;
 
     int score = -INFINITE;
     int ttMove = NOMOVE;


### PR DESCRIPTION
Never drop into quiescence while in check. Should help discover mating lines and forks on the king.

ELO   | 18.14 +- 9.29 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3125 W: 989 L: 826 D: 1310
http://chess.grantnet.us/viewTest/3736/

ELO   | 23.61 +- 10.42 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2240 W: 662 L: 510 D: 1068
http://chess.grantnet.us/viewTest/3738/