### PR TITLE
Cache align TT

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -70,7 +70,7 @@ release:
 	$(RELEASE)-pext.exe     $(PEXT)
 
 dev:
-	$(BIN)-dev $(PEXT) $(DEV)
+	$(BENCH)-dev $(PEXT) $(DEV)
 
 gprof:
 	$(COMP) $(PFLAGS) $(SRC) $(LIBS) $(PEXT) -o $(OUT)$(EXE)-prof

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -49,10 +49,13 @@ void InitTT() {
         exit(EXIT_FAILURE);
     }
 
-    // Success
     TT.table = (TTEntry *)(((uintptr_t)TT.mem + 64 - 1) & ~(64 - 1));
     TT.currentMB = MB;
-    TT.dirty = false;
+
+    // Ensure the memory is 0'ed out
+    TT.dirty = true;
+    ClearTT();
+
     printf("HashTable init complete with %" PRIu64 " entries, using %" PRIu64 "MB.\n", TT.count, MB);
     fflush(stdout);
 }

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -36,20 +36,21 @@ void InitTT() {
     TT.count = HashSize / sizeof(TTEntry);
 
     // Free memory if already allocated
-    if (TT.table != NULL)
-        free(TT.table);
+    if (TT.currentMB > 0)
+        free(TT.mem);
 
     // Allocate memory
-    TT.table = (TTEntry *)calloc(TT.count, sizeof(TTEntry));
+    TT.mem = malloc(TT.count * sizeof(TTEntry) + 64 - 1);
 
     // Allocation failed
-    if (!TT.table) {
+    if (!TT.mem) {
         printf("Allocating %" PRIu64 "MB for the transposition table failed.\n", MB);
         fflush(stdout);
         exit(EXIT_FAILURE);
     }
 
     // Success
+    TT.table = (TTEntry *)(((uintptr_t)TT.mem + 64 - 1) & ~(64 - 1));
     TT.currentMB = MB;
     TT.dirty = false;
     printf("HashTable init complete with %" PRIu64 " entries, using %" PRIu64 "MB.\n", TT.count, MB);

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -52,7 +52,7 @@ void InitTT() {
     // Success
     TT.currentMB = MB;
     TT.dirty = false;
-    printf("HashTable init complete with %d entries, using %" PRIu64 "MB.\n", TT.count, MB);
+    printf("HashTable init complete with %" PRIu64 " entries, using %" PRIu64 "MB.\n", TT.count, MB);
     fflush(stdout);
 }
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -15,7 +15,7 @@ enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 typedef struct {
 
     TTEntry *table;
-    int count;
+    size_t count;
     size_t currentMB;
     size_t requestedMB;
     bool dirty;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -14,6 +14,7 @@ enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 
 typedef struct {
 
+    void *mem;
     TTEntry *table;
     size_t count;
     size_t currentMB;

--- a/src/uci.c
+++ b/src/uci.c
@@ -218,6 +218,6 @@ int main(int argc, char **argv) {
         }
 #endif
     }
-    free(TT.table);
+    free(TT.mem);
     return 0;
 }


### PR DESCRIPTION
Aligns the transposition table with the cache line.

This seems to have fixed weiss' crashing - 93k games without crashing except on my machine which is likely a time control, or possibly windows, issue. Crashing on my machine is also greatly diminished compared to other recent tests.

ELO   | -0.16 +- 1.74 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 93258 W: 28429 L: 28472 D: 36357
http://chess.grantnet.us/viewTest/4463/