### PR TITLE
Speedup MakeMove

### DIFF
--- a/src/makemove.c
+++ b/src/makemove.c
@@ -242,7 +242,9 @@ bool MakeMove(Position *pos, const int move) {
         pos->enPas = NO_SQ;
     }
 
-    // Hash out the old castling rights, update and hash back in
+    // Rehash the castling rights if at least one side can castle,
+    // and either the to or from square is the original square of
+    // a king or rook.
     if (pos->castlePerm && CastlePerm[from] ^ CastlePerm[to]) {
         HASH_CA;
         pos->castlePerm &= CastlePerm[from];

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -243,10 +243,12 @@ bool MakeMove(Position *pos, const int move) {
     }
 
     // Hash out the old castling rights, update and hash back in
-    HASH_CA;
-    pos->castlePerm &= CastlePerm[from];
-    pos->castlePerm &= CastlePerm[to];
-    HASH_CA;
+    if (pos->castlePerm && CastlePerm[from] ^ CastlePerm[to]) {
+        HASH_CA;
+        pos->castlePerm &= CastlePerm[from];
+        pos->castlePerm &= CastlePerm[to];
+        HASH_CA;
+    }
 
     // Move the rook during castling
     if (move & FLAG_CASTLE)


### PR DESCRIPTION
Only rehash the castling rights if at least one side can castle, and either the to or from square is the original square of a king or rook.

ELO   | 5.59 +- 4.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15527 W: 4951 L: 4701 D: 5875
http://chess.grantnet.us/viewTest/4361/