### PR TITLE
Piecelist Index

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -76,8 +76,9 @@ static void UpdatePosition(Position *pos) {
             // Phase
             pos->basePhase -= phaseValue[piece];
 
-            // Piece list / count
-            pos->pieceList[piece][pos->pieceCounts[piece]++] = sq;
+            // Piece list
+            pos->index[sq] = pos->pieceCounts[piece]++;
+            pos->pieceList[piece][pos->index[sq]] = sq;
 
             // King square
             if (piece == wK) pos->kingSq[WHITE] = sq;
@@ -93,16 +94,17 @@ static void UpdatePosition(Position *pos) {
 // Clears the board
 static void ClearPosition(Position *pos) {
 
+    // Array representation
+    memset(pos->board, 0ULL, sizeof(pos->board));
+
     // Bitboard representations
     memset(pos->colorBB, 0ULL, sizeof(pos->colorBB));
     memset(pos->pieceBB, 0ULL, sizeof(pos->pieceBB));
 
-    // Array representation
-    memset(pos->board, 0ULL, sizeof(pos->board));
-
-    // Piece lists and counts
+    // Piece list
     memset(pos->pieceCounts, 0, sizeof(pos->pieceCounts));
     memset(pos->pieceList,   0, sizeof(pos->pieceList));
+    memset(pos->index,       0, sizeof(pos->index));
 
     // King squares
     pos->kingSq[BLACK] = pos->kingSq[WHITE] = NO_SQ;

--- a/src/types.h
+++ b/src/types.h
@@ -120,6 +120,7 @@ typedef struct {
 
     int pieceCounts[PIECE_NB];
     int pieceList[PIECE_NB][10];
+    int index[64];
 
     int kingSq[2];
     int bigPieces[2];


### PR DESCRIPTION
Keeping track of the piecelist index of the piece on each square. No longer has to loop through the piecelist to find the correct one. A very significant speed up; 8-10% faster bench on my machine, and test games show a clear improvement.

ELO   | 8.47 +- 5.76 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7919 W: 2345 L: 2152 D: 3422
http://chess.grantnet.us/viewTest/3874/