### PR TITLE
bishops > knights

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -44,7 +44,7 @@ typedef enum Piece {
 enum PieceValue {
     P_MG =  128, P_EG =  140,
     N_MG =  430, N_EG =  450,
-    B_MG =  430, B_EG =  450,
+    B_MG =  450, B_EG =  475,
     R_MG =  700, R_EG =  740,
     Q_MG = 1280, Q_EG = 1400
 };


### PR DESCRIPTION
Either weiss is better with bishops or knights are overvalued by other terms relative to bishops.

ELO   | 10.07 +- 6.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6800 W: 2213 L: 2016 D: 2571
http://chess.grantnet.us/viewTest/4004/

ELO   | 9.70 +- 6.36 (95%)
SPRT  | 32.0+0.32s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6625 W: 2007 L: 1822 D: 2796
http://chess.grantnet.us/viewTest/4005/