### PR TITLE
Widen initial aspiration window

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -466,7 +466,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
     const int score = info->score;
     // Dynamic bonus increasing initial window and relaxation delta
     const int bonus = score * score;
-    const int initialWindow = 8 + bonus / 2048;
+    const int initialWindow = 12 + bonus / 2048;
     const int delta = 64 + bonus / 256;
     // Initial window
     int alpha = MAX(score - initialWindow, -INFINITE);


### PR DESCRIPTION
As expected the initial window of 8 was too small. Will continue tweaking aspiration.

ELO   | 11.30 +- 7.27 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5999 W: 2147 L: 1952 D: 1900
http://chess.grantnet.us/viewTest/4115/

ELO   | 8.52 +- 5.88 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7754 W: 2343 L: 2153 D: 3258
http://chess.grantnet.us/viewTest/4117/