### PR TITLE
Increase NMP depth reduction based on eval

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -320,7 +320,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         // Null Move Pruning
         if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 3) {
 
-            int R = 3 + depth / 4;
+            int R = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
 
             MakeNullMove(pos);
             score = -AlphaBeta(-beta, -beta + 1, depth - R, pos, info, &pv_from_here, false);


### PR DESCRIPTION
Increase depth reduction based on how much eval beats beta. When static eval beats beta by a lot we don't need as strong evidence to conclude this is already too good.

ELO   | 5.36 +- 4.21 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15875 W: 4953 L: 4708 D: 6214
http://chess.grantnet.us/viewTest/4232/

ELO   | 11.48 +- 6.92 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5025 W: 1390 L: 1224 D: 2411
http://chess.grantnet.us/viewTest/4238/