### PR TITLE
Null move prune at lower depth

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -318,7 +318,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
             return eval;
 
         // Null Move Pruning
-        if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 4) {
+        if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 2) {
 
             int R = 3 + depth / 4;
 

--- a/src/search.c
+++ b/src/search.c
@@ -318,7 +318,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
             return eval;
 
         // Null Move Pruning
-        if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 2) {
+        if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 3) {
 
             int R = 3 + depth / 4;
 


### PR DESCRIPTION
Use null move pruning also at depth 3.

Tests vs depth 2 which beat 4 handily.

ELO   | 7.08 +- 5.15 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10695 W: 3381 L: 3163 D: 4151
http://chess.grantnet.us/viewTest/4231/

ELO   | 13.12 +- 7.49 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4426 W: 1270 L: 1103 D: 2053
http://chess.grantnet.us/viewTest/4235/