### PR TITLE
Tweak time management

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -35,7 +35,7 @@ CONSTR InitReductions() {
 // Check time situation
 static bool OutOfTime(SearchInfo *info) {
 
-    if (  (info->nodes & 8192) == 0
+    if (  (info->nodes & 8191) == 8191
         && limits.timelimit
         && TimeSince(limits.start) >= limits.maxUsage)
 

--- a/src/search.c
+++ b/src/search.c
@@ -498,6 +498,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 static void InitTimeManagement() {
 
     const int overhead = 50;
+    const int minTime = 20;
 
     // Default to spending 1/30 of remaining time
     if (limits.movestogo == 0)
@@ -514,11 +515,9 @@ static void InitTimeManagement() {
 
     // Calculate how much time to use if given time constraints
     if (limits.time) {
-        int timeThisMove = MIN(limits.time, (limits.time / limits.movestogo) + 2 * limits.inc);
+        int timeThisMove = MIN(limits.time, (limits.time / limits.movestogo) + 2 * limits.inc) - overhead;
 
-        limits.stop = limits.start
-                    + timeThisMove
-                    - overhead;
+        limits.stop = limits.start + MAX(minTime, timeThisMove);
 
         limits.timelimit = true;
     } else

--- a/src/search.c
+++ b/src/search.c
@@ -37,7 +37,7 @@ static bool OutOfTime(SearchInfo *info) {
 
     if (  (info->nodes & 8192) == 0
         && limits.timelimit
-        && Now() >= limits.stop)
+        && TimeSince(limits.start) >= limits.maxUsage - 10)
 
         return true;
 
@@ -497,7 +497,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 // Decides when to stop a search
 static void InitTimeManagement() {
 
-    const int overhead = 50;
+    const int overhead = 30;
     const int minTime = 20;
 
     // Default to spending 1/30 of remaining time
@@ -517,7 +517,7 @@ static void InitTimeManagement() {
     if (limits.time) {
         int timeThisMove = MIN(limits.time, (limits.time / limits.movestogo) + 2 * limits.inc) - overhead;
 
-        limits.stop = limits.start + MAX(minTime, timeThisMove);
+        limits.maxUsage = MAX(minTime, timeThisMove);
 
         limits.timelimit = true;
     } else

--- a/src/search.c
+++ b/src/search.c
@@ -37,7 +37,7 @@ static bool OutOfTime(SearchInfo *info) {
 
     if (  (info->nodes & 8192) == 0
         && limits.timelimit
-        && TimeSince(limits.start) >= limits.maxUsage - 10)
+        && TimeSince(limits.start) >= limits.maxUsage)
 
         return true;
 

--- a/src/search.c
+++ b/src/search.c
@@ -498,7 +498,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 static void InitTimeManagement() {
 
     const int overhead = 30;
-    const int minTime = 20;
+    const int minTime = 10;
 
     // Default to spending 1/30 of remaining time
     if (limits.movestogo == 0)
@@ -515,7 +515,7 @@ static void InitTimeManagement() {
 
     // Calculate how much time to use if given time constraints
     if (limits.time) {
-        int timeThisMove = MIN(limits.time, (limits.time / limits.movestogo) + 2 * limits.inc) - overhead;
+        int timeThisMove = MIN(limits.time, (limits.time / limits.movestogo) + 1.5 * limits.inc) - overhead;
 
         limits.maxUsage = MAX(minTime, timeThisMove);
 

--- a/src/time.c
+++ b/src/time.c
@@ -16,3 +16,7 @@ int Now() {
     return t.tv_sec * 1000 + t.tv_nsec / 1000000;
 #endif
 }
+
+int TimeSince(const int time) {
+    return Now() - time;
+}

--- a/src/time.h
+++ b/src/time.h
@@ -4,3 +4,4 @@
 
 
 int Now();
+int TimeSince(const int time);

--- a/src/types.h
+++ b/src/types.h
@@ -179,7 +179,7 @@ typedef struct {
 
 typedef struct {
 
-    int start, time, inc, movestogo, movetime, depth, stop;
+    int start, time, inc, movestogo, movetime, depth, maxUsage;
     bool timelimit;
 
 } SearchLimits;


### PR DESCRIPTION
Adds a minimum thinking time of 10ms, lowers move overhead to 30ms from 50, switches to using elapsed time rather than fixed points in time to check for timeout, and changes the OutOfTime logic to not check for timeout at 0 nodes as aborting a search at that point is nonsensical.

ELO   | 5.44 +- 4.25 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15765 W: 4969 L: 4722 D: 6074
http://chess.grantnet.us/viewTest/4359/

ELO   | 6.61 +- 5.74 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-2.50, 2.50]
Games | N: 7304 W: 1970 L: 1831 D: 3503
http://chess.grantnet.us/viewTest/4362/