### PR TITLE
Eval history

### DIFF
--- a/src/makemove.c
+++ b/src/makemove.c
@@ -317,7 +317,7 @@ void MakeNullMove(Position *pos) {
     assert(CheckBoard(pos));
 
     // Save misc info for takeback
-    // pos->history[pos->hisPly].move    = NOMOVE;
+    pos->history[pos->hisPly].move       = NOMOVE;
     pos->history[pos->hisPly].enPas      = pos->enPas;
     pos->history[pos->hisPly].fiftyMove  = pos->fiftyMove;
     pos->history[pos->hisPly].castlePerm = pos->castlePerm;

--- a/src/search.c
+++ b/src/search.c
@@ -302,12 +302,16 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     }
 
     int score = -INFINITE;
+    int eval = NOSCORE;
 
     // Skip pruning while in check and at the root
     if (!inCheck && !root) {
 
         // Do a static evaluation for pruning consideration
-        int eval = EvalPosition(pos);
+        if (pos->history[pos->hisPly - 1].move == NOMOVE)
+            pos->history[pos->ply].eval = eval = -pos->history[pos->ply - 1].eval;
+        else
+            pos->history[pos->ply].eval = eval = EvalPosition(pos);
 
         // Razoring
         if (!pvNode && depth < 2 && eval + 640 < alpha)

--- a/src/search.c
+++ b/src/search.c
@@ -309,9 +309,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
         // Do a static evaluation for pruning consideration
         if (pos->history[pos->hisPly - 1].move == NOMOVE)
-            pos->history[pos->ply].eval = eval = -pos->history[pos->ply - 1].eval;
+            pos->history[pos->hisPly].eval = eval = -pos->history[pos->hisPly - 1].eval;
         else
-            pos->history[pos->ply].eval = eval = EvalPosition(pos);
+            pos->history[pos->hisPly].eval = eval = EvalPosition(pos);
 
         // Razoring
         if (!pvNode && depth < 2 && eval + 640 < alpha)

--- a/src/types.h
+++ b/src/types.h
@@ -92,7 +92,7 @@ typedef struct {
     int castlePerm;
     uint64_t posKey;
     int eval;
-} Undo;
+} History;
 
 typedef struct {
     uint64_t posKey;
@@ -134,7 +134,7 @@ typedef struct {
 
     uint64_t posKey;
 
-    Undo history[MAXGAMEMOVES];
+    History history[MAXGAMEMOVES];
 
     TT hashTable[1];
 

--- a/src/types.h
+++ b/src/types.h
@@ -91,6 +91,7 @@ typedef struct {
     int fiftyMove;
     int castlePerm;
     uint64_t posKey;
+    int eval;
 } Undo;
 
 typedef struct {


### PR DESCRIPTION
Saves a history of static evaluations and uses them along with the move history to avoid recalculating the static evaluation after a null move; the position has obviously not changed aside from side to move so the evaluation is just the opposite of the previous.

ELO   | 8.63 +- 5.98 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7975 W: 2553 L: 2355 D: 3067
http://chess.grantnet.us/viewTest/4313/

ELO   | 7.87 +- 5.40 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8350 W: 2291 L: 2102 D: 3957
http://chess.grantnet.us/viewTest/4314/