### PR TITLE
Final phase value updated incrementally

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -75,7 +75,7 @@ static void UpdatePosition(Position *pos) {
             pos->material += PSQT[piece][sq];
 
             // Phase
-            pos->phase -= phaseValue[piece];
+            pos->basePhase -= phaseValue[piece];
 
             // Piece list / count
             pos->pieceList[piece][pos->pieceCounts[piece]] = sq;
@@ -86,6 +86,9 @@ static void UpdatePosition(Position *pos) {
             if (piece == bK) pos->kingSq[BLACK] = sq;
         }
     }
+
+    pos->phase = (pos->basePhase * 256 + 12) / 24;
+
     assert(CheckBoard(pos));
 }
 
@@ -111,7 +114,7 @@ static void ClearPosition(Position *pos) {
 
     // Misc
     pos->material   = 0;
-    pos->phase      = 24;
+    pos->basePhase  = 24;
     pos->side       = BOTH;
     pos->enPas      = NO_SQ;
     pos->fiftyMove  = 0;

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -294,6 +294,8 @@ int EvalPosition(const Position *pos) {
         mobility -= QueenMobility[PopCount((BishopAttacks(sq, occupied) | RookAttacks(sq, occupied)) & mobilityArea[BLACK])];
     }
 
+    score += mobility;
+
     // Kings
     score += KingLineVulnerability * PopCount(  RookAttacks(pos->kingSq[WHITE], pos->colorBBs[WHITE] | pos->pieceBBs[PAWN])
                                             | BishopAttacks(pos->kingSq[WHITE], pos->colorBBs[WHITE] | pos->pieceBBs[PAWN]));
@@ -301,12 +303,7 @@ int EvalPosition(const Position *pos) {
                                             | BishopAttacks(pos->kingSq[BLACK], pos->colorBBs[BLACK] | pos->pieceBBs[PAWN]));
 
     // Adjust score by phase
-    const int basePhase = 24;
-    int phase = pos->phase;
-    phase = (phase * 256 + (basePhase / 2)) / basePhase;
-
-    score += mobility;
-
+    const int phase = pos->phase;
     score = ((MgScore(score) * (256 - phase)) + (EgScore(score) * phase)) / 256;
 
     assert(score > -INFINITE && score < INFINITE);

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -49,7 +49,8 @@ static void ClearPiece(const int sq, Position *pos) {
     pos->material -= PSQT[piece][sq];
 
     // Update phase
-    pos->phase += phaseValue[piece];
+    pos->basePhase += phaseValue[piece];
+    pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     // Update various piece lists
     if (pieceBig[piece])
@@ -94,7 +95,8 @@ static void AddPiece(const int sq, Position *pos, const int piece) {
     pos->material += PSQT[piece][sq];
 
     // Update phase
-    pos->phase -= phaseValue[piece];
+    pos->basePhase -= phaseValue[piece];
+    pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     // Update various piece lists
     if (pieceBig[piece])

--- a/src/types.h
+++ b/src/types.h
@@ -123,6 +123,7 @@ typedef struct {
     int bigPieces[2];
 
     int material;
+    int basePhase;
     int phase;
 
     int side;


### PR DESCRIPTION
Move the rest of the phase calculation out to makemove. Probably a speedup, passed -3, 1 SPRT on 5+0.05 and 10+0.1.

ELO   | 1.10 +- 2.89 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 32920 W: 9835 L: 9731 D: 13354
http://chess.grantnet.us/viewTest/3765/

ELO   | 2.28 +- 3.56 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 20765 W: 5972 L: 5836 D: 8957
http://chess.grantnet.us/viewTest/3764/