### PR TITLE
Improved time management

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -514,12 +514,13 @@ static void InitTimeManagement() {
     }
 
     double ratio = limits.movestogo ? MAX(1.0, limits.movestogo * 0.75)
-                                    : 30;
+                                    : 30.0;
 
     int timeThisMove = limits.time / ratio + 1.5 * limits.inc;
 
-    // Use at most time - overhead, and at least minTime
-    limits.maxUsage  = MAX(minTime, MIN(limits.time - MAX(overhead, limits.movestogo * minTime), timeThisMove));
+    // Try to save at least 10ms for each move left to go
+    // as well as a buffer of 30ms, while using at least 10ms
+    limits.maxUsage  = MAX(minTime, MIN(limits.time - overhead - limits.movestogo * minTime, timeThisMove));
     limits.timelimit = true;
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -513,13 +513,13 @@ static void InitTimeManagement() {
         return;
     }
 
-    int ratio = limits.movestogo ? MAX(1, limits.movestogo * 0.75)
-                                 : 30;
+    double ratio = limits.movestogo ? MAX(1.0, limits.movestogo * 0.75)
+                                    : 30;
 
     int timeThisMove = limits.time / ratio + 1.5 * limits.inc;
 
     // Use at most time - overhead, and at least minTime
-    limits.maxUsage  = MAX(minTime, MIN(limits.time - overhead, timeThisMove));
+    limits.maxUsage  = MAX(minTime, MIN(limits.time - overhead - limits.movestogo * minTime, timeThisMove));
     limits.timelimit = true;
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -500,28 +500,27 @@ static void InitTimeManagement() {
     const int overhead = 30;
     const int minTime = 10;
 
-    // Default to spending 1/30 of remaining time
-    if (limits.movestogo == 0)
-        limits.movestogo = 30;
-
     // In movetime mode we use all the time given each turn
     if (limits.movetime) {
-        limits.time = limits.movetime;
-        limits.movestogo = 1;
+        limits.maxUsage = MAX(minTime, limits.movetime - overhead);
+        limits.timelimit = true;
+        return;
     }
 
-    // Update search depth limit if we were given one
-    limits.depth = limits.depth == 0 ? MAXDEPTH : limits.depth;
-
-    // Calculate how much time to use if given time constraints
-    if (limits.time) {
-        int timeThisMove = MIN(limits.time, (limits.time / limits.movestogo) + 1.5 * limits.inc) - overhead;
-
-        limits.maxUsage = MAX(minTime, timeThisMove);
-
-        limits.timelimit = true;
-    } else
+    // No time and no movetime means there is no timelimit
+    if (!limits.time) {
         limits.timelimit = false;
+        return;
+    }
+
+    int ratio = limits.movestogo ? MAX(1, limits.movestogo * 0.75)
+                                 : 30;
+
+    int timeThisMove = limits.time / ratio + 1.5 * limits.inc;
+
+    // Use at most time - overhead, and at least minTime
+    limits.maxUsage  = MAX(minTime, MIN(limits.time - overhead, timeThisMove));
+    limits.timelimit = true;
 }
 
 // Root of search

--- a/src/search.c
+++ b/src/search.c
@@ -519,7 +519,7 @@ static void InitTimeManagement() {
     int timeThisMove = limits.time / ratio + 1.5 * limits.inc;
 
     // Use at most time - overhead, and at least minTime
-    limits.maxUsage  = MAX(minTime, MIN(limits.time - overhead - limits.movestogo * minTime, timeThisMove));
+    limits.maxUsage  = MAX(minTime, MIN(limits.time - MAX(overhead, limits.movestogo * minTime), timeThisMove));
     limits.timelimit = true;
 }
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -46,6 +46,9 @@ INLINE void TimeControl(int side, char *line) {
     if ((ptr = strstr(line, "movestogo"))) limits.movestogo = atoi(ptr + 10);
     if ((ptr = strstr(line, "movetime")))  limits.movetime  = atoi(ptr +  9);
     if ((ptr = strstr(line, "depth")))     limits.depth     = atoi(ptr +  6);
+
+    // If no depth limit is given, use MAXDEPTH
+    limits.depth = limits.depth == 0 ? MAXDEPTH : limits.depth;
 }
 
 // Parses a 'go' and starts a search


### PR DESCRIPTION
No longer includes overhead in the time usage calculation of every turn, but rather only to keep a buffer of time. This results in using closer to all the time given at short TC, spending down to near 100ms left at 10+0.1 rather than ~500ms.

Also uses more time early on in repeating time controls rather than equal time on all turns, as saving a lot of time for later is pointless if the game is decided before it can be used. And saves at least 10ms for each move left (+ the overhead buffer).

ELO   | 18.49 +- 10.53 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 2615 W: 886 L: 747 D: 982
http://chess.grantnet.us/viewTest/4374/

ELO   | 22.11 +- 10.66 (95%)
SPRT  | 40/9.0s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2643 W: 937 L: 769 D: 937
http://chess.grantnet.us/viewTest/4372/

ELO   | 5.03 +- 3.94 (95%)
SPRT  | 40/40.0s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16568 W: 4736 L: 4496 D: 7336
http://chess.grantnet.us/viewTest/4373/