### PR TITLE
Remove promos from search history

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -11,7 +11,7 @@
 
 
 enum { QUIET, NOISY };
-enum { ENPAS, PROMO, PROMOCAP };
+enum { ENPAS, PROMO };
 
 static int MvvLvaScores[PIECE_NB][PIECE_NB];
 
@@ -39,21 +39,18 @@ INLINE void AddMove(const Position *pos, MoveList *list, const int from, const i
 
     // Add scores to help move ordering based on search history heuristics / mvvlva
     if (type == NOISY)
-        *moveScore = MvvLvaScores[captured][pos->board[from]] + 1000000;
+        *moveScore = MvvLvaScores[captured][pos->board[from]];
 
     if (type == QUIET) {
         if (pos->searchKillers[0][pos->ply] == move)
             *moveScore = 900000;
         else if (pos->searchKillers[1][pos->ply] == move)
             *moveScore = 800000;
-        else if (promo)
-            *moveScore = 700000;
         else
             *moveScore = pos->searchHistory[pos->board[from]][to];
     }
 
-    list->moves[list->count].move = move;
-    list->count++;
+    list->moves[list->count++].move = move;
 }
 INLINE void AddSpecialPawn(const Position *pos, MoveList *list, const int from, const int to, const int color, const int movetype, const int type) {
 
@@ -63,19 +60,10 @@ INLINE void AddSpecialPawn(const Position *pos, MoveList *list, const int from, 
     if (movetype == ENPAS) {
         int move = MOVE(from, to, EMPTY, EMPTY, FLAG_ENPAS);
         list->moves[list->count].move = move;
-        list->moves[list->count].score = 105 + 1000000;
+        list->moves[list->count].score = 105;
         list->count++;
     }
     if (movetype == PROMO) {
-        if (type == NOISY)
-            AddMove(pos, list, from, to, makePiece(color, QUEEN ), FLAG_NONE, QUIET);
-        if (type == QUIET) {
-            AddMove(pos, list, from, to, makePiece(color, KNIGHT), FLAG_NONE, QUIET);
-            AddMove(pos, list, from, to, makePiece(color, ROOK  ), FLAG_NONE, QUIET);
-            AddMove(pos, list, from, to, makePiece(color, BISHOP), FLAG_NONE, QUIET);
-        }
-    }
-    if (movetype == PROMOCAP) {
         if (type == NOISY)
             AddMove(pos, list, from, to, makePiece(color, QUEEN ), FLAG_NONE, NOISY);
         if (type == QUIET) {
@@ -176,11 +164,11 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const int color, const 
         // Promoting captures
         while (lPromoCap) {
             sq = PopLsb(&lPromoCap);
-            AddSpecialPawn(pos, list, relBackward(color, sq, 7), sq, color, PROMOCAP, type);
+            AddSpecialPawn(pos, list, relBackward(color, sq, 7), sq, color, PROMO, type);
         }
         while (rPromoCap) {
             sq = PopLsb(&rPromoCap);
-            AddSpecialPawn(pos, list, relBackward(color, sq, 9), sq, color, PROMOCAP, type);
+            AddSpecialPawn(pos, list, relBackward(color, sq, 9), sq, color, PROMO, type);
         }
         // Promotions
         while (promotions) {

--- a/src/search.c
+++ b/src/search.c
@@ -359,8 +359,8 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
         movesTried++;
 
-        bool moveIsNoisy = move & MOVE_IS_NOISY;
-        bool doLMR = depth > 2 && movesTried > (2 + pvNode) && pos->ply && !moveIsNoisy;
+        bool quiet = !(move & MOVE_IS_NOISY);
+        bool doLMR = depth > 2 && movesTried > (2 + pvNode) && pos->ply && quiet;
 
         // Reduced depth zero-window search (-1 depth)
         if (doLMR) {
@@ -405,7 +405,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 if (score >= beta) {
 
                     // Update killers if quiet move
-                    if (!(move & MOVE_IS_CAPTURE)) {
+                    if (quiet) {
                         pos->searchKillers[1][pos->ply] = pos->searchKillers[0][pos->ply];
                         pos->searchKillers[0][pos->ply] = move;
                     }
@@ -421,7 +421,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 }
 
                 // Update searchHistory if quiet move and not beta cutoff
-                if (!(move & MOVE_IS_CAPTURE))
+                if (quiet)
                     pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth;
             }
         }


### PR DESCRIPTION
Promoting captures were already excluded, now normal promotions too are also excluded from searchHistory. Pawns wanting to promote to a square does not necessarily imply that the square is good for other pieces to go to - it's not like the pawn has many options. This leads to slightly better move ordering and thus faster searches.

ELO   | 7.85 +- 5.52 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8630 W: 2545 L: 2350 D: 3735
http://chess.grantnet.us/viewTest/3879/

insert LTC