### PR TITLE
Cleanup attack bitboard initialization

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -23,8 +23,8 @@ typedef struct {
 static Bitboard bishop_attacks[0x1480];
 static Bitboard rook_attacks[0x19000];
 
-static Magic mBishopTable[64];
-static Magic mRookTable[64];
+static Magic BishopTable[64];
+static Magic RookTable[64];
 
 Bitboard pawn_attacks[2][64];
 Bitboard knight_attacks[64];
@@ -135,40 +135,42 @@ static Bitboard MakeSliderAttacks(const int sq, const Bitboard occupied, const i
 
 // Inits the magic shit
 #ifdef USE_PEXT
-static void InitSliderAttacks(Magic *table, Bitboard *attackTable, const int *dir) {
+static void InitSliderAttacks(Magic *m, Bitboard *table, const int *dir) {
 #else
-static void InitSliderAttacks(Magic *table, Bitboard *attackTable, const Bitboard *magics, const int *dir) {
+static void InitSliderAttacks(Magic *m, Bitboard *table, const uint64_t *magics, const int *dir) {
 #endif
-    int size, index;
+    int size = 0, index;
     Bitboard edges, occupied;
 
-    table[0].attacks = attackTable;
+    m[0].attacks = table;
 
     for (int sq = A1; sq <= H8; ++sq) {
 
+        // Construct the mask
         edges = ((rank1BB | rank8BB) & ~rankBBs[rankOf(sq)])
               | ((fileABB | fileHBB) & ~fileBBs[fileOf(sq)]);
 
-        table[sq].mask  = MakeSliderAttacks(sq, 0, dir) & ~edges;
+        m[sq].mask  = MakeSliderAttacks(sq, 0, dir) & ~edges;
+
 #ifndef USE_PEXT
-        table[sq].magic = magics[sq];
-        table[sq].shift = 64 - PopCount(table[sq].mask);
+        m[sq].magic = magics[sq];
+        m[sq].shift = 64 - PopCount(m[sq].mask);
 #endif
 
-        table[sq].attacks = sq == A1 ? attackTable : table[sq - 1].attacks + size + 1;
+        m[sq].attacks = sq == A1 ? table : m[sq - 1].attacks + size;
 
         size = occupied = 0;
 
         do {
 #ifdef USE_PEXT
-            index = _pext_u64(occupied, table[sq].mask);
+            index = _pext_u64(occupied, m[sq].mask);
 #else
-            index = (occupied * table[sq].magic) >> table[sq].shift;
+            index = (occupied * m[sq].magic) >> m[sq].shift;
 #endif
-            if (index > size)
-                size = index;
-            table[sq].attacks[index] = MakeSliderAttacks(sq, occupied, dir);
-            occupied = (occupied - table[sq].mask) & table[sq].mask; // Carry rippler
+            m[sq].attacks[index] = MakeSliderAttacks(sq, occupied, dir);
+
+            size++;
+            occupied = (occupied - m[sq].mask) & m[sq].mask; // Carry rippler
         } while (occupied);
     }
 }
@@ -186,35 +188,35 @@ CONSTR InitAttacks() {
 
     // Magic
 #ifdef USE_PEXT
-    InitSliderAttacks(mBishopTable, bishop_attacks, bishopDirections);
-    InitSliderAttacks(  mRookTable,   rook_attacks,   rookDirections);
+    InitSliderAttacks(BishopTable, bishop_attacks, bishopDirections);
+    InitSliderAttacks(  RookTable,   rook_attacks,   rookDirections);
 #else
-    InitSliderAttacks(mBishopTable, bishop_attacks, BishopMagics, bishopDirections);
-    InitSliderAttacks(  mRookTable,   rook_attacks,   RookMagics,   rookDirections);
+    InitSliderAttacks(BishopTable, bishop_attacks, BishopMagics, bishopDirections);
+    InitSliderAttacks(  RookTable,   rook_attacks,   RookMagics,   rookDirections);
 #endif
 }
 
 // Returns the attack bitboard for a bishop based on what squares are occupied
 Bitboard BishopAttacks(const int sq, Bitboard occupied) {
 #ifdef USE_PEXT
-    return mBishopTable[sq].attacks[_pext_u64(occupied, mBishopTable[sq].mask)];
+    return BishopTable[sq].attacks[_pext_u64(occupied, BishopTable[sq].mask)];
 #else
-    occupied     &= mBishopTable[sq].mask;
-    occupied     *= mBishopTable[sq].magic;
-    occupied    >>= mBishopTable[sq].shift;
-    return mBishopTable[sq].attacks[occupied];
+    occupied  &= BishopTable[sq].mask;
+    occupied  *= BishopTable[sq].magic;
+    occupied >>= BishopTable[sq].shift;
+    return BishopTable[sq].attacks[occupied];
 #endif
 }
 
 // Returns the attack bitboard for a rook based on what squares are occupied
 Bitboard RookAttacks(const int sq, Bitboard occupied) {
 #ifdef USE_PEXT
-    return mRookTable[sq].attacks[_pext_u64(occupied, mRookTable[sq].mask)];
+    return RookTable[sq].attacks[_pext_u64(occupied, RookTable[sq].mask)];
 #else
-    occupied     &= mRookTable[sq].mask;
-    occupied     *= mRookTable[sq].magic;
-    occupied    >>= mRookTable[sq].shift;
-    return mRookTable[sq].attacks[occupied];
+    occupied  &= RookTable[sq].mask;
+    occupied  *= RookTable[sq].magic;
+    occupied >>= RookTable[sq].shift;
+    return RookTable[sq].attacks[occupied];
 #endif
 }
 


### PR DESCRIPTION
General cleanup and refactoring of the way non-slider attack bitboards are initialized, based on code by protonspring for Stockfish. No functional change, the test result is likely just small sample size.

ELO   | 4.63 +- 5.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 8925 W: 2841 L: 2722 D: 3362
http://chess.grantnet.us/viewTest/4339/