### PR TITLE
Lower aspiration bonus

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -453,8 +453,8 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window
-    int alpha = score - delta / 4;
-    int beta  = score + delta / 4;
+    int alpha = MAX(score - delta / 4, -INFINITE);
+    int beta  = MIN(score + delta / 4,  INFINITE);
     // Counter for failed searches, bounds are relaxed more for each successive fail
     unsigned fails = 0;
 

--- a/src/search.c
+++ b/src/search.c
@@ -449,7 +449,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 
     const int score = info->score;
     // Dynamic bonus increasing initial window and delta
-    const int bonus = (score * score) / 8;
+    const int bonus = (score * score) / 16;
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window


### PR DESCRIPTION
After the recent improvements, the score difference from one search iteration to the next is probably smaller, allowing a tightening of the aspiration window, increasing pruning, without incurring too many researches.

ELO   | 7.01 +- 5.02 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10410 W: 3054 L: 2844 D: 4512
http://chess.grantnet.us/viewTest/3754/

ELO   | 9.34 +- 5.96 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6510 W: 1713 L: 1538 D: 3259
http://chess.grantnet.us/viewTest/3755/