### PR TITLE
Speedup + Cleanup

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -96,8 +96,8 @@ static void InitSliderAttacks(Magic *m, Bitboard *table, const uint64_t *magics,
     for (int sq = A1; sq <= H8; ++sq) {
 
         // Construct the mask
-        edges = ((rank1BB | rank8BB) & ~rankBBs[rankOf(sq)])
-              | ((fileABB | fileHBB) & ~fileBBs[fileOf(sq)]);
+        edges = ((rank1BB | rank8BB) & ~rankBB[rankOf(sq)])
+              | ((fileABB | fileHBB) & ~fileBB[fileOf(sq)]);
 
         m[sq].mask  = MakeSliderAttacks(sq, 0, dir) & ~edges;
 

--- a/src/bitboards.c
+++ b/src/bitboards.c
@@ -6,19 +6,19 @@
 #include "bitboards.h"
 
 
-const Bitboard fileBBs[] = { 0x0101010101010101ULL, 0x0202020202020202ULL, 0x0404040404040404ULL, 0x0808080808080808ULL,
-                             0x1010101010101010ULL, 0x2020202020202020ULL, 0x4040404040404040ULL, 0x8080808080808080ULL };
+const Bitboard fileBB[] = { fileABB, fileBBB, fileCBB, fileDBB,
+                            fileEBB, fileFBB, fileGBB, fileHBB };
 
-const Bitboard rankBBs[] = {         0xFF,         0xFF00,         0xFF0000,         0xFF000000,
-                             0xFF00000000, 0xFF0000000000, 0xFF000000000000, 0xFF00000000000000 };
+const Bitboard rankBB[] = { rank1BB, rank2BB, rank3BB, rank4BB,
+                            rank5BB, rank6BB, rank7BB, rank8BB };
+
+Bitboard SquareBB[64];
 
 
 CONSTR InitBitMasks() {
 
-    for (int i = A1; i <= H8; ++i) {
-        SetMask[i]  |= (1ULL << i);
-        ClearMask[i] = ~SetMask[i];
-    }
+    for (int sq = A1; sq <= H8; ++sq)
+        SquareBB[sq] = (1ULL << sq);
 }
 
 // Unused, here for occasional print debugging

--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -5,19 +5,19 @@
 #include "types.h"
 
 
-#define SETBIT(bb, sq) ((bb) |= SetMask[(sq)])
-#define CLRBIT(bb, sq) ((bb) &= ClearMask[(sq)])
+#define SETBIT(bb, sq) ((bb) |= SquareBB[(sq)])
+#define CLRBIT(bb, sq) ((bb) ^= SquareBB[(sq)])
 
 
 enum {
-    fileABB = 0x0101010101010101ULL,
-    fileBBB = 0x0202020202020202ULL,
-    fileCBB = 0x0404040404040404ULL,
-    fileDBB = 0x0808080808080808ULL,
-    fileEBB = 0x1010101010101010ULL,
-    fileFBB = 0x2020202020202020ULL,
-    fileGBB = 0x4040404040404040ULL,
-    fileHBB = 0x8080808080808080ULL,
+    fileABB = 0x0101010101010101,
+    fileBBB = 0x0202020202020202,
+    fileCBB = 0x0404040404040404,
+    fileDBB = 0x0808080808080808,
+    fileEBB = 0x1010101010101010,
+    fileFBB = 0x2020202020202020,
+    fileGBB = 0x4040404040404040,
+    fileHBB = 0x8080808080808080,
 
     rank1BB = 0xFF,
     rank2BB = 0xFF00,
@@ -36,11 +36,10 @@ static const Bitboard bitF1G1   = (1ULL << F1) | (1ULL << G1);
 static const Bitboard bitF8G8   = (1ULL << F8) | (1ULL << G8);
 
 
-Bitboard   SetMask[64];
-Bitboard ClearMask[64];
+extern Bitboard SquareBB[64];
 
-const Bitboard fileBBs[8];
-const Bitboard rankBBs[8];
+extern const Bitboard fileBB[8];
+extern const Bitboard rankBB[8];
 
 // void PrintBB(const Bitboard bb);
 

--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -53,6 +53,7 @@ INLINE int PopCount(const Bitboard bb) {
 // Returns the index of the least significant bit
 INLINE int Lsb(const Bitboard bb) {
 
+    assert(bb);
     return __builtin_ctzll(bb);
 }
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -69,7 +69,7 @@ CONSTR InitEvalMasks() {
         // Left side
         if (fileOf(sq) > FILE_A) {
 
-            IsolatedMask[sq] |= fileBBs[fileOf(sq) - 1];
+            IsolatedMask[sq] |= fileBB[fileOf(sq) - 1];
 
             for (tsq = sq + 7; tsq <= H8; tsq += 8)
                 PassedMask[WHITE][sq] |= (1ULL << tsq);
@@ -81,7 +81,7 @@ CONSTR InitEvalMasks() {
         // Right side
         if (fileOf(sq) < FILE_H) {
 
-            IsolatedMask[sq] |= fileBBs[fileOf(sq) + 1];
+            IsolatedMask[sq] |= fileBB[fileOf(sq) + 1];
 
             for (tsq = sq + 9; tsq <= H8; tsq += 8)
                 PassedMask[WHITE][sq] |= (1ULL << tsq);
@@ -207,9 +207,9 @@ INLINE int evalRooks(const EvalInfo *ei, const Position *pos, const int color) {
         int sq = pos->pieceList[rooks][i];
 
         // Open/Semi-open file bonus
-        if (!(pieceBB(PAWN) & fileBBs[fileOf(sq)]))
+        if (!(pieceBB(PAWN) & fileBB[fileOf(sq)]))
             eval += RookOpenFile;
-        else if (!(colorBB(color) & pieceBB(PAWN) & fileBBs[fileOf(sq)]))
+        else if (!(colorBB(color) & pieceBB(PAWN) & fileBB[fileOf(sq)]))
             eval += RookSemiOpenFile;
 
         // Mobility
@@ -229,9 +229,9 @@ INLINE int evalQueens(const EvalInfo *ei, const Position *pos, const int color) 
         int sq = pos->pieceList[queens][i];
 
         // Open/Semi-open file bonus
-        if (!(pieceBB(PAWN) & fileBBs[fileOf(sq)]))
+        if (!(pieceBB(PAWN) & fileBB[fileOf(sq)]))
             eval += QueenOpenFile;
-        else if (!(colorBB(color) & pieceBB(PAWN) & fileBBs[fileOf(sq)]))
+        else if (!(colorBB(color) & pieceBB(PAWN) & fileBB[fileOf(sq)]))
             eval += QueenSemiOpenFile;
 
         // Mobility

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -160,8 +160,8 @@ void TakeMove(Position *pos) {
 
     // Get the move from history
     const int move = history(0).move;
-    const int from = FROMSQ(move);
-    const int   to =   TOSQ(move);
+    const int from = fromSq(move);
+    const int   to =   toSq(move);
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
@@ -184,17 +184,17 @@ void TakeMove(Position *pos) {
     MovePiece(to, from, pos);
 
     // Add back captured piece if any
-    int captured = CAPTURED(move);
+    int captured = capturing(move);
     if (captured != EMPTY) {
         assert(ValidPiece(captured));
         AddPiece(to, pos, captured);
     }
 
     // Remove promoted piece and put back the pawn
-    if (PROMOTION(move) != EMPTY) {
-        assert(ValidPiece(PROMOTION(move)) && !piecePawn[PROMOTION(move)]);
+    if (promotion(move) != EMPTY) {
+        assert(ValidPiece(promotion(move)) && !piecePawn[promotion(move)]);
         ClearPiece(from, pos);
-        AddPiece(from, pos, makePiece(colorOf(PROMOTION(move)), PAWN));
+        AddPiece(from, pos, makePiece(colorOf(promotion(move)), PAWN));
     }
 
     // Get old poskey from history
@@ -208,9 +208,9 @@ bool MakeMove(Position *pos, const int move) {
 
     assert(CheckBoard(pos));
 
-    const int from     = FROMSQ(move);
-    const int to       = TOSQ(move);
-    const int captured = CAPTURED(move);
+    const int from     = fromSq(move);
+    const int to       = toSq(move);
+    const int captured = capturing(move);
 
     const int side = sideToMove();
 
@@ -280,7 +280,7 @@ bool MakeMove(Position *pos, const int move) {
         // Reset 50mr after a pawn move
         pos->fiftyMove = 0;
 
-        int promo = PROMOTION(move);
+        int promo = promotion(move);
 
         // If the move is a pawnstart we set the en passant square and hash it in
         if (move & FLAG_PAWNSTART) {

--- a/src/move.c
+++ b/src/move.c
@@ -14,12 +14,12 @@
 // Checks whether a move is pseudo-legal (assuming it is pseudo-legal in some position)
 bool MoveIsPseudoLegal(const Position *pos, const int move) {
 
-    const int from  = FROMSQ(move);
-    const int to    = TOSQ(move);
+    const int from  = fromSq(move);
+    const int to    = toSq(move);
     const int piece = pieceOn(from);
     const int color = colorOf(piece);
 
-    const int capt1 = CAPTURED(move);
+    const int capt1 = capturing(move);
     const int capt2 = pieceOn(to);
 
     // Easy sanity tests
@@ -77,12 +77,12 @@ char *MoveToStr(const int move) {
     static char moveStr[6];
     char pchar;
 
-    int ff = fileOf(FROMSQ(move));
-    int rf = rankOf(FROMSQ(move));
-    int ft = fileOf(TOSQ(move));
-    int rt = rankOf(TOSQ(move));
+    int ff = fileOf(fromSq(move));
+    int rf = rankOf(fromSq(move));
+    int ft = fileOf(toSq(move));
+    int rt = rankOf(toSq(move));
 
-    int promo = pieceTypeOf(PROMOTION(move));
+    int promo = pieceTypeOf(promotion(move));
 
     if (promo) {
 
@@ -127,9 +127,9 @@ int ParseMove(const char *ptrChar, Position *pos) {
 
         int move = list->moves[moveNum].move;
 
-        if (FROMSQ(move) == from && TOSQ(move) == to) {
+        if (fromSq(move) == from && toSq(move) == to) {
 
-            int promo = pieceTypeOf(PROMOTION(move));
+            int promo = pieceTypeOf(promotion(move));
 
             if (promo) {
 
@@ -180,9 +180,9 @@ int ParseEPDMove(const char *ptrChar, Position *pos) {
 
         int move = list->moves[moveNum].move;
 
-        if (FROMSQ(move) == from && TOSQ(move) == to) {
+        if (fromSq(move) == from && toSq(move) == to) {
 
-            int promo = pieceTypeOf(PROMOTION(move));
+            int promo = pieceTypeOf(promotion(move));
 
             if (promo) {
 

--- a/src/move.h
+++ b/src/move.h
@@ -5,35 +5,43 @@
 #include "types.h"
 
 /* Move contents - total 23bits used
-0000 0000 0000 0000 0011 1111 -> From              0x3F
-0000 0000 0000 1111 1100 0000 -> To        >> 6    0x3F
-0000 0000 1111 0000 0000 0000 -> Captured  >> 12   0xF
-0000 1111 0000 0000 0000 0000 -> Promotion >> 16   0xF
-0001 0000 0000 0000 0000 0000 -> En passant        0x100000
-0010 0000 0000 0000 0000 0000 -> Pawn Start        0x200000
-0100 0000 0000 0000 0000 0000 -> Castle            0x400000
+0000 0000 0000 0000 0011 1111 -> From       <<  0
+0000 0000 0000 1111 1100 0000 -> To         <<  6
+0000 0000 1111 0000 0000 0000 -> Captured   << 12
+0000 1111 0000 0000 0000 0000 -> Promotion  << 16
+0001 0000 0000 0000 0000 0000 -> En passant << 20
+0010 0000 0000 0000 0000 0000 -> Pawn Start << 21
+0100 0000 0000 0000 0000 0000 -> Castle     << 22
 */
-
-// Constructs a move
-#define MOVE(f, t, ca, pro, fl) ((f) | ((t) << 6) | ((ca) << 12) | ((pro) << 16) | (fl))
-
-// Macros to get info out of a move
-#define FROMSQ(m)     ((m)        & 0x3F)
-#define TOSQ(m)      (((m) >>  6) & 0x3F)
-#define CAPTURED(m)  (((m) >> 12) & 0xF)
-#define PROMOTION(m) (((m) >> 16) & 0xF)
 
 #define NOMOVE 0
 
-// Possible flags
+// Fields
+#define MOVE_FROM       0x00003F
+#define MOVE_TO         0x000FC0
+#define MOVE_CAPT       0x00F000
+#define MOVE_PROMO      0x0F0000
+#define MOVE_FLAGS      0x700000
+
+// Special move flags
 #define FLAG_NONE       0
 #define FLAG_ENPAS      0x100000
 #define FLAG_PAWNSTART  0x200000
 #define FLAG_CASTLE     0x400000
 
-// Move either has enpas flag or a captured piece
-#define MOVE_IS_CAPTURE 0x10F000
-#define MOVE_IS_NOISY   0x1FF000
+// Move constructor
+#define MOVE(f, t, ca, pro, fl) ((f) | ((t) << 6) | ((ca) << 12) | ((pro) << 16) | (fl))
+
+// Extract info from a move
+#define fromSq(move)     ((move) & MOVE_FROM)
+#define toSq(move)      (((move) & MOVE_TO)    >>  6)
+#define capturing(move) (((move) & MOVE_CAPT)  >> 12)
+#define promotion(move) (((move) & MOVE_PROMO) >> 16)
+
+// Move types
+#define moveIsCapture(move) (move & (MOVE_CAPT | FLAG_ENPAS))
+#define moveIsNoisy(move)   (move & (MOVE_CAPT | MOVE_PROMO | FLAG_ENPAS))
+#define moveIsSpecial(move) (move & MOVE_FLAGS)
 
 
 bool MoveIsPseudoLegal(const Position *pos, const int move);

--- a/src/search.c
+++ b/src/search.c
@@ -112,7 +112,7 @@ static void PrintConclusion(const SearchInfo *info) {
 }
 
 INLINE bool pawnOn7th(const Position *pos) {
-    return colorBB(sideToMove()) & pieceBB(PAWN) & rankBBs[relativeRank(sideToMove(), RANK_7)];
+    return colorBB(sideToMove()) & pieceBB(PAWN) & rankBB[relativeRank(sideToMove(), RANK_7)];
 }
 
 // Dynamic delta pruning margin

--- a/src/search.c
+++ b/src/search.c
@@ -367,7 +367,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     int move;
     while ((move = NextMove(&mp))) {
 
-        bool quiet = !(move & MOVE_IS_NOISY);
+        bool quiet = !moveIsNoisy(move);
 
         if (quiet)
             quietCount++;
@@ -426,7 +426,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
                 // Update search history
                 if (quiet)
-                    pos->searchHistory[pieceOn(FROMSQ(bestMove))][TOSQ(bestMove)] += depth * depth;
+                    pos->searchHistory[pieceOn(fromSq(bestMove))][toSq(bestMove)] += depth * depth;
 
                 // If score beats beta we have a cutoff
                 if (score >= beta) {

--- a/src/validate.c
+++ b/src/validate.c
@@ -26,8 +26,8 @@ bool MoveListOk(const MoveList *list, const Position *pos) {
 
     for (unsigned int MoveNum = 0; MoveNum < list->count; ++MoveNum) {
 
-        to   =   TOSQ(list->moves[MoveNum].move);
-        from = FROMSQ(list->moves[MoveNum].move);
+        to   =   toSq(list->moves[MoveNum].move);
+        from = fromSq(list->moves[MoveNum].move);
 
         if (!ValidSquare(to) || !ValidSquare(from))
             return false;


### PR DESCRIPTION
CLRBIT is only called correctly (when the bit is 1) so flipping the bit by ^ with SetMask instead of &ing with ClearMask is safe. Saves the memory used by ClearMask, and speeds up makemove functions. SetMask renamed SquareBB.

move.h rewritten for improved readability, only real change is the order of the operations in the info extractor macros.

Cleaned up bitboards files and added an assert for lsb to check it isn't called with argument 0.

These seemingly tiny changes achieved an incredible performance in testing, though it could just be small sample size.

ELO   | 14.82 +- 8.20 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 4200 W: 1367 L: 1188 D: 1645
http://chess.grantnet.us/viewTest/4391/