### PR TITLE
Razoring

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -322,6 +322,10 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         // Do a static evaluation for pruning consideration
         score = EvalPosition(pos);
 
+        // Razoring
+        if (depth < 2 && pos->ply && score + 500 < alpha)
+            return Quiescence(alpha, beta, pos, info, pv);
+
         // Null Move Pruning
         if (doNull && score >= beta && pos->ply && (pos->bigPieces[pos->side] > 0) && depth >= 4) {
 

--- a/src/search.c
+++ b/src/search.c
@@ -323,7 +323,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         score = EvalPosition(pos);
 
         // Razoring
-        if (depth < 2 && pos->ply && score + 500 < alpha)
+        if (!pvNode && depth < 2 && pos->ply && score + 500 < alpha)
             return Quiescence(alpha, beta, pos, info, pv);
 
         // Null Move Pruning


### PR DESCRIPTION
Skip straight to quiescence search at pre-frontier (depth=1) nodes if the evaluation is 500 below alpha. Not done at root, or in pv nodes. The margin of 500 is probably a bit higher than optimal, but I'd rather start it too high than too low, and it cuts down bench by about 15% as is. Lowering the margin did not improve bench by much (the lowest bench I managed was 65k at 300, compared to 66k at 500).

ELO   | 9.50 +- 6.21 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6950 W: 2104 L: 1914 D: 2932
http://chess.grantnet.us/viewTest/3889/

ELO   | 10.42 +- 6.42 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5569 W: 1463 L: 1296 D: 2810
http://chess.grantnet.us/viewTest/3890/