### PR TITLE
Tune Eval 1

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -24,9 +24,9 @@ static const int QueenOpenFile = S(5, 5);
 static const int  RookSemiOpenFile = S(5, 5);
 static const int QueenSemiOpenFile = S(3, 3);
 
-static const int BishopPair = S(30, 30);
+static const int BishopPair = S(50, 50);
 
-static const int KingLineVulnerability = S(-5, 0);
+static const int KingLineVulnerability = S(-8, 0);
 
 // Mobility
 static const int KnightMobility[9] = {


### PR DESCRIPTION
CLOP tuning of Bishop Pair and KLVuln values showed they were too small. My initial theory is that mobility evaluation may be a bit too high, or at least the other bonuses are too small relative to mobility. Preliminary results of a CLOP run on the remaining various bonuses/maluses, except passed pawns, show they should all be increased as well. This will be tested next. 

There seems to be a lot of ELO to be gained by improving evaluation values.

ELO   | 16.10 +- 8.74 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3650 W: 1181 L: 1012 D: 1457
http://chess.grantnet.us/viewTest/3850/

ELO   | 12.24 +- 7.21 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4854 W: 1406 L: 1235 D: 2213
http://chess.grantnet.us/viewTest/3863/