### PR TITLE
Dynamic delta margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -125,15 +125,15 @@ static bool pawnOn7th(const Position *pos) {
 // Dynamic delta pruning margin
 static int QuiescenceDeltaMargin(const Position *pos) {
 
-    // Optimistic to improve our position by a pawn
-    int DeltaBase = P_MG;
-
-    if (pawnOn7th(pos)) DeltaBase = Q_MG;
+    // Optimistic to improve our position by a pawn, or if we have
+    // a pawn on the 7th we can hope to improve by a queen instead
+    const int DeltaBase = pawnOn7th(pos) ? Q_MG : P_MG;
 
     // Look for possible captures on the board
     const bitboard enemy = pos->colorBBs[!pos->side];
 
     // Find the most valuable piece we could take and add to our base
+    // TODO: Faster with pos->pieceCounts?
     return (enemy & pos->pieceBBs[QUEEN ]) ? DeltaBase + Q_MG
          : (enemy & pos->pieceBBs[ROOK  ]) ? DeltaBase + R_MG
          : (enemy & pos->pieceBBs[BISHOP]) ? DeltaBase + B_MG

--- a/src/search.c
+++ b/src/search.c
@@ -114,21 +114,31 @@ static void PrintConclusion(const PV pv) {
     fflush(stdout);
 }
 
+static uint64_t relativeRank7(const int side) {
+    return side ? rank7BB : rank2BB;
+}
+
+static bool pawnOn7th(const Position *pos) {
+    return pos->colorBBs[pos->side] & pos->pieceBBs[PAWN] & relativeRank7(pos->side);
+}
+
 // Dynamic delta pruning margin
 static int QuiescenceDeltaMargin(const Position *pos) {
 
-    // Optimistic to improve our position by a pawns
-    const int DeltaBase = P_MG;
+    // Optimistic to improve our position by a pawn
+    int DeltaBase = P_MG;
+
+    if (pawnOn7th(pos)) DeltaBase = Q_MG;
 
     // Look for possible captures on the board
     const bitboard enemy = pos->colorBBs[!pos->side];
 
-    // Find the most valuable piece we could take and add our base
+    // Find the most valuable piece we could take and add to our base
     return (enemy & pos->pieceBBs[QUEEN ]) ? DeltaBase + Q_MG
          : (enemy & pos->pieceBBs[ROOK  ]) ? DeltaBase + R_MG
          : (enemy & pos->pieceBBs[BISHOP]) ? DeltaBase + B_MG
          : (enemy & pos->pieceBBs[KNIGHT]) ? DeltaBase + N_MG
-         :  DeltaBase + P_MG;
+                                           : DeltaBase + P_MG;
 }
 
 // Quiescence


### PR DESCRIPTION
Low base delta margin, increased by the best possible capture we could make (most valuable piece opponent has) and further increased if we have a pawn on the 7th as we might have a move that both promotes and captures.

ELO   | 8.38 +- 5.73 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7925 W: 2323 L: 2132 D: 3470
http://chess.grantnet.us/viewTest/3745/

ELO   | 8.82 +- 5.80 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6975 W: 1858 L: 1681 D: 3436
http://chess.grantnet.us/viewTest/3746/