### PR TITLE
Abort with long jmp

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -74,23 +74,29 @@ static void ClearForSearch(Position *pos, SearchInfo *info) {
 }
 
 // Print thinking
-static void PrintThinking(const SearchInfo *info, Position *pos, int score, const int depth) {
+static void PrintThinking(const SearchInfo *info, Position *pos) {
+
+    int score = info->score;
 
     // Determine whether we have a centipawn or mate score
-    char *scoreType = abs(score) > ISMATE ? "mate" : "cp";
+    char *type = abs(score) > ISMATE ? "mate" : "cp";
 
     // Convert score to mate score when applicable
     score = score >  ISMATE ?  ((INFINITE - score) / 2) + 1
           : score < -ISMATE ? -((INFINITE + score) / 2)
           : score;
 
+    int depth    = info->IDDepth;
+    int seldepth = info->seldepth;
     int elapsed  = GetTimeMs() - info->starttime;
     int hashFull = HashFull(pos);
     int nps      = (int)(1000 * (info->nodes / (elapsed + 1)));
+    uint64_t nodes  = info->nodes;
+    uint64_t tbhits = info->tbhits;
 
     // Basic info
     printf("info score %s %d depth %d seldepth %d nodes %" PRId64 " nps %d tbhits %" PRId64 " time %d hashfull %d ",
-            scoreType, score, depth, info->seldepth, info->nodes, nps, info->tbhits, elapsed, hashFull);
+            type, score, depth, seldepth, nodes, nps, tbhits, elapsed, hashFull);
 
     // Principal variation
     printf("pv");
@@ -108,11 +114,11 @@ static void PrintThinking(const SearchInfo *info, Position *pos, int score, cons
 }
 
 // Print conclusion of search - best move and ponder move
-static void PrintConclusion(const PV pv) {
+static void PrintConclusion(const SearchInfo *info) {
 
-    printf("bestmove %s", MoveToStr(pv.line[0]));
-    if (pv.length > 1)
-        printf(" ponder %s", MoveToStr(pv.line[1]));
+    printf("bestmove %s", MoveToStr(info->bestMove));
+    if (info->ponderMove)
+        printf(" ponder %s", MoveToStr(info->ponderMove));
     printf("\n\n");
     fflush(stdout);
 }
@@ -439,20 +445,20 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 }
 
 // Aspiration window
-int AspirationWindow(Position *pos, SearchInfo *info, const int depth, int previousScore, PV *pv) {
+int AspirationWindow(Position *pos, SearchInfo *info, PV *pv) {
 
     // Dynamic bonus increasing initial window and delta
-    const int bonus = (previousScore * previousScore) / 8;
+    const int bonus = (info->score * info->score) / 8;
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window
-    int alpha = previousScore - delta / 4;
-    int beta  = previousScore + delta / 4;
+    int alpha = info->score - delta / 4;
+    int beta  = info->score + delta / 4;
     // Counter for failed searches, bounds are relaxed more for each successive fail
     unsigned fails = 0;
 
     while (true) {
-        int result = AlphaBeta(alpha, beta, depth, pos, info, pv, true);
+        int result = AlphaBeta(alpha, beta, info->IDDepth, pos, info, pv, true);
         // Result within the bounds is accepted as correct
         if (result >= alpha && result <= beta)
             return result;
@@ -471,26 +477,27 @@ int AspirationWindow(Position *pos, SearchInfo *info, const int depth, int previ
 // Root of search
 void SearchPosition(Position *pos, SearchInfo *info) {
 
-    int score;
-    unsigned depth;
-
     ClearForSearch(pos, info);
 
     // Iterative deepening
-    for (depth = 1; depth <= info->depth; ++depth) {
+    for (info->IDDepth = 1; info->IDDepth <= info->depth; ++info->IDDepth) {
 
         if (setjmp(info->jumpBuffer)) break;
 
         // Search position, using aspiration windows for higher depths
-        if (depth > 6)
-            score = AspirationWindow(pos, info, depth, score, &info->pv);
+        if (info->depth > 6)
+            info->score = AspirationWindow(pos, info, &info->pv);
         else
-            score = AlphaBeta(-INFINITE, INFINITE, depth, pos, info, &info->pv, true);
+            info->score = AlphaBeta(-INFINITE, INFINITE, info->IDDepth, pos, info, &info->pv, true);
 
         // Print thinking
-        PrintThinking(info, pos, score, depth);
+        PrintThinking(info, pos);
+
+        // Save bestMove and ponderMove before overwriting the pv next iteration
+        info->bestMove   = info->pv.line[0];
+        info->ponderMove = info->pv.length > 1 ? info->pv.line[1] : NOMOVE;
     }
 
     // Print conclusion
-    PrintConclusion(info->pv);
+    PrintConclusion(info);
 }

--- a/src/search.c
+++ b/src/search.c
@@ -445,20 +445,21 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 }
 
 // Aspiration window
-int AspirationWindow(Position *pos, SearchInfo *info, PV *pv) {
+static int AspirationWindow(Position *pos, SearchInfo *info) {
 
+    const int score = info->score;
     // Dynamic bonus increasing initial window and delta
-    const int bonus = (info->score * info->score) / 8;
+    const int bonus = (score * score) / 8;
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window
-    int alpha = info->score - delta / 4;
-    int beta  = info->score + delta / 4;
+    int alpha = score - delta / 4;
+    int beta  = score + delta / 4;
     // Counter for failed searches, bounds are relaxed more for each successive fail
     unsigned fails = 0;
 
     while (true) {
-        int result = AlphaBeta(alpha, beta, info->IDDepth, pos, info, pv, true);
+        int result = AlphaBeta(alpha, beta, info->IDDepth, pos, info, &info->pv, true);
         // Result within the bounds is accepted as correct
         if (result >= alpha && result <= beta)
             return result;
@@ -486,7 +487,7 @@ void SearchPosition(Position *pos, SearchInfo *info) {
 
         // Search position, using aspiration windows for higher depths
         if (info->depth > 6)
-            info->score = AspirationWindow(pos, info, &info->pv);
+            info->score = AspirationWindow(pos, info);
         else
             info->score = AlphaBeta(-INFINITE, INFINITE, info->IDDepth, pos, info, &info->pv, true);
 

--- a/src/search.c
+++ b/src/search.c
@@ -486,7 +486,7 @@ void SearchPosition(Position *pos, SearchInfo *info) {
         if (setjmp(info->jumpBuffer)) break;
 
         // Search position, using aspiration windows for higher depths
-        if (info->depth > 6)
+        if (info->IDDepth > 6)
             info->score = AspirationWindow(pos, info);
         else
             info->score = AlphaBeta(-INFINITE, INFINITE, info->IDDepth, pos, info, &info->pv, true);

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <inttypes.h>
+#include <setjmp.h>
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -155,17 +156,15 @@ typedef struct {
 	uint64_t nodes;
 	uint64_t tbhits;
 
-	int stopped;
-
 #ifdef SEARCH_STATS
 	float fh;
 	float fhf;
 	int nullCut;
 #endif
 
-#ifdef DEV
 	PV pv;
-#endif
+
+	jmp_buf jumpBuffer;
 
 	char syzygyPath[256];
 

--- a/src/types.h
+++ b/src/types.h
@@ -148,7 +148,7 @@ typedef struct {
 
 	int starttime;
 	int stoptime;
-	unsigned int depth;
+	int depth;
 	int seldepth;
 	int timeset;
 	int movestogo;
@@ -163,8 +163,13 @@ typedef struct {
 #endif
 
 	PV pv;
+	int bestMove;
+	int ponderMove;
 
 	jmp_buf jumpBuffer;
+
+	int score;
+	int IDDepth;
 
 	char syzygyPath[256];
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -21,6 +21,9 @@
 #define INPUT_SIZE 4096
 
 
+bool ABORT_SIGNAL = false;
+
+
 // Checks if a string begins with another string
 static inline bool BeginsWith(const char *string, const char *token) {
 	return strstr(string, token) == string;
@@ -30,9 +33,9 @@ static inline bool BeginsWith(const char *string, const char *token) {
 static void *ParseGo(void *searchThreadInfo) {
 
 	SearchThread *sst = (SearchThread*)searchThreadInfo;
-	char *line           = sst->line;
-	Position *pos         = sst->pos;
-	SearchInfo *info   = sst->info;
+	char *line        = sst->line;
+	Position *pos     = sst->pos;
+	SearchInfo *info  = sst->info;
 
 	info->starttime = GetTimeMs();
 	info->timeset = false;
@@ -190,6 +193,7 @@ int main(int argc, char **argv) {
 	while (GetInput(line)) {
 
 		if (BeginsWith(line, "go")) {
+			ABORT_SIGNAL = false;
 			strncpy(searchThreadInfo.line, line, INPUT_SIZE);
 			pthread_create(&searchThread, NULL, &ParseGo, &searchThreadInfo);
 
@@ -203,7 +207,7 @@ int main(int argc, char **argv) {
 			ClearHashTable(pos->hashTable);
 
 		else if (BeginsWith(line, "stop")) {
-			info->stopped = true;
+			ABORT_SIGNAL = true;
 			pthread_join(searchThread, NULL);
 
 		} else if (BeginsWith(line, "quit")) {


### PR DESCRIPTION
Using setbuf/longjmp to abort a search if time is up or a stop command is given. Moved more information into the SearchInfo struct to avoid warnings of clobbering. Hopefully this will help eliminate the time losses during testing.

Fixed a bug: The current PV in a new iteration of ID was used to print bestmove and pondermove, so if a search was aborted midway after changing the PV the new one would be printed despite the search not having finished proving it better.

Also cleaned up PrintThinking, AspirationWindow and SearchPosition a bit.

No functional changes.