### PR TITLE
Tune eval 2

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -19,10 +19,10 @@ static bitboard IsolatedMask[64];
 static const int PawnPassed[8] = { 0, S(5, 5), S(10, 10), S(20, 20), S(35, 35), S(60, 60), S(100, 100), 0 };
 static const int PawnIsolated = S(-15, -14);
 
-static const int  RookOpenFile = S(30, 15);
-static const int QueenOpenFile = S(20, 30);
-static const int  RookSemiOpenFile = S(10, 20);
-static const int QueenSemiOpenFile = S(20, 15);
+static const int  RookOpenFile = S(20, 10);
+static const int QueenOpenFile = S(10, 15);
+static const int  RookSemiOpenFile = S(10, 15);
+static const int QueenSemiOpenFile = S(8, 5);
 
 static const int BishopPair = S(50, 50);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -17,12 +17,12 @@ static bitboard IsolatedMask[64];
 
 // Various bonuses and maluses
 static const int PawnPassed[8] = { 0, S(5, 5), S(10, 10), S(20, 20), S(35, 35), S(60, 60), S(100, 100), 0 };
-static const int PawnIsolated = S(-10, -10);
+static const int PawnIsolated = S(-15, -14);
 
-static const int  RookOpenFile = S(10, 10);
-static const int QueenOpenFile = S(5, 5);
-static const int  RookSemiOpenFile = S(5, 5);
-static const int QueenSemiOpenFile = S(3, 3);
+static const int  RookOpenFile = S(30, 15);
+static const int QueenOpenFile = S(20, 30);
+static const int  RookSemiOpenFile = S(10, 20);
+static const int QueenSemiOpenFile = S(20, 15);
 
 static const int BishopPair = S(50, 50);
 


### PR DESCRIPTION
CLOP tuning of various evaluation terms. CLOP indicated higher values in this and the previous tune #95 , but test games showed that more conservative increases performed better in both cases. Next up is tuning passed pawn values.

https://www.remi-coulom.fr/CLOP/

ELO   | 6.93 +- 5.12 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10329 W: 3121 L: 2915 D: 4293
http://chess.grantnet.us/viewTest/3868/

ELO   | 8.92 +- 5.89 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6931 W: 1892 L: 1714 D: 3325
http://chess.grantnet.us/viewTest/3872/