### PR TITLE
Increased eval scores

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -16,38 +16,38 @@ static Bitboard PassedMask[2][64];
 static Bitboard IsolatedMask[64];
 
 // Various bonuses and maluses
-static const int PawnPassed[8] = { 0, S(5, 5), S(10, 10), S(20, 20), S(35, 35), S(60, 60), S(100, 100), 0 };
-static const int PawnIsolated = S(-15, -14);
+static const int PawnPassed[8] = { 0, S(6, 6), S(13, 13), S(25, 25), S(45, 45), S(75, 75), S(130, 130), 0 };
+static const int PawnIsolated = S(-20, -18);
 
-static const int  RookOpenFile = S(20, 10);
-static const int QueenOpenFile = S(10, 15);
-static const int  RookSemiOpenFile = S(10, 15);
-static const int QueenSemiOpenFile = S(8, 5);
+static const int  RookOpenFile = S(25, 13);
+static const int QueenOpenFile = S(13, 20);
+static const int  RookSemiOpenFile = S(13, 20);
+static const int QueenSemiOpenFile = S(10, 6);
 
-static const int BishopPair = S(50, 50);
+static const int BishopPair = S(65, 65);
 
-static const int KingLineVulnerability = S(-8, 0);
+static const int KingLineVulnerability = S(-10, 0);
 
 // Mobility
 static const int KnightMobility[9] = {
-    S(-50, -50), S(-25, -25), S(-15, -15), S(0, 0), S(15, 15), S(25, 25), S(35, 35), S(40, 40), S(50, 50)
+    S(-65, -65), S(-32, -32), S(-20, -20), S(0, 0), S(20, 20), S(32, 32), S(45, 45), S(50, 50), S(65, 65)
 };
 
 static const int BishopMobility[14] = {
-    S(-50, -50), S(-35, -35), S(-25, -25), S(-10, -10), S( 0,  0), S(10, 10), S(15, 15),
-    S( 20,  20), S( 25,  25), S( 30,  30), S( 35,  35), S(40, 40), S(45, 45), S(50, 50)
+    S(-65, -65), S(-45, -45), S(-32, -32), S(-13, -13), S( 0,  0), S(13, 13), S(20, 20),
+    S( 25,  25), S( 32,  32), S( 38,  38), S( 45,  45), S(50, 50), S(57, 57), S(65, 65)
 };
 
 static const int RookMobility[15] = {
-    S(-50, -50), S(-35, -35), S(-25, -25), S(-10, -10), S( 0,  0), S(10, 10), S(15, 15),
-    S( 20,  20), S( 25,  25), S( 30,  30), S( 35,  35), S(40, 40), S(45, 45), S(50, 50), S(55, 55)
+    S(-65, -65), S(-45, -45), S(-32, -32), S(-13, -13), S( 0,  0), S(13, 13), S(20, 20),
+    S( 25,  25), S( 32,  32), S( 38,  38), S( 45,  45), S(50, 50), S(57, 57), S(65, 65), S(70, 70)
 };
 
 static const int QueenMobility[28] = {
-    S(-50, -50), S(-45, -45), S(-40, -40), S(-35, -35), S(-30, -30), S(-25, -25), S(-20, -20),
-    S(-15, -15), S(-10, -10), S( -5,  -5), S(  0,   0), S(  5,   5), S( 10,  10), S( 15,  15),
-    S( 20,  20), S( 25,  25), S( 30,  30), S( 35,  35), S( 40,  40), S( 45,  45), S( 50,  50),
-    S( 55,  55), S( 60,  60), S( 65,  65), S( 70,  70), S( 75,  75), S( 80,  80), S( 85,  85)
+    S(-65, -65), S(-57, -57), S(-50, -50), S(-45, -45), S(-38, -38), S(-32, -32), S(-25, -25),
+    S(-20, -20), S(-13, -13), S( -6,  -6), S(  0,   0), S(  6,   6), S( 13,  13), S( 20,  20),
+    S( 25,  25), S( 32,  32), S( 38,  38), S( 45,  45), S( 50,  50), S( 57,  57), S( 65,  65),
+    S( 70,  70), S( 75,  75), S( 83,  83), S( 90,  90), S( 95,  95), S( 100,  100), S( 105,  105)
 };
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -325,11 +325,11 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         score = EvalPosition(pos);
 
         // Razoring
-        if (!pvNode && depth < 2 && score + 500 < alpha)
+        if (!pvNode && depth < 2 && score + 640 < alpha)
             return Quiescence(alpha, beta, pos, info, pv);
 
         // Reverse Futility Pruning
-        if (!pvNode && depth < 7 && score - 175 * depth >= beta)
+        if (!pvNode && depth < 7 && score - 225 * depth >= beta)
             return score;
 
         // Null Move Pruning
@@ -467,7 +467,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 
     const int score = info->score;
     // Dynamic bonus increasing initial window and delta
-    const int bonus = (score * score) / 16;
+    const int bonus = (score * score) / 32;
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window

--- a/src/types.h
+++ b/src/types.h
@@ -42,11 +42,11 @@ typedef enum Piece {
 } Piece;
 
 enum PieceValue {
-    P_MG =  100, P_EG =  110,
-    N_MG =  335, N_EG =  350,
-    B_MG =  335, B_EG =  350,
-    R_MG =  550, R_EG =  580,
-    Q_MG = 1000, Q_EG = 1100
+    P_MG =  128, P_EG =  140,
+    N_MG =  430, N_EG =  450,
+    B_MG =  430, B_EG =  450,
+    R_MG =  700, R_EG =  740,
+    Q_MG = 1280, Q_EG = 1400
 };
 
 enum File { FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE_NONE };


### PR DESCRIPTION
Increased all eval scores by ~28% (aiming for 128 for pawn mg) to have a finer grain. I forgot to increase PSQTs at first, but local testing showed this to be a gain at STC so I went with it. Seems to be a wash at LTC, but this is the direction I want to go so I'll risk the slight regression - tuning values should bring it all back anyway.

ELO   | 4.61 +- 3.65 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20349 W: 6083 L: 5813 D: 8453
http://chess.grantnet.us/viewTest/3984/

ELO   | 0.27 +- 2.83 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | -3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29700 W: 7656 L: 7633 D: 14411
http://chess.grantnet.us/viewTest/3985/