### PR TITLE
Global transposition table

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -34,7 +34,7 @@ void ConsoleLoop(Position *pos) {
 
     ParseFen(START_FEN, pos);
 
-    InitTT(pos->hashTable, 256);
+    InitTT(256);
 
     tb_init("F:\\Syzygy");
 
@@ -76,7 +76,7 @@ void ConsoleLoop(Position *pos) {
         }
 
         if (!strcmp(command, "new")) {
-            ClearTT(pos->hashTable);
+            ClearTT();
             ParseFen(START_FEN, pos);
             continue;
         }

--- a/src/search.c
+++ b/src/search.c
@@ -68,7 +68,7 @@ static void ClearForSearch(Position *pos, SearchInfo *info) {
 }
 
 // Print thinking
-static void PrintThinking(const SearchInfo *info, Position *pos) {
+static void PrintThinking(const SearchInfo *info) {
 
     int score = info->score;
 
@@ -83,7 +83,7 @@ static void PrintThinking(const SearchInfo *info, Position *pos) {
     TimePoint elapsed = Now() - Limits.start;
     int depth    = info->depth;
     int seldepth = info->seldepth;
-    int hashFull = HashFull(pos);
+    int hashFull = HashFull();
     int nps      = (int)(1000 * (info->nodes / (elapsed + 1)));
     uint64_t nodes  = info->nodes;
     uint64_t tbhits = info->tbhits;
@@ -542,7 +542,7 @@ void SearchPosition(Position *pos, SearchInfo *info) {
             info->score = AlphaBeta(-INFINITE, INFINITE, info->depth, pos, info, &info->pv);
 
         // Print thinking
-        PrintThinking(info, pos);
+        PrintThinking(info);
 
         // Save bestMove and ponderMove before overwriting the pv next iteration
         info->bestMove   = info->pv.line[0];

--- a/src/search.c
+++ b/src/search.c
@@ -65,6 +65,9 @@ static void ClearForSearch(Position *pos, SearchInfo *info) {
     memset(pos->searchKillers, 0, sizeof(pos->searchKillers));
 
     pos->ply = 0;
+
+    // Mark TT as used
+    TT.dirty = true;
 }
 
 // Print thinking

--- a/src/tests.c
+++ b/src/tests.c
@@ -34,7 +34,7 @@ void Benchmark(int depth, Position *pos, SearchInfo *info) {
         Limits.start = Now();
         SearchPosition(pos, info);
         nodes += info->nodes;
-        ClearTT(pos->hashTable);
+        ClearTT();
     }
 
     TimePoint elapsed = Now() - startTime + 1;
@@ -257,9 +257,9 @@ search:
                 }
 
                 // Get pv score
-                int index = pos->posKey % pos->hashTable->numEntries;
-                if (pos->hashTable->TT[index].posKey == pos->posKey)
-                    foundScore = pos->hashTable->TT[index].score;
+                int index = pos->posKey % TT.count;
+                if (TT.table[index].posKey == pos->posKey)
+                    foundScore = TT.table[index].score;
 
                 // Translate score to mate depth
                 if (foundScore > ISMATE)
@@ -290,7 +290,7 @@ search:
                 // Clear lineIn for reuse
                 memset(&lineIn[0], 0, sizeof(lineIn));
                 // Clear TT
-                ClearTT(pos->hashTable);
+                ClearTT();
             }
         }
     }

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -16,7 +16,11 @@ TranspositionTable TT;
 // Clears the transposition table
 void ClearTT() {
 
+    if (!TT.dirty) return;
+
     memset(TT.table, 0, TT.count * sizeof(TTEntry));
+
+    TT.dirty = false;
 }
 
 // Initializes the transposition table
@@ -51,6 +55,7 @@ void InitTT(uint64_t MB) {
     // Success
     } else {
         TT.MB = MB;
+        TT.dirty = false;
         printf("HashTable init complete with %d entries, using %" PRIu64 "MB.\n", TT.count, MB);
         fflush(stdout);
     }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -13,9 +13,12 @@
 enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 
 typedef struct {
+
     TTEntry *table;
     int count;
     uint64_t MB;
+    bool dirty;
+
 } TranspositionTable;
 
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -12,6 +12,15 @@
 
 enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 
+typedef struct {
+    TTEntry *table;
+    int count;
+    uint64_t MB;
+} TranspositionTable;
+
+
+extern TranspositionTable TT;
+
 
 // Mate scores are stored as mate in 0 as they depend on the current ply
 INLINE int ScoreToTT (int score, const int ply) {
@@ -27,8 +36,8 @@ INLINE int ScoreFromTT (int score, const int ply) {
                             : score;
 }
 
-void ClearTT(TT *table);
-void  InitTT(TT *table, uint64_t MB);
+void ClearTT();
+void InitTT(uint64_t MB);
 TTEntry* ProbeTT(const Position *pos, const uint64_t key, bool *ttHit);
 void StoreTTEntry(TTEntry *tte, const uint64_t posKey, const int move, const int score, const int depth, const int flag);
-int HashFull(const Position *pos);
+int HashFull();

--- a/src/types.h
+++ b/src/types.h
@@ -114,12 +114,6 @@ typedef struct {
 } TTEntry;
 
 typedef struct {
-    TTEntry *TT;
-    int numEntries;
-    uint64_t MB;
-} TT;
-
-typedef struct {
 
     int board[64];
     Bitboard pieceBB[TYPE_NB];
@@ -146,8 +140,6 @@ typedef struct {
     uint64_t posKey;
 
     History history[MAXGAMEMOVES];
-
-    TT hashTable[1];
 
     int searchHistory[PIECE_NB][64];
     int searchKillers[MAXDEPTH][2];

--- a/src/uci.c
+++ b/src/uci.c
@@ -111,12 +111,12 @@ static void ParsePosition(const char *line, Position *pos) {
 }
 
 // Parses a 'setoption' and updates settings
-static void SetOption(Position *pos, char *line) {
+static void SetOption(char *line) {
 
     if (BeginsWith(line, "setoption name Hash value ")) {
         int MB;
         sscanf(line, "%*s %*s %*s %*s %d", &MB);
-        InitTT(pos->hashTable, MB);
+        InitTT(MB);
 
     } else if (BeginsWith(line, "setoption name SyzygyPath value ")) {
 
@@ -161,8 +161,8 @@ int main(int argc, char **argv) {
     // Init engine
     Position pos[1];
     SearchInfo info[1];
-    pos->hashTable->TT = NULL;
-    InitTT(pos->hashTable, DEFAULTHASH);
+    TT.MB = 0;
+    InitTT(DEFAULTHASH);
 
     // Benchmark
     if (argc > 1 && strstr(argv[1], "bench")) {
@@ -195,7 +195,7 @@ int main(int argc, char **argv) {
             ParsePosition(line, pos);
 
         else if (BeginsWith(line, "ucinewgame"))
-            ClearTT(pos->hashTable);
+            ClearTT();
 
         else if (BeginsWith(line, "stop"))
             ABORT_SIGNAL = true,
@@ -208,7 +208,7 @@ int main(int argc, char **argv) {
             PrintUCI();
 
         else if (BeginsWith(line, "setoption"))
-            SetOption(pos, line);
+            SetOption(line);
 
         // Non UCI commands
 #ifdef DEV
@@ -218,6 +218,6 @@ int main(int argc, char **argv) {
         }
 #endif
     }
-    free(pos->hashTable->TT);
+    free(TT.table);
     return 0;
 }


### PR DESCRIPTION
Makes the TT global. Also avoids re-clearing it if it is already clear, which previously happened any time ucinewgame was given before the first game. Should be a speedup especially when using huge size TT.

ELO   | -0.96 +- 2.03 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -0.36 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 68378 W: 20714 L: 20903 D: 26761
http://chess.grantnet.us/viewTest/4440/