### PR TITLE
TT replacement scheme

### DIFF
--- a/src/defs.h
+++ b/src/defs.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#define NAME "weiss 0.8"
+#define NAME "weiss 0.8-dev"
 
 #define NDEBUG
 #include <assert.h>

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -70,11 +70,14 @@ void StoreTTEntry(TTEntry *tte, const uint64_t posKey, const int move, const int
     assert(flag >= BOUND_UPPER && flag <= BOUND_EXACT);
     assert(depth >= 1 && depth < MAXDEPTH);
 
-    tte->posKey = posKey;
-    tte->move   = move;
-    tte->score  = score;
-    tte->depth  = depth;
-    tte->flag   = flag;
+    // Store new data unless it would overwrite data about the same
+    // position searched to a lower depth.
+    if (!(posKey == tte->posKey && depth < tte->depth))
+        tte->posKey = posKey,
+        tte->move   = move,
+        tte->score  = score,
+        tte->depth  = depth,
+        tte->flag   = flag;
 }
 
 // Estimates the load factor of the transposition table (1 = 0.1%)

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -72,7 +72,7 @@ void StoreTTEntry(TTEntry *tte, const uint64_t posKey, const int move, const int
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (posKey != tte->posKey || depth >= tte->depth)
+    if (posKey != tte->posKey || depth >= tte->depth || flag == BOUND_EXACT)
         tte->posKey = posKey,
         tte->move   = move,
         tte->score  = score,

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -72,7 +72,7 @@ void StoreTTEntry(TTEntry *tte, const uint64_t posKey, const int move, const int
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (!(posKey == tte->posKey && depth < tte->depth))
+    if (posKey != tte->posKey || depth >= tte->depth)
         tte->posKey = posKey,
         tte->move   = move,
         tte->score  = score,

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -71,7 +71,7 @@ void StoreTTEntry(TTEntry *tte, const uint64_t posKey, const int move, const int
     assert(depth >= 1 && depth < MAXDEPTH);
 
     // Store new data unless it would overwrite data about the same
-    // position searched to a lower depth.
+    // position searched to a higher depth.
     if (!(posKey == tte->posKey && depth < tte->depth))
         tte->posKey = posKey,
         tte->move   = move,


### PR DESCRIPTION
Rather than always overwriting the old data in the transposition table, now only does so if the new data is for a different position, is the result of searching at least equally deep, or the data is an exact score (as opposed to being an upper or lower bound. An exact score is generally more useful when fetched again later).

ELO   | 16.98 +- 8.97 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3501 W: 1149 L: 978 D: 1374
http://chess.grantnet.us/viewTest/4267/

ELO   | 6.63 +- 4.79 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10434 W: 2803 L: 2604 D: 5027
http://chess.grantnet.us/viewTest/4268/