### PR TITLE
Lower aspiration window dynamic bonus

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -465,7 +465,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 
     const int score = info->score;
     // Dynamic bonus increasing initial window and delta
-    const int bonus = (score * score) / 64;
+    const int bonus = (score * score) / 256;
     // Delta used for initial window and widening
     const int delta = (P_MG / 2) + bonus;
     // Initial window


### PR DESCRIPTION
Weirdly dividing by 128 does not improve from 64, but 256 does. I will probably redo the whole aspiration window function, in particular decoupling the initial window and the delta used to relax bounds upon failing high or low.

ELO   | 3.43 +- 2.64 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 44551 W: 15166 L: 14726 D: 14659
http://chess.grantnet.us/viewTest/4108/

ELO   | 4.44 +- 3.54 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21622 W: 6456 L: 6180 D: 8986
http://chess.grantnet.us/viewTest/4110/