### PR TITLE
Free memory after benchmark

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -169,6 +169,7 @@ int main(int argc, char **argv) {
             Benchmark(atoi(argv[2]), pos, info);
         else
             Benchmark(13, pos, info);
+        free(TT.mem);
         return 0;
     }
 


### PR DESCRIPTION
Now correctly frees the memory allocated for the transposition table before exiting after benchmarking.

No functional change.