### PR TITLE
Lower dynamic aspiration bonus

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -465,7 +465,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 
     const int score = info->score;
     // Dynamic bonus increasing initial window and delta
-    const int bonus = (score * score) / 32;
+    const int bonus = (score * score) / 64;
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window


### PR DESCRIPTION
Another big gain from shrinking the aspiration window.

ELO   | 6.57 +- 4.96 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12331 W: 4161 L: 3928 D: 4242
http://chess.grantnet.us/viewTest/4099/

ELO   | 12.18 +- 7.24 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5109 W: 1565 L: 1386 D: 2158
http://chess.grantnet.us/viewTest/4101/