### PR TITLE
Quiet history on beta cutoff

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -146,7 +146,7 @@ static int QuiescenceDeltaMargin(const Position *pos) {
          : (enemy & pos->pieceBB[ROOK  ]) ? DeltaBase + R_MG
          : (enemy & pos->pieceBB[BISHOP]) ? DeltaBase + B_MG
          : (enemy & pos->pieceBB[KNIGHT]) ? DeltaBase + N_MG
-                                           : DeltaBase + P_MG;
+                                          : DeltaBase + P_MG;
 }
 
 // Quiescence
@@ -203,6 +203,7 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
 
         movesTried++;
 
+        // Found a new best move in this position
         if (score > bestScore) {
 
             bestScore = score;
@@ -265,8 +266,8 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     if (pos->ply > info->seldepth)
         info->seldepth = pos->ply;
 
-    // Early exits (not in root node)
-    if (pos->ply) {
+    // Early exits
+    if (!root) {
 
         // Position is drawn
         if (IsRepetition(pos) || pos->fiftyMove >= 100)
@@ -369,6 +370,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         if (quiet)
             quietCount++;
 
+        // Late move pruning
         if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 4 * depth * depth)
             break;
 
@@ -379,7 +381,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
         bool doLMR = depth > 2 && movesTried > (2 + pvNode) && pos->ply && quiet;
 
-        // Reduced depth zero-window search (-1 depth)
+        // Reduced depth zero-window search
         if (doLMR) {
             // Base reduction
             R  = Reductions[MIN(31, depth)][MIN(31, movesTried)];
@@ -418,7 +420,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 pv->line[0] = move;
                 memcpy(pv->line + 1, pv_from_here.line, sizeof(int) * pv_from_here.length);
 
-                // Update searchHistory if quiet move and not beta cutoff
+                // Update search history
                 if (quiet)
                     pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth;
 

--- a/src/search.c
+++ b/src/search.c
@@ -418,6 +418,10 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 pv->line[0] = move;
                 memcpy(pv->line + 1, pv_from_here.line, sizeof(int) * pv_from_here.length);
 
+                // Update searchHistory if quiet move and not beta cutoff
+                if (quiet)
+                    pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth;
+
                 // If score beats beta we have a cutoff
                 if (score >= beta) {
 
@@ -436,10 +440,6 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
                     return score;
                 }
-
-                // Update searchHistory if quiet move and not beta cutoff
-                if (quiet)
-                    pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth;
             }
         }
     }


### PR DESCRIPTION
Update history also on a beta cutoff. The beta cutoffs are the best moves found in the position, so encouraging trying them earlier is obviously better than only encouraging moves that beat alpha but not beta.

Passes easily:

ELO   | 26.13 +- 11.31 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2105 W: 688 L: 530 D: 887
http://chess.grantnet.us/viewTest/3944/

And is probably slightly better than only updating on beta cutoffs:

ELO   | -2.90 +- 4.76 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | -3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10194 W: 2501 L: 2586 D: 5107
http://chess.grantnet.us/viewTest/3946/