### PR TITLE
Quadratic depth history bonus

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -424,7 +424,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
                 // Update search history
                 if (quiet)
-                    pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth;
+                    pos->searchHistory[pos->board[FROMSQ(bestMove)]][TOSQ(bestMove)] += depth * depth;
 
                 // If score beats beta we have a cutoff
                 if (score >= beta) {


### PR DESCRIPTION
Devalue history at lower depths to a larger extent than before. This resulted in a much bigger gain than expected; I've tried this with short local tests earlier, but saw no improvement.

ELO   | 9.59 +- 6.40 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6850 W: 2167 L: 1978 D: 2705
http://chess.grantnet.us/viewTest/4083/

ELO   | 15.78 +- 8.33 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3525 W: 1009 L: 849 D: 1667
http://chess.grantnet.us/viewTest/4084/