### PR TITLE
Remove pos->kingSq

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -79,10 +79,6 @@ static void UpdatePosition(Position *pos) {
             // Piece list
             pos->index[sq] = pos->pieceCounts[piece]++;
             pos->pieceList[piece][pos->index[sq]] = sq;
-
-            // King square
-            if (piece == wK) pos->kingSq[WHITE] = sq;
-            if (piece == bK) pos->kingSq[BLACK] = sq;
         }
     }
 
@@ -105,9 +101,6 @@ static void ClearPosition(Position *pos) {
     memset(pos->pieceCounts, 0, sizeof(pos->pieceCounts));
     memset(pos->pieceList,   0, sizeof(pos->pieceList));
     memset(pos->index,       0, sizeof(pos->index));
-
-    // King squares
-    pos->kingSq[BLACK] = pos->kingSq[WHITE] = NO_SQ;
 
     // Big piece counts
     pos->bigPieces[BLACK] = pos->bigPieces[WHITE] = 0;
@@ -334,9 +327,6 @@ bool CheckBoard(const Position *pos) {
     assert(pos->enPas == NO_SQ
        || (pos->enPas >= 40 && pos->enPas < 48 && pos->side == WHITE)
        || (pos->enPas >= 16 && pos->enPas < 24 && pos->side == BLACK));
-
-    assert(pos->board[pos->kingSq[WHITE]] == wK);
-    assert(pos->board[pos->kingSq[BLACK]] == bK);
 
     assert(pos->castlePerm >= 0 && pos->castlePerm <= 15);
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -95,7 +95,7 @@ static bool checkresult(Position *pos) {
     if (found != 0)
         return false;
 
-    int InCheck = SqAttacked(pos->kingSq[pos->side], !pos->side, pos);
+    int InCheck = SqAttacked(pos->pieceList[makePiece(pos->side, KING)][1], !pos->side, pos);
 
     if (InCheck) {
         if (pos->side == WHITE) {

--- a/src/cli.c
+++ b/src/cli.c
@@ -95,7 +95,7 @@ static bool checkresult(Position *pos) {
     if (found != 0)
         return false;
 
-    int InCheck = SqAttacked(pos->pieceList[makePiece(pos->side, KING)][1], !pos->side, pos);
+    int InCheck = SqAttacked(pos->pieceList[makePiece(pos->side, KING)][0], !pos->side, pos);
 
     if (InCheck) {
         if (pos->side == WHITE) {

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -246,10 +246,11 @@ INLINE int evalQueens(const EvalInfo *ei, const Position *pos, const int color) 
 INLINE int evalKings(const Position *pos, const int color) {
 
     int eval = 0;
+    int kingSq = pos->pieceList[makePiece(color, KING)][0];
 
     // King safety
-    eval += KingLineVulnerability * PopCount(BishopAttacks(pos->kingSq[color], pos->colorBB[color] | pos->pieceBB[PAWN])
-                                             | RookAttacks(pos->kingSq[color], pos->colorBB[color] | pos->pieceBB[PAWN]));
+    eval += KingLineVulnerability * PopCount(BishopAttacks(kingSq, pos->colorBB[color] | pos->pieceBB[PAWN])
+                                             | RookAttacks(kingSq, pos->colorBB[color] | pos->pieceBB[PAWN]));
 
     return eval;
 }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -183,10 +183,6 @@ void TakeMove(Position *pos) {
     // Make reverse move (from <-> to)
     MovePiece(to, from, pos);
 
-    // Update king position if king moved
-    if (pieceKing[pos->board[from]])
-        pos->kingSq[pos->side] = from;
-
     // Add back captured piece if any
     int captured = CAPTURED(move);
     if (captured != EMPTY) {
@@ -298,10 +294,7 @@ bool MakeMove(Position *pos, const int move) {
             ClearPiece(to, pos);
             AddPiece(to, pos, promo);
         }
-
-    // Update king position if king moved
-    } else if (pieceKing[pos->board[to]])
-        pos->kingSq[side] = to;
+    }
 
     // Change turn to play
     pos->side ^= 1;
@@ -310,7 +303,7 @@ bool MakeMove(Position *pos, const int move) {
     assert(CheckBoard(pos));
 
     // If own king is attacked after the move, take it back immediately
-    if (SqAttacked(pos->kingSq[side], pos->side, pos)) {
+    if (SqAttacked(pos->pieceList[makePiece(side, KING)][0], pos->side, pos)) {
         TakeMove(pos);
         return false;
     }
@@ -322,7 +315,6 @@ bool MakeMove(Position *pos, const int move) {
 void MakeNullMove(Position *pos) {
 
     assert(CheckBoard(pos));
-    assert(!SqAttacked(pos->kingSq[pos->side], !pos->side, pos));
 
     // Save misc info for takeback
     // pos->history[pos->hisPly].move    = NOMOVE;

--- a/src/search.c
+++ b/src/search.c
@@ -248,7 +248,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     int R;
 
     // Extend search if in check
-    const bool inCheck = SqAttacked(pos->kingSq[pos->side], !pos->side, pos);
+    const bool inCheck = SqAttacked(pos->pieceList[makePiece(pos->side, KING)][0], !pos->side, pos);
     if (inCheck) depth++;
 
     // Quiescence at the end of search

--- a/src/types.h
+++ b/src/types.h
@@ -122,7 +122,6 @@ typedef struct {
     int pieceList[PIECE_NB][10];
     int index[64];
 
-    int kingSq[2];
     int bigPieces[2];
 
     int material;


### PR DESCRIPTION
Simplification removing kingSq and using the piece list instead. Saves a few lines of codes, and speeds up makemove.

ELO   | 5.19 +- 5.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 10441 W: 3095 L: 2939 D: 4407
http://chess.grantnet.us/viewTest/3875/