### PR TITLE
Refactor time management

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -20,6 +20,7 @@
 
 int Reductions[32][32];
 
+SearchLimits limits;
 extern bool ABORT_SIGNAL;
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -32,6 +32,38 @@ CONSTR InitReductions() {
             Reductions[depth][moves] = 0.75 + log(depth) * log(moves) / 2.25;
 }
 
+// Decides when to stop a search
+static void TimeManagement(SearchInfo *info) {
+
+    info->starttime = now();
+
+    const int moveOverhead = 50;
+
+    // Default to spending 1/30 of remaining time
+    if (limits.movestogo == 0)
+        limits.movestogo = 30;
+
+    // In movetime mode we use all the time given each turn
+    if (limits.movetime) {
+        limits.time = limits.movetime;
+        limits.movestogo = 1;
+    }
+
+    // Update search depth limit if we were given one
+    info->depth = limits.depth == 0 ? MAXDEPTH : limits.depth;
+
+    // Calculate how much time to use if given time constraints
+    if (limits.time) {
+        int timeThisMove = (limits.time / limits.movestogo) + limits.inc;
+        int maxTime = limits.time;
+        info->stoptime = info->starttime
+                       + MIN(maxTime, timeThisMove)
+                       - moveOverhead;
+        info->timeset = true;
+    } else
+        info->timeset = false;
+}
+
 // Check time situation
 static bool OutOfTime(SearchInfo *info) {
 
@@ -494,6 +526,8 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 void SearchPosition(Position *pos, SearchInfo *info) {
 
     ClearForSearch(pos, info);
+
+    TimeManagement(info);
 
     // Iterative deepening
     for (info->IDDepth = 1; info->IDDepth <= info->depth; ++info->IDDepth) {

--- a/src/search.c
+++ b/src/search.c
@@ -54,7 +54,7 @@ static void TimeManagement(SearchInfo *info) {
 
     // Calculate how much time to use if given time constraints
     if (limits.time) {
-        int timeThisMove = (limits.time / limits.movestogo) + limits.inc;
+        int timeThisMove = (limits.time / limits.movestogo) + 2 * limits.inc;
         int maxTime = limits.time;
         info->stoptime = info->starttime
                        + MIN(maxTime, timeThisMove)

--- a/src/search.h
+++ b/src/search.h
@@ -5,4 +5,6 @@
 #include "types.h"
 
 
+extern SearchLimits limits;
+
 void SearchPosition(Position *pos, SearchInfo *info);

--- a/src/tests.c
+++ b/src/tests.c
@@ -23,7 +23,7 @@ void benchmark(int depth, Position *pos, SearchInfo *info) {
 
     uint64_t nodes = 0ULL;
 
-    info->depth = depth;
+    limits.depth = depth;
     info->timeset = false;
 
     int startTime = now();

--- a/src/types.h
+++ b/src/types.h
@@ -175,6 +175,12 @@ typedef struct {
 
 } SearchThread;
 
+typedef struct {
+
+    int time, inc, movestogo, movetime, depth;
+
+} SearchLimits;
+
 /* Functions */
 
 INLINE int fileOf(const int square) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -30,46 +30,20 @@ INLINE bool BeginsWith(const char *string, const char *token) {
 }
 
 // Time management
-INLINE void TimeControl(Position *pos, SearchInfo *info, char *line) {
-
-    const int moveOverhead = 50;
-
-    info->starttime = now();
+INLINE void TimeControl(int side, char *line) {
 
     memset(&limits, 0, sizeof(SearchLimits));
-
-    limits.movestogo = 30; // Default to spending 1/30 of remaining time
 
     // Read in relevant search constraints
     char *ptr = NULL;
     // if ((ptr = strstr(line, "infinite")))
-    if ((ptr = strstr(line, "wtime")) && pos->side == WHITE) limits.time = atoi(ptr + 6);
-    if ((ptr = strstr(line, "btime")) && pos->side == BLACK) limits.time = atoi(ptr + 6);
-    if ((ptr = strstr(line, "winc"))  && pos->side == WHITE) limits.inc  = atoi(ptr + 5);
-    if ((ptr = strstr(line, "binc"))  && pos->side == BLACK) limits.inc  = atoi(ptr + 5);
+    if ((ptr = strstr(line, "wtime")) && side == WHITE) limits.time = atoi(ptr + 6);
+    if ((ptr = strstr(line, "btime")) && side == BLACK) limits.time = atoi(ptr + 6);
+    if ((ptr = strstr(line, "winc"))  && side == WHITE) limits.inc  = atoi(ptr + 5);
+    if ((ptr = strstr(line, "binc"))  && side == BLACK) limits.inc  = atoi(ptr + 5);
     if ((ptr = strstr(line, "movestogo"))) limits.movestogo = atoi(ptr + 10);
     if ((ptr = strstr(line, "movetime")))  limits.movetime  = atoi(ptr +  9);
     if ((ptr = strstr(line, "depth")))     limits.depth     = atoi(ptr +  6);
-
-    // In movetime mode we use all the time given each turn
-    if (limits.movetime) {
-        limits.time = limits.movetime;
-        limits.movestogo = 1;
-    }
-
-    // Update search depth limit if we were given one
-    info->depth = limits.depth == 0 ? MAXDEPTH : limits.depth;
-
-    // Calculate how much time to use if given time constraints
-    if (limits.time) {
-        int timeThisMove = (limits.time / limits.movestogo) + limits.inc;
-        int maxTime = limits.time;
-        info->stoptime = info->starttime
-                       + MIN(maxTime, timeThisMove)
-                       - moveOverhead;
-        info->timeset = true;
-    } else
-        info->timeset = false;
 }
 
 // Parses a 'go' and starts a search
@@ -79,7 +53,7 @@ static void *ParseGo(void *searchThreadInfo) {
     Position *pos     = sst->pos;
     SearchInfo *info  = sst->info;
 
-    TimeControl(pos, info, sst->line);
+    TimeControl(pos->side, sst->line);
 
     SearchPosition(pos, info);
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -29,64 +29,57 @@ INLINE bool BeginsWith(const char *string, const char *token) {
     return strstr(string, token) == string;
 }
 
+// Time management
+INLINE void TimeControl(Position *pos, SearchInfo *info, char *line) {
+
+    const int moveOverhead = 50;
+
+    info->starttime = now();
+
+    memset(&limits, 0, sizeof(SearchLimits));
+
+    limits.movestogo = 30; // Default to spending 1/30 of remaining time
+
+    // Read in relevant search constraints
+    char *ptr = NULL;
+    // if ((ptr = strstr(line, "infinite")))
+    if ((ptr = strstr(line, "wtime")) && pos->side == WHITE) limits.time = atoi(ptr + 6);
+    if ((ptr = strstr(line, "btime")) && pos->side == BLACK) limits.time = atoi(ptr + 6);
+    if ((ptr = strstr(line, "winc"))  && pos->side == WHITE) limits.inc  = atoi(ptr + 5);
+    if ((ptr = strstr(line, "binc"))  && pos->side == BLACK) limits.inc  = atoi(ptr + 5);
+    if ((ptr = strstr(line, "movestogo"))) limits.movestogo = atoi(ptr + 10);
+    if ((ptr = strstr(line, "movetime")))  limits.movetime  = atoi(ptr +  9);
+    if ((ptr = strstr(line, "depth")))     limits.depth     = atoi(ptr +  6);
+
+    // In movetime mode we use all the time given each turn
+    if (limits.movetime) {
+        limits.time = limits.movetime;
+        limits.movestogo = 1;
+    }
+
+    // Update search depth limit if we were given one
+    info->depth = limits.depth == 0 ? MAXDEPTH : limits.depth;
+
+    // Calculate how much time to use if given time constraints
+    if (limits.time) {
+        int timeThisMove = (limits.time / limits.movestogo) + limits.inc;
+        int maxTime = limits.time;
+        info->stoptime = info->starttime
+                       + MIN(maxTime, timeThisMove)
+                       - moveOverhead;
+        info->timeset = true;
+    } else
+        info->timeset = false;
+}
+
 // Parses a 'go' and starts a search
 static void *ParseGo(void *searchThreadInfo) {
 
     SearchThread *sst = (SearchThread*)searchThreadInfo;
-    char *line        = sst->line;
     Position *pos     = sst->pos;
     SearchInfo *info  = sst->info;
 
-    info->starttime = now();
-    info->timeset = false;
-
-    const int moveOverhead = 50;
-    int depth = -1, movestogo = 30, movetime = -1;
-    int time = -1, inc = 0;
-    char *ptr = NULL;
-
-    // Read in relevant time constraints if any
-    if ((ptr = strstr(line, "infinite"))) {
-        ;
-    }
-    // Increment
-    if ((ptr = strstr(line, "binc")) && pos->side == BLACK)
-        inc = atoi(ptr + 5);
-    if ((ptr = strstr(line, "winc")) && pos->side == WHITE)
-        inc = atoi(ptr + 5);
-    // Total remaining time
-    if ((ptr = strstr(line, "wtime")) && pos->side == WHITE)
-        time = atoi(ptr + 6);
-    if ((ptr = strstr(line, "btime")) && pos->side == BLACK)
-        time = atoi(ptr + 6);
-    // Moves left until next time control
-    if ((ptr = strstr(line, "movestogo")))
-        movestogo = atoi(ptr + 10);
-    // Time per move
-    if ((ptr = strstr(line, "movetime")))
-        movetime = atoi(ptr + 9);
-    // Max depth to search to
-    if ((ptr = strstr(line, "depth")))
-        depth = atoi(ptr + 6);
-
-    // In movetime mode we use all the time given each turn and expect more next move
-    if (movetime != -1) {
-        time = movetime;
-        movestogo = 1;
-    }
-
-    // Update search depth limit if we were given one
-    info->depth = depth == -1 ? MAXDEPTH : depth;
-
-    // Calculate how much time to use if given time constraints
-    if (time != -1) {
-        info->timeset = true;
-        int timeThisMove = (time / movestogo) + inc;    // Try to use 1/30 of remaining time + increment
-        int maxTime = time;                             // Most time we can use
-        info->stoptime  = info->starttime;
-        info->stoptime += timeThisMove > maxTime ? maxTime : timeThisMove;
-        info->stoptime -= moveOverhead;
-    }
+    TimeControl(pos, info, sst->line);
 
     SearchPosition(pos, info);
 


### PR DESCRIPTION
Moved everything about time control and management except parsing the input from uci to search. 

Also increased time usage in increment time control which was a huge gain at least in self-play games.

ELO   | 34.01 +- 13.39 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1650 W: 602 L: 441 D: 607
http://chess.grantnet.us/viewTest/4200/

ELO   | 22.96 +- 10.22 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.12 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2500 W: 784 L: 619 D: 1097
http://chess.grantnet.us/viewTest/4201/