### PR TITLE
Smaller initial aspiration window

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -469,8 +469,8 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window
-    int alpha = MAX(score - delta / 4, -INFINITE);
-    int beta  = MIN(score + delta / 4,  INFINITE);
+    int alpha = MAX(score - delta / 8, -INFINITE);
+    int beta  = MIN(score + delta / 8,  INFINITE);
     // Counter for failed searches, bounds are relaxed more for each successive fail
     unsigned fails = 0;
 


### PR DESCRIPTION
Smaller initial aspiration window. Will have to try tweaking this even more as this was a much bigger gain than anticipated.

ELO   | 18.63 +- 9.53 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3174 W: 1069 L: 899 D: 1206
http://chess.grantnet.us/viewTest/4095/

ELO   | 15.49 +- 8.25 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3680 W: 1076 L: 912 D: 1692
http://chess.grantnet.us/viewTest/4097/