### PR TITLE
No double killers

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -42,9 +42,9 @@ INLINE void AddMove(const Position *pos, MoveList *list, const int from, const i
         *moveScore = MvvLvaScores[captured][pos->board[from]];
 
     if (type == QUIET) {
-        if (pos->searchKillers[0][pos->ply] == move)
+        if (pos->searchKillers[pos->ply][0] == move)
             *moveScore = 900000;
-        else if (pos->searchKillers[1][pos->ply] == move)
+        else if (pos->searchKillers[pos->ply][1] == move)
             *moveScore = 800000;
         else
             *moveScore = pos->searchHistory[pos->board[from]][to];

--- a/src/search.c
+++ b/src/search.c
@@ -422,9 +422,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 if (score >= beta) {
 
                     // Update killers if quiet move
-                    if (quiet && pos->searchKillers[0][pos->ply] != move) {
-                        pos->searchKillers[1][pos->ply] = pos->searchKillers[0][pos->ply];
-                        pos->searchKillers[0][pos->ply] = move;
+                    if (quiet && pos->searchKillers[pos->ply][0] != move) {
+                        pos->searchKillers[pos->ply][1] = pos->searchKillers[pos->ply][0];
+                        pos->searchKillers[pos->ply][0] = move;
                     }
 
     #ifdef SEARCH_STATS

--- a/src/search.c
+++ b/src/search.c
@@ -422,7 +422,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 if (score >= beta) {
 
                     // Update killers if quiet move
-                    if (quiet) {
+                    if (quiet && pos->searchKillers[0][pos->ply] != move) {
                         pos->searchKillers[1][pos->ply] = pos->searchKillers[0][pos->ply];
                         pos->searchKillers[0][pos->ply] = move;
                     }

--- a/src/types.h
+++ b/src/types.h
@@ -143,7 +143,7 @@ typedef struct {
     HashTable hashTable[1];
 
     int searchHistory[PIECE_NB][64];
-    int searchKillers[2][MAXDEPTH];
+    int searchKillers[MAXDEPTH][2];
 
 } Position;
 


### PR DESCRIPTION
If the same quiet move caused a beta cutoff twice in a row, both killers would become that move. This obviously isn't useful, and fixing it improves move ordering a fair bit. Also switched the indexing so elements used together are stored close together.

ELO   | 15.20 +- 8.49 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.89 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3750 W: 1175 L: 1011 D: 1564
http://chess.grantnet.us/viewTest/3942/