### PR TITLE
Defer allocation of TT until necessary

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -34,7 +34,8 @@ void ConsoleLoop(Position *pos) {
 
     ParseFen(START_FEN, pos);
 
-    InitTT(256);
+    TT.requestedMB = 256;
+    InitTT();
 
     tb_init("F:\\Syzygy");
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -23,42 +23,37 @@ void ClearTT() {
     TT.dirty = false;
 }
 
-// Initializes the transposition table
-void InitTT(uint64_t MB) {
+// Allocates memory for the transposition table
+void InitTT() {
 
-    // Ignore if already initialized with this size
-    if (TT.MB && TT.MB == MB) {
-        printf("HashTable already initialized to %" PRIu64 ".\n", MB);
-        fflush(stdout);
+    // Ignore if already correct size
+    if (TT.currentMB == TT.requestedMB)
         return;
-    }
 
-    uint64_t HashSize = MB * 1024 * 1024;
+    size_t MB = TT.requestedMB;
+
+    size_t HashSize = MB * 1024 * 1024;
     TT.count = HashSize / sizeof(TTEntry);
 
-    MB = MAX(MINHASH, MB); // Don't go under minhash
-    MB = MIN(MAXHASH, MB); // Don't go over maxhash
-
-    // Free memory if we have already allocated
+    // Free memory if already allocated
     if (TT.table != NULL)
         free(TT.table);
 
     // Allocate memory
     TT.table = (TTEntry *)calloc(TT.count, sizeof(TTEntry));
 
-    // If allocation fails, try half the size
+    // Allocation failed
     if (!TT.table) {
-        printf("Hash Allocation Failed, trying %" PRIu64 "MB...\n", MB / 2);
+        printf("Allocating %" PRIu64 "MB for the transposition table failed.\n", MB);
         fflush(stdout);
-        InitTT(MB / 2);
+        exit(EXIT_FAILURE);
+    }
 
     // Success
-    } else {
-        TT.MB = MB;
-        TT.dirty = false;
-        printf("HashTable init complete with %d entries, using %" PRIu64 "MB.\n", TT.count, MB);
-        fflush(stdout);
-    }
+    TT.currentMB = MB;
+    TT.dirty = false;
+    printf("HashTable init complete with %d entries, using %" PRIu64 "MB.\n", TT.count, MB);
+    fflush(stdout);
 }
 
 // Probe the transposition table

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -16,7 +16,8 @@ typedef struct {
 
     TTEntry *table;
     int count;
-    uint64_t MB;
+    size_t currentMB;
+    size_t requestedMB;
     bool dirty;
 
 } TranspositionTable;
@@ -40,7 +41,7 @@ INLINE int ScoreFromTT (int score, const int ply) {
 }
 
 void ClearTT();
-void InitTT(uint64_t MB);
+void InitTT();
 TTEntry* ProbeTT(const Position *pos, const uint64_t key, bool *ttHit);
 void StoreTTEntry(TTEntry *tte, const uint64_t posKey, const int move, const int score, const int depth, const int flag);
 int HashFull();

--- a/src/uci.c
+++ b/src/uci.c
@@ -114,9 +114,7 @@ static void ParsePosition(const char *line, Position *pos) {
 static void SetOption(char *line) {
 
     if (BeginsWith(line, "setoption name Hash value ")) {
-        int MB;
-        sscanf(line, "%*s %*s %*s %*s %d", &MB);
-        InitTT(MB);
+        sscanf(line, "%*s %*s %*s %*s %" PRIu64 "", &TT.requestedMB);
 
     } else if (BeginsWith(line, "setoption name SyzygyPath value ")) {
 
@@ -135,7 +133,7 @@ static void SetOption(char *line) {
 static void PrintUCI() {
     printf("id name %s\n", NAME);
     printf("id author Terje Kirstihagen\n");
-    printf("option name Hash type spin default %d min 4 max %d\n", DEFAULTHASH, MAXHASH);
+    printf("option name Hash type spin default %d min %d max %d\n", DEFAULTHASH, MINHASH, MAXHASH);
     printf("option name SyzygyPath type string default <empty>\n");
     printf("option name Ponder type check default false\n"); // Turn on ponder stats in cutechess gui
     printf("uciok\n"); fflush(stdout);
@@ -161,11 +159,12 @@ int main(int argc, char **argv) {
     // Init engine
     Position pos[1];
     SearchInfo info[1];
-    TT.MB = 0;
-    InitTT(DEFAULTHASH);
+    TT.currentMB = 0;
+    TT.requestedMB = DEFAULTHASH;
 
     // Benchmark
     if (argc > 1 && strstr(argv[1], "bench")) {
+        InitTT();
         if (argc > 2)
             Benchmark(atoi(argv[2]), pos, info);
         else
@@ -184,12 +183,13 @@ int main(int argc, char **argv) {
     while (GetInput(line)) {
 
         if (BeginsWith(line, "go"))
+            InitTT(),
             ABORT_SIGNAL = false,
             strncpy(searchThreadInfo.line, line, INPUT_SIZE),
             pthread_create(&searchThread, NULL, &ParseGo, &searchThreadInfo);
 
         else if (BeginsWith(line, "isready"))
-            printf("readyok\n"), fflush(stdout);
+            InitTT(), printf("readyok\n"), fflush(stdout);
 
         else if (BeginsWith(line, "position"))
             ParsePosition(line, pos);

--- a/src/uci.c
+++ b/src/uci.c
@@ -183,13 +183,13 @@ int main(int argc, char **argv) {
     while (GetInput(line)) {
 
         if (BeginsWith(line, "go"))
-            InitTT(),
             ABORT_SIGNAL = false,
             strncpy(searchThreadInfo.line, line, INPUT_SIZE),
             pthread_create(&searchThread, NULL, &ParseGo, &searchThreadInfo);
 
         else if (BeginsWith(line, "isready"))
-            InitTT(), printf("readyok\n"), fflush(stdout);
+            InitTT(),
+            printf("readyok\n"), fflush(stdout);
 
         else if (BeginsWith(line, "position"))
             ParsePosition(line, pos);


### PR DESCRIPTION
This change avoids allocating the TT with the default size only to free it and reallocate in the likely event that a hash size is specified by the user. This speeds up initialization in most cases.

If told to search before getting an 'isready' weiss will now crash. Checking for allocated TT on every 'go' showed a 4 elo loss so I will allow this behavior. With that said, the uci protocol specifies an isready must be given before starting a search to allow initialization to finish, and recommends it after any command which could take some time. Reasonable interpretation is that isready should always be given between setting hash size and starting a search.

```
* isready
  this is used to synchronize the engine with the GUI. When the GUI has sent 
  a command or multiple commands that can take some time to complete,
  this command can be used to wait for the engine to be ready again or to ping 
  the engine to find out if it is still alive. E.g. this should be sent after setting the 
  path to the tablebases as this can take some time. This command is also required 
  once before the engine is asked to do any search to wait for the engine to finish 
  initializing. This command must always be answered with "readyok" and can be 
  sent also when the engine is calculating in which case the engine should also 
  immediately answer with "readyok" without stopping the search.
```

ELO   | 2.03 +- 4.25 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 15751 W: 4898 L: 4806 D: 6047
http://chess.grantnet.us/viewTest/4456/