### PR TITLE
Dynamic NMP depth

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -307,21 +307,23 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     if (!inCheck && !root) {
 
         // Do a static evaluation for pruning consideration
-        score = EvalPosition(pos);
+        int eval = EvalPosition(pos);
 
         // Razoring
-        if (!pvNode && depth < 2 && score + 640 < alpha)
+        if (!pvNode && depth < 2 && eval + 640 < alpha)
             return Quiescence(alpha, beta, pos, info, pv);
 
         // Reverse Futility Pruning
-        if (!pvNode && depth < 7 && score - 225 * depth >= beta)
-            return score;
+        if (!pvNode && depth < 7 && eval - 225 * depth >= beta)
+            return eval;
 
         // Null Move Pruning
-        if (doNull && score >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 4) {
+        if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 4) {
+
+            int R = 3 + depth / 4;
 
             MakeNullMove(pos);
-            score = -AlphaBeta(-beta, -beta + 1, depth - 4, pos, info, &pv_from_here, false);
+            score = -AlphaBeta(-beta, -beta + 1, depth - R, pos, info, &pv_from_here, false);
             TakeNullMove(pos);
 
             // Cutoff


### PR DESCRIPTION
Rather than a static depth reduction of 4 on null move pruning searches, now uses 3 + depth / 4. Static reduction of 4 (or so) was supposedly common a long time ago when engines did much shallower searches, in recent times with vastly increased search depths it seems to be important to scale reductions with the depth.

ELO   | 6.92 +- 5.16 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11098 W: 3653 L: 3432 D: 4013
http://chess.grantnet.us/viewTest/4226/


http://chess.grantnet.us/viewTest/4228/