### PR TITLE
Internal Iterative Deepening

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -326,9 +326,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         }
 
         // Internal iterative deepening
-        if (depth >= 4 && !ttMove) {
+        if (depth >= 5 && !ttMove) {
 
-            AlphaBeta(alpha, beta, MIN(6, depth - 4), pos, info, &pv_from_here, true);
+            AlphaBeta(alpha, beta, depth - MAX(5, depth / 2), pos, info, &pv_from_here, true);
 
             ProbeHashEntry(pos, &ttMove, &score, alpha, beta, depth);
         }

--- a/src/search.c
+++ b/src/search.c
@@ -328,7 +328,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         // Internal iterative deepening
         if (depth >= 4 && !ttMove) {
 
-            AlphaBeta(alpha, beta, depth - 4, pos, info, &pv_from_here, true);
+            AlphaBeta(alpha, beta, MIN(6, depth - 4), pos, info, &pv_from_here, true);
 
             ProbeHashEntry(pos, &ttMove, &score, alpha, beta, depth);
         }

--- a/src/search.c
+++ b/src/search.c
@@ -326,9 +326,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         }
 
         // Internal iterative deepening
-        if (depth >= 5 && !ttMove) {
+        if (depth >= 4 && !ttMove) {
 
-            AlphaBeta(alpha, beta, MAX(1, MIN(depth / 3, depth - 5)), pos, info, &pv_from_here, false);
+            AlphaBeta(alpha, beta, MAX(1, MIN(depth / 2, depth - 4)), pos, info, &pv_from_here, false);
 
             ProbeHashEntry(pos, &ttMove, &score, alpha, beta, depth);
         }

--- a/src/search.c
+++ b/src/search.c
@@ -324,6 +324,14 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
                 return score;
             }
         }
+
+        // Internal iterative deepening
+        if (depth >= 4 && !ttMove) {
+
+            AlphaBeta(alpha, beta, depth - 4, pos, info, &pv_from_here, true);
+
+            ProbeHashEntry(pos, &ttMove, &score, alpha, beta, depth);
+        }
     }
 
     InitNormalMP(&mp, &list, pos, ttMove);

--- a/src/search.c
+++ b/src/search.c
@@ -326,9 +326,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         }
 
         // Internal iterative deepening
-        if (depth >= 4 && !ttMove) {
+        if (depth >= 5 && !ttMove) {
 
-            AlphaBeta(alpha, beta, MAX(1, MIN(depth / 3, depth - 4)), pos, info, &pv_from_here, false);
+            AlphaBeta(alpha, beta, MAX(1, MIN(depth / 3, depth - 5)), pos, info, &pv_from_here, false);
 
             ProbeHashEntry(pos, &ttMove, &score, alpha, beta, depth);
         }

--- a/src/search.c
+++ b/src/search.c
@@ -326,9 +326,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         }
 
         // Internal iterative deepening
-        if (depth >= 5 && !ttMove) {
+        if (depth >= 4 && !ttMove) {
 
-            AlphaBeta(alpha, beta, depth - MAX(5, depth / 2), pos, info, &pv_from_here, true);
+            AlphaBeta(alpha, beta, MAX(1, MIN(depth / 3, depth - 4)), pos, info, &pv_from_here, false);
 
             ProbeHashEntry(pos, &ttMove, &score, alpha, beta, depth);
         }


### PR DESCRIPTION
Do a reduced-depth search when we don't get a move from the TT, then probe TT again to hopefully get one. Should improve move ordering, and skips movegen when the newly gained ttmove causes a cutoff. This version with MAX and MIN is a bit slow, so is not much of a gain at STC if at all, but is a decent gain at LTC. If I can get quiescence search to save to TT without losing elo, then the MAX can probably go.

ELO   | -0.00 +- 3.40 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24451 W: 7480 L: 7480 D: 9491
http://chess.grantnet.us/viewTest/4038/

ELO   | 4.11 +- 3.24 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.08 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23155 W: 6217 L: 5943 D: 10995
http://chess.grantnet.us/viewTest/4040/