### PR TITLE
Template movegen

### DIFF
--- a/src/move.h
+++ b/src/move.h
@@ -26,6 +26,7 @@
 #define NOMOVE 0
 
 // Possible flags
+#define FLAG_NONE       0
 #define FLAG_ENPAS      0x100000
 #define FLAG_PAWNSTART  0x200000
 #define FLAG_CASTLE     0x400000

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -76,49 +76,27 @@ INLINE void AddEnPas(const int move, MoveList *list) {
     list->moves[list->count].score = 105 + 1000000;
     list->count++;
 }
-static inline void AddWPromo(const Position *pos, const int from, const int to, MoveList *list) {
+INLINE void AddPromo(const Position *pos, MoveList *list, const int from, const int to, const int color) {
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
     assert(CheckBoard(pos));
 
-    AddQuiet(pos, from, to, wQ, 0, list);
-    AddQuiet(pos, from, to, wN, 0, list);
-    AddQuiet(pos, from, to, wR, 0, list);
-    AddQuiet(pos, from, to, wB, 0, list);
+    AddQuiet(pos, from, to, makePiece(color, QUEEN ), 0, list);
+    AddQuiet(pos, from, to, makePiece(color, KNIGHT), 0, list);
+    AddQuiet(pos, from, to, makePiece(color, ROOK  ), 0, list);
+    AddQuiet(pos, from, to, makePiece(color, BISHOP), 0, list);
 }
-static inline void AddWPromoCapture(const Position *pos, const int from, const int to, MoveList *list) {
+INLINE void AddPromoCapture(const Position *pos, MoveList *list, const int from, const int to, const int color) {
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
     assert(CheckBoard(pos));
 
-    AddCapture(pos, from, to, wQ, list);
-    AddCapture(pos, from, to, wN, list);
-    AddCapture(pos, from, to, wR, list);
-    AddCapture(pos, from, to, wB, list);
-}
-static inline void AddBPromo(const Position *pos, const int from, const int to, MoveList *list) {
-
-    assert(ValidSquare(from));
-    assert(ValidSquare(to));
-    assert(CheckBoard(pos));
-
-    AddQuiet(pos, from, to, bQ, 0, list);
-    AddQuiet(pos, from, to, bN, 0, list);
-    AddQuiet(pos, from, to, bR, 0, list);
-    AddQuiet(pos, from, to, bB, 0, list);
-}
-static inline void AddBPromoCapture(const Position *pos, const int from, const int to, MoveList *list) {
-
-    assert(ValidSquare(from));
-    assert(ValidSquare(to));
-    assert(CheckBoard(pos));
-
-    AddCapture(pos, from, to, bQ, list);
-    AddCapture(pos, from, to, bN, list);
-    AddCapture(pos, from, to, bR, list);
-    AddCapture(pos, from, to, bB, list);
+    AddCapture(pos, from, to, makePiece(color, QUEEN ), list);
+    AddCapture(pos, from, to, makePiece(color, KNIGHT), list);
+    AddCapture(pos, from, to, makePiece(color, ROOK  ), list);
+    AddCapture(pos, from, to, makePiece(color, BISHOP), list);
 }
 
 /* Generators for specific color/piece combinations - called by generic generators*/
@@ -180,16 +158,16 @@ static inline void GenWPawnNoisy(const Position *pos, MoveList *list, const bitb
     // Promoting captures
     while (lPromoCap) {
         sq = PopLsb(&lPromoCap);
-        AddWPromoCapture(pos, sq - 7, sq, list);
+        AddPromoCapture(pos, list, sq - 7, sq, WHITE);
     }
     while (rPromoCap) {
         sq = PopLsb(&rPromoCap);
-        AddWPromoCapture(pos, sq - 9, sq, list);
+        AddPromoCapture(pos, list, sq - 9, sq, WHITE);
     }
     // Promotions
     while (promotions) {
         sq = PopLsb(&promotions);
-        AddWPromo(pos, (sq - 8), sq, list);
+        AddPromo(pos, list, (sq - 8), sq, WHITE);
     }
     // Captures
     while (lNormalCap) {
@@ -246,16 +224,16 @@ static inline void GenBPawnNoisy(const Position *pos, MoveList *list, const bitb
     // Promoting captures
     while (lPromoCap) {
         sq = PopLsb(&lPromoCap);
-        AddBPromoCapture(pos, sq + 7, sq, list);
+        AddPromoCapture(pos, list, sq + 7, sq, BLACK);
     }
     while (rPromoCap) {
         sq = PopLsb(&rPromoCap);
-        AddBPromoCapture(pos, sq + 9, sq, list);
+        AddPromoCapture(pos, list, sq + 9, sq, BLACK);
     }
     // Promotions
     while (promotions) {
         sq = PopLsb(&promotions);
-        AddBPromo(pos, (sq + 8), sq, list);
+        AddPromo(pos, list, (sq + 8), sq, BLACK);
     }
     // Captures
     while (lNormalCap) {

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -112,6 +112,10 @@ INLINE void GenCastling(const Position *pos, MoveList *list, const int color, co
                 AddMove(pos, list, from, qsto, EMPTY, FLAG_CASTLE, QUIET);
 }
 
+// Returns a square behind (relative to color)
+// 7 : diagonally to the left
+// 8 : directly behind
+// 9 : diagonally to the right
 INLINE int relBackward(const int color, const int sq, const int diff) {
     return color == WHITE ? sq - diff : sq + diff;
 }

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -351,12 +351,12 @@ void GenQuietMoves(const Position *pos, MoveList *list) {
 
     assert(CheckBoard(pos));
 
-    const int side = pos->side;
+    const int color = pos->side;
 
     const bitboard occupied = pos->colorBBs[BOTH];
     const bitboard empty    = ~occupied;
 
-    if (side == WHITE) {
+    if (color == WHITE) {
         GenCastling  (pos, list, occupied, WHITE);
         GenWPawnQuiet(pos, list, empty);
         GenPieceType(pos, list, WHITE, QUIET, KNIGHT);
@@ -382,29 +382,28 @@ void GenNoisyMoves(const Position *pos, MoveList *list) {
 
     assert(CheckBoard(pos));
 
-    const int side = pos->side;
+    const int color = pos->side;
 
     const bitboard occupied = pos->colorBBs[BOTH];
-    const bitboard enemies  = pos->colorBBs[!side];
+    const bitboard enemies  = pos->colorBBs[!color];
     const bitboard empty    = ~occupied;
 
     // Pawns
-    if (side == WHITE) {
-        GenWPawnNoisy  (pos, list, enemies, empty);
+    if (color == WHITE) {
+        GenWPawnNoisy(pos, list, enemies, empty);
         GenPieceType(pos, list, WHITE, NOISY, KNIGHT);
         GenPieceType(pos, list, WHITE, NOISY, ROOK);
         GenPieceType(pos, list, WHITE, NOISY, BISHOP);
         GenPieceType(pos, list, WHITE, NOISY, QUEEN);
         GenKing     (pos, list, enemies, WHITE, NOISY);
     } else {
-        GenBPawnNoisy  (pos, list, enemies, empty);
+        GenBPawnNoisy(pos, list, enemies, empty);
         GenPieceType(pos, list, BLACK, NOISY, KNIGHT);
         GenPieceType(pos, list, BLACK, NOISY, ROOK);
         GenPieceType(pos, list, BLACK, NOISY, BISHOP);
         GenPieceType(pos, list, BLACK, NOISY, QUEEN);
         GenKing     (pos, list, enemies, BLACK, NOISY);
     }
-
 
     assert(MoveListOk(list, pos));
 }

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -298,12 +298,12 @@ static inline void GenBPawnQuiet(const Position *pos, MoveList *list, const bitb
 }
 
 // White knight
-static inline void GenWKnightQuiet(const Position *pos, MoveList *list, const bitboard empty) {
+INLINE void GenKnightQuiet(const Position *pos, MoveList *list, const bitboard empty, const int color) {
 
     int sq;
     bitboard moves;
 
-    bitboard knights = pos->colorBBs[WHITE] & pos->pieceBBs[KNIGHT];
+    bitboard knights = pos->colorBBs[color] & pos->pieceBBs[KNIGHT];
 
     while (knights) {
 
@@ -314,12 +314,12 @@ static inline void GenWKnightQuiet(const Position *pos, MoveList *list, const bi
             AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
     }
 }
-static inline void GenWKnightNoisy(const Position *pos, MoveList *list, const bitboard enemies) {
+INLINE void GenKnightNoisy(const Position *pos, MoveList *list, const bitboard enemies, const int color) {
 
     int sq;
     bitboard attacks;
 
-    bitboard knights = pos->colorBBs[WHITE] & pos->pieceBBs[KNIGHT];
+    bitboard knights = pos->colorBBs[color] & pos->pieceBBs[KNIGHT];
 
     while (knights) {
 
@@ -330,47 +330,14 @@ static inline void GenWKnightNoisy(const Position *pos, MoveList *list, const bi
             AddCapture(pos, sq, PopLsb(&attacks), EMPTY, list);
     }
 }
-// Black knight
-static inline void GenBKnightQuiet(const Position *pos, MoveList *list, const bitboard empty) {
-
-    int sq;
-    bitboard moves;
-
-    bitboard knights = pos->colorBBs[BLACK] & pos->pieceBBs[KNIGHT];
-
-    while (knights) {
-
-        sq = PopLsb(&knights);
-
-        moves = knight_attacks[sq] & empty;
-        while (moves)
-            AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
-    }
-}
-static inline void GenBKnightNoisy(const Position *pos, MoveList *list, const bitboard enemies) {
-
-    int sq;
-    bitboard attacks;
-
-    bitboard knights = pos->colorBBs[BLACK] & pos->pieceBBs[KNIGHT];
-
-    while (knights) {
-
-        sq = PopLsb(&knights);
-
-        attacks = knight_attacks[sq] & enemies;
-        while (attacks)
-            AddCapture(pos, sq, PopLsb(&attacks), 0, list);
-    }
-}
 
 // White bishop
-static inline void GenWBishopQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied) {
+INLINE void GenBishopQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied, const int color) {
 
     int sq;
     bitboard moves;
 
-    bitboard bishops = pos->colorBBs[WHITE] & pos->pieceBBs[BISHOP];
+    bitboard bishops = pos->colorBBs[color] & pos->pieceBBs[BISHOP];
 
     while (bishops) {
 
@@ -381,45 +348,12 @@ static inline void GenWBishopQuiet(const Position *pos, MoveList *list, const bi
             AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
     }
 }
-static inline void GenWBishopNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied) {
+INLINE void GenBishopNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied, const int color) {
 
     int sq;
     bitboard attacks;
 
-    bitboard bishops = pos->colorBBs[WHITE] & pos->pieceBBs[BISHOP];
-
-    while (bishops) {
-
-        sq = PopLsb(&bishops);
-
-        attacks = BishopAttacks(sq, occupied) & enemies;
-        while (attacks)
-            AddCapture(pos, sq, PopLsb(&attacks), 0, list);
-    }
-}
-// Black bishop
-static inline void GenBBishopQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied) {
-
-    int sq;
-    bitboard moves;
-
-    bitboard bishops = pos->colorBBs[BLACK] & pos->pieceBBs[BISHOP];
-
-    while (bishops) {
-
-        sq = PopLsb(&bishops);
-
-        moves = BishopAttacks(sq, occupied) & empty;
-        while (moves)
-            AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
-    }
-}
-static inline void GenBBishopNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied) {
-
-    int sq;
-    bitboard attacks;
-
-    bitboard bishops = pos->colorBBs[BLACK] & pos->pieceBBs[BISHOP];
+    bitboard bishops = pos->colorBBs[color] & pos->pieceBBs[BISHOP];
 
     while (bishops) {
 
@@ -432,12 +366,12 @@ static inline void GenBBishopNoisy(const Position *pos, MoveList *list, const bi
 }
 
 // White rook
-static inline void GenWRookQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied) {
+INLINE void GenRookQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied, const int color) {
 
     int sq;
     bitboard moves;
 
-    bitboard rooks = pos->colorBBs[WHITE] & pos->pieceBBs[ROOK];
+    bitboard rooks = pos->colorBBs[color] & pos->pieceBBs[ROOK];
 
     while (rooks) {
 
@@ -448,45 +382,12 @@ static inline void GenWRookQuiet(const Position *pos, MoveList *list, const bitb
             AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
     }
 }
-static inline void GenWRookNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied) {
+INLINE void GenRookNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied, const int color) {
 
     int sq;
     bitboard attacks;
 
-    bitboard rooks = pos->colorBBs[WHITE] & pos->pieceBBs[ROOK];
-
-    while (rooks) {
-
-        sq = PopLsb(&rooks);
-
-        attacks = RookAttacks(sq, occupied) & enemies;
-        while (attacks)
-            AddCapture(pos, sq, PopLsb(&attacks), 0, list);
-    }
-}
-// Black rook
-static inline void GenBRookQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied) {
-
-    int sq;
-    bitboard moves;
-
-    bitboard rooks = pos->colorBBs[BLACK] & pos->pieceBBs[ROOK];
-
-    while (rooks) {
-
-        sq = PopLsb(&rooks);
-
-        moves = RookAttacks(sq, occupied) & empty;
-        while (moves)
-            AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
-    }
-}
-static inline void GenBRookNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied) {
-
-    int sq;
-    bitboard attacks;
-
-    bitboard rooks = pos->colorBBs[BLACK] & pos->pieceBBs[ROOK];
+    bitboard rooks = pos->colorBBs[color] & pos->pieceBBs[ROOK];
 
     while (rooks) {
 
@@ -499,12 +400,12 @@ static inline void GenBRookNoisy(const Position *pos, MoveList *list, const bitb
 }
 
 // White queen
-static inline void GenWQueenQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied) {
+INLINE void GenQueenQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied, const int color) {
 
     int sq;
     bitboard moves;
 
-    bitboard queens  = pos->colorBBs[WHITE] & pos->pieceBBs[ QUEEN];
+    bitboard queens = pos->colorBBs[color] & pos->pieceBBs[QUEEN];
 
     while (queens) {
 
@@ -515,45 +416,12 @@ static inline void GenWQueenQuiet(const Position *pos, MoveList *list, const bit
             AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
     }
 }
-static inline void GenWQueenNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied) {
+INLINE void GenQueenNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied, const int color) {
 
     int sq;
     bitboard attacks;
 
-    bitboard queens  = pos->colorBBs[WHITE] & pos->pieceBBs[ QUEEN];
-
-    while (queens) {
-
-        sq = PopLsb(&queens);
-
-        attacks = (BishopAttacks(sq, occupied) | RookAttacks(sq, occupied)) & enemies;
-        while (attacks)
-            AddCapture(pos, sq, PopLsb(&attacks), 0, list);
-    }
-}
-// Black queen
-static inline void GenBQueenQuiet(const Position *pos, MoveList *list, const bitboard empty, const bitboard occupied) {
-
-    int sq;
-    bitboard moves;
-
-    bitboard queens  = pos->colorBBs[BLACK] & pos->pieceBBs[ QUEEN];
-
-    while (queens) {
-
-        sq = PopLsb(&queens);
-
-        moves = (BishopAttacks(sq, occupied) | RookAttacks(sq, occupied)) & empty;
-        while (moves)
-            AddQuiet(pos, sq, PopLsb(&moves), EMPTY, 0, list);
-    }
-}
-static inline void GenBQueenNoisy(const Position *pos, MoveList *list, const bitboard enemies, const bitboard occupied) {
-
-    int sq;
-    bitboard attacks;
-
-    bitboard queens  = pos->colorBBs[BLACK] & pos->pieceBBs[ QUEEN];
+    bitboard queens = pos->colorBBs[color] & pos->pieceBBs[QUEEN];
 
     while (queens) {
 
@@ -580,17 +448,17 @@ void GenQuietMoves(const Position *pos, MoveList *list) {
     if (side == WHITE) {
         GenWCastling   (pos, list, occupied);
         GenWPawnQuiet  (pos, list, empty);
-        GenWKnightQuiet(pos, list, empty);
-        GenWRookQuiet  (pos, list, empty, occupied);
-        GenWBishopQuiet(pos, list, empty, occupied);
-        GenWQueenQuiet (pos, list, empty, occupied);
+        GenKnightQuiet(pos, list, empty, WHITE);
+        GenRookQuiet  (pos, list, empty, occupied, WHITE);
+        GenBishopQuiet(pos, list, empty, occupied, WHITE);
+        GenQueenQuiet (pos, list, empty, occupied, WHITE);
     } else {
         GenBCastling   (pos, list, occupied);
         GenBPawnQuiet  (pos, list, empty);
-        GenBKnightQuiet(pos, list, empty);
-        GenBRookQuiet  (pos, list, empty, occupied);
-        GenBBishopQuiet(pos, list, empty, occupied);
-        GenBQueenQuiet (pos, list, empty, occupied);
+        GenKnightQuiet(pos, list, empty, BLACK);
+        GenRookQuiet  (pos, list, empty, occupied, BLACK);
+        GenBishopQuiet(pos, list, empty, occupied, BLACK);
+        GenQueenQuiet (pos, list, empty, occupied, BLACK);
     }
 
     GenKingQuiet(pos, list, pos->kingSq[side], empty);
@@ -612,17 +480,17 @@ void GenNoisyMoves(const Position *pos, MoveList *list) {
     // Pawns
     if (side == WHITE) {
         GenWPawnNoisy  (pos, list, enemies, empty);
-        GenWKnightNoisy(pos, list, enemies);
-        GenWRookNoisy  (pos, list, enemies, occupied);
-        GenWBishopNoisy(pos, list, enemies, occupied);
-        GenWQueenNoisy (pos, list, enemies, occupied);
+        GenKnightNoisy(pos, list, enemies, WHITE);
+        GenRookNoisy  (pos, list, enemies, occupied, WHITE);
+        GenBishopNoisy(pos, list, enemies, occupied, WHITE);
+        GenQueenNoisy (pos, list, enemies, occupied, WHITE);
 
     } else {
         GenBPawnNoisy  (pos, list, enemies, empty);
-        GenBKnightNoisy(pos, list, enemies);
-        GenBRookNoisy  (pos, list, enemies, occupied);
-        GenBBishopNoisy(pos, list, enemies, occupied);
-        GenBQueenNoisy (pos, list, enemies, occupied);
+        GenKnightNoisy(pos, list, enemies, BLACK);
+        GenRookNoisy  (pos, list, enemies, occupied, BLACK);
+        GenBishopNoisy(pos, list, enemies, occupied, BLACK);
+        GenQueenNoisy (pos, list, enemies, occupied, BLACK);
     }
 
     GenKingNoisy(pos, list, pos->kingSq[side], enemies);


### PR DESCRIPTION
Finally found a way to fix the horrible movegen code. The new setup takes advantage of forcing inlining so the compiler optimizes the code in a similar way to C++ templates. Saves almost 400 lines of code, making it far more readable, at no cost.

142 additions and 517 deletions.

<add test result>