### PR TITLE
Lower NMP depth reduction

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -320,7 +320,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         // Null Move Pruning
         if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 3) {
 
-            int R = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
+            int R = 3 + depth / 3 + MIN(3, (eval - beta) / 256);
 
             MakeNullMove(pos);
             score = -AlphaBeta(-beta, -beta + 1, depth - R, pos, info, &pv_from_here, false);

--- a/src/search.c
+++ b/src/search.c
@@ -320,7 +320,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         // Null Move Pruning
         if (doNull && eval >= beta && (pos->bigPieces[pos->side] > 0) && depth >= 3) {
 
-            int R = 3 + depth / 3 + MIN(3, (eval - beta) / 256);
+            int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 
             MakeNullMove(pos);
             score = -AlphaBeta(-beta, -beta + 1, depth - R, pos, info, &pv_from_here, false);


### PR DESCRIPTION
Lowers the bonus to reduction given based on depth. Given the big elo gain it would seem likely that lowering it further is better still, or perhaps the eval bonus can increased.

ELO   | 7.79 +- 5.59 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9150 W: 2929 L: 2724 D: 3497
http://chess.grantnet.us/viewTest/4248/

ELO   | 7.76 +- 5.34 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8549 W: 2348 L: 2157 D: 4044
http://chess.grantnet.us/viewTest/4249/