### PR TITLE
Refactor MoveIsPseudoLegal

### DIFF
--- a/src/move.c
+++ b/src/move.c
@@ -32,14 +32,10 @@ bool MoveIsPseudoLegal(const Position *pos, const int move) {
         case BISHOP: return SquareBB[to] & BishopAttacks(from, pieceBB(ALL));
         case ROOK  : return SquareBB[to] &   RookAttacks(from, pieceBB(ALL));
         case QUEEN : return SquareBB[to] & (BishopAttacks(from, pieceBB(ALL)) | RookAttacks(from, pieceBB(ALL)));
-        case PAWN  :
-            if (move & FLAG_ENPAS)
-                return to == pos->enPas;
-            if (move & FLAG_PAWNSTART)
-                return pieceOn(to + 8 - 16 * color) == EMPTY;
-            if (move & MOVE_CAPT)
-                return SquareBB[to] & pawn_attacks[color][from];
-            return (to + 8 - 16 * color) == from;
+        case PAWN  : return (move & FLAG_ENPAS)     ? to == pos->enPas
+                          : (move & FLAG_PAWNSTART) ? pieceOn(to + 8 - 16 * color) == EMPTY
+                          : (move & MOVE_CAPT)      ? SquareBB[to] & pawn_attacks[color][from]
+                                                    : (to + 8 - 16 * color) == from;
         case KING  :
             if (move & FLAG_CASTLE)
                 switch (to) {

--- a/src/move.c
+++ b/src/move.c
@@ -32,29 +32,17 @@ bool MoveIsPseudoLegal(const Position *pos, const int move) {
         case BISHOP: return SquareBB[to] & BishopAttacks(from, pieceBB(ALL));
         case ROOK  : return SquareBB[to] &   RookAttacks(from, pieceBB(ALL));
         case QUEEN : return SquareBB[to] & (BishopAttacks(from, pieceBB(ALL)) | RookAttacks(from, pieceBB(ALL)));
-        case PAWN  : return (move & FLAG_ENPAS)     ? to == pos->enPas
-                          : (move & FLAG_PAWNSTART) ? pieceOn(to + 8 - 16 * color) == EMPTY
-                          : (move & MOVE_CAPT)      ? SquareBB[to] & pawn_attacks[color][from]
-                                                    : (to + 8 - 16 * color) == from;
+        case PAWN  : return (moveIsEnPas(move))   ? to == pos->enPas
+                          : (moveIsPStart(move))  ? pieceOn(to + 8 - 16 * color) == EMPTY
+                          : (moveIsCapture(move)) ? SquareBB[to] & pawn_attacks[color][from]
+                                                  : (to + 8 - 16 * color) == from;
         case KING  :
-            if (move & FLAG_CASTLE)
+            if (moveIsCastle(move))
                 switch (to) {
-                    case C1: return    (pos->castlePerm & WQCA)
-                                    && !(pieceBB(ALL) & bitB1C1D1)
-                                    && !SqAttacked(E1, BLACK, pos)
-                                    && !SqAttacked(D1, BLACK, pos);
-                    case G1: return    (pos->castlePerm & WKCA)
-                                    && !(pieceBB(ALL) & bitF1G1)
-                                    && !SqAttacked(E1, BLACK, pos)
-                                    && !SqAttacked(F1, BLACK, pos);
-                    case C8: return    (pos->castlePerm & BQCA)
-                                    && !(pieceBB(ALL) & bitB8C8D8)
-                                    && !SqAttacked(E8, WHITE, pos)
-                                    && !SqAttacked(D8, WHITE, pos);
-                    case G8: return    (pos->castlePerm & BKCA)
-                                    && !(pieceBB(ALL) & bitF8G8)
-                                    && !SqAttacked(E8, WHITE, pos)
-                                    && !SqAttacked(F8, WHITE, pos);
+                    case C1: return CastlePseudoLegal(pos, bitB1C1D1, WQCA, E1, D1, WHITE);
+                    case G1: return CastlePseudoLegal(pos, bitF1G1,   WKCA, E1, F1, WHITE);
+                    case C8: return CastlePseudoLegal(pos, bitB8C8D8, BQCA, E8, D8, BLACK);
+                    case G8: return CastlePseudoLegal(pos, bitF8G8,   BKCA, E8, F8, BLACK);
                 }
             return SquareBB[to] & king_attacks[from];
     }

--- a/src/move.c
+++ b/src/move.c
@@ -14,59 +14,53 @@
 // Checks whether a move is pseudo-legal (assuming it is pseudo-legal in some position)
 bool MoveIsPseudoLegal(const Position *pos, const int move) {
 
+    if (!move) return false;
+
+    const int color = sideToMove();
     const int from  = fromSq(move);
     const int to    = toSq(move);
-    const int piece = pieceOn(from);
-    const int color = colorOf(piece);
 
-    const int capt1 = capturing(move);
-    const int capt2 = pieceOn(to);
-
-    // Easy sanity tests
-    if (   piece == EMPTY
-        || color != sideToMove()
-        || capt1 != capt2
-        || move  == NOMOVE)
+    // Must move our own piece to a square not occupied by our own pieces
+    if (  !(colorBB(color) & SquareBB[from])
+        || (colorBB(color) & SquareBB[to])
+        || capturing(move) != pieceOn(to))
         return false;
 
-    const Bitboard occupied = pieceBB(ALL);
-    const Bitboard toBB     = 1ULL << to;
-
     // Make sure the piece at 'from' can move to 'to' (ignoring pins/moving into check)
-    switch (pieceTypeOf(piece)) {
-        case KNIGHT: return toBB & knight_attacks[from];
-        case BISHOP: return toBB & BishopAttacks(from, occupied);
-        case ROOK  : return toBB &   RookAttacks(from, occupied);
-        case QUEEN : return toBB & (BishopAttacks(from, occupied) | RookAttacks(from, occupied));
+    switch (pieceTypeOf(pieceOn(from))) {
+        case KNIGHT: return SquareBB[to] & knight_attacks[from];
+        case BISHOP: return SquareBB[to] & BishopAttacks(from, pieceBB(ALL));
+        case ROOK  : return SquareBB[to] &   RookAttacks(from, pieceBB(ALL));
+        case QUEEN : return SquareBB[to] & (BishopAttacks(from, pieceBB(ALL)) | RookAttacks(from, pieceBB(ALL)));
         case PAWN  :
             if (move & FLAG_ENPAS)
                 return to == pos->enPas;
             if (move & FLAG_PAWNSTART)
                 return pieceOn(to + 8 - 16 * color) == EMPTY;
-            if (capt1)
-                return toBB & pawn_attacks[color][from];
+            if (move & MOVE_CAPT)
+                return SquareBB[to] & pawn_attacks[color][from];
             return (to + 8 - 16 * color) == from;
         case KING  :
             if (move & FLAG_CASTLE)
                 switch (to) {
                     case C1: return    (pos->castlePerm & WQCA)
-                                    && !(occupied & bitB1C1D1)
+                                    && !(pieceBB(ALL) & bitB1C1D1)
                                     && !SqAttacked(E1, BLACK, pos)
                                     && !SqAttacked(D1, BLACK, pos);
                     case G1: return    (pos->castlePerm & WKCA)
-                                    && !(occupied & bitF1G1)
+                                    && !(pieceBB(ALL) & bitF1G1)
                                     && !SqAttacked(E1, BLACK, pos)
                                     && !SqAttacked(F1, BLACK, pos);
                     case C8: return    (pos->castlePerm & BQCA)
-                                    && !(occupied & bitB8C8D8)
+                                    && !(pieceBB(ALL) & bitB8C8D8)
                                     && !SqAttacked(E8, WHITE, pos)
                                     && !SqAttacked(D8, WHITE, pos);
                     case G8: return    (pos->castlePerm & BKCA)
-                                    && !(occupied & bitF8G8)
+                                    && !(pieceBB(ALL) & bitF8G8)
                                     && !SqAttacked(E8, WHITE, pos)
                                     && !SqAttacked(F8, WHITE, pos);
                 }
-            return toBB & king_attacks[from];
+            return SquareBB[to] & king_attacks[from];
     }
     return false;
 }

--- a/src/move.h
+++ b/src/move.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "attack.h"
 #include "types.h"
 
 /* Move contents - total 23bits used
@@ -39,10 +40,21 @@
 #define promotion(move) (((move) & MOVE_PROMO) >> 16)
 
 // Move types
-#define moveIsCapture(move) (move & (MOVE_CAPT | FLAG_ENPAS))
+#define moveIsEnPas(move)   (move & FLAG_ENPAS)
+#define moveIsPStart(move)  (move & FLAG_PAWNSTART)
+#define moveIsCastle(move)  (move & FLAG_CASTLE)
+#define moveIsCapture(move) (move & MOVE_CAPT)
 #define moveIsNoisy(move)   (move & (MOVE_CAPT | MOVE_PROMO | FLAG_ENPAS))
-#define moveIsSpecial(move) (move & MOVE_FLAGS)
 
+
+// Checks legality of a specific castle move given the current position
+INLINE bool CastlePseudoLegal(const Position *pos, Bitboard between, int type, int sq1, int sq2, int color) {
+
+    return (pos->castlePerm & type)
+        && !(pieceBB(ALL) & between)
+        && !SqAttacked(sq1, !color, pos)
+        && !SqAttacked(sq2, !color, pos);
+}
 
 bool MoveIsPseudoLegal(const Position *pos, const int move);
 char *MoveToStr(const int move);

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -73,36 +73,24 @@ INLINE void AddSpecialPawn(const Position *pos, MoveList *list, const int from, 
     }
 }
 
-// Castling is a mess due to testing most of the legality here, rather than in makemove
+// Castling is now a bit less of a mess
 INLINE void GenCastling(const Position *pos, MoveList *list, const int color, const int type) {
 
     if (type != QUIET) return;
 
-    const int KCA = color == WHITE ? WKCA : BKCA;
-    const int QCA = color == WHITE ? WQCA : BQCA;
-    const Bitboard kingbits  = color == WHITE ? bitF1G1 : bitF8G8;
-    const Bitboard queenbits = color == WHITE ? bitB1C1D1 : bitB8C8D8;
-    const int from = color == WHITE ? E1 : E8;
-    const int ksto = color == WHITE ? G1 : G8;
-    const int qsto = color == WHITE ? C1 : C8;
-    const int ksmiddle = color == WHITE ? F1 : F8;
-    const int qsmiddle = color == WHITE ? D1 : D8;
-
-    const Bitboard occupied = pieceBB(ALL);
+    const int from = color == WHITE ? E1   : E8;
+    const int KCA  = color == WHITE ? WKCA : BKCA;
+    const int QCA  = color == WHITE ? WQCA : BQCA;
+    const Bitboard betweenKS = color == WHITE ? bitF1G1   : bitF8G8;
+    const Bitboard betweenQS = color == WHITE ? bitB1C1D1 : bitB8C8D8;
 
     // King side castle
-    if (pos->castlePerm & KCA)
-        if (!(occupied & kingbits))
-            if (   !SqAttacked(from, !color, pos)
-                && !SqAttacked(ksmiddle, !color, pos))
-                AddMove(pos, list, from, ksto, EMPTY, FLAG_CASTLE, QUIET);
+    if (CastlePseudoLegal(pos, betweenKS, KCA, from, from+1, color))
+        AddMove(pos, list, from, from+2, EMPTY, FLAG_CASTLE, QUIET);
 
     // Queen side castle
-    if (pos->castlePerm & QCA)
-        if (!(occupied & queenbits))
-            if (   !SqAttacked(from, !color, pos)
-                && !SqAttacked(qsmiddle, !color, pos))
-                AddMove(pos, list, from, qsto, EMPTY, FLAG_CASTLE, QUIET);
+    if (CastlePseudoLegal(pos, betweenQS, QCA, from, from-1, color))
+        AddMove(pos, list, from, from-2, EMPTY, FLAG_CASTLE, QUIET);
 }
 
 // Returns a square behind (relative to color)


### PR DESCRIPTION
Improved readability for MoveIsPseudoLegal (as well as castling movegen) by using a helper function for checking pseudo-legality of castling, new movetype macros, and cleaner sanity checks. 

No functional change.

ELO   | 1.73 +- 3.34 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 25283 W: 7778 L: 7652 D: 9853
http://chess.grantnet.us/viewTest/4409/