### PR TITLE
Fix printing size_t on 32bit OS

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -56,7 +56,7 @@ void InitTT() {
     TT.dirty = true;
     ClearTT();
 
-    printf("HashTable init complete with %" PRIu64 " entries, using %" PRIu64 "MB.\n", TT.count, MB);
+    printf("HashTable init complete with %" PRI_SIZET " entries, using %" PRI_SIZET "MB.\n", TT.count, MB);
     fflush(stdout);
 }
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -44,7 +44,7 @@ void InitTT() {
 
     // Allocation failed
     if (!TT.mem) {
-        printf("Allocating %" PRIu64 "MB for the transposition table failed.\n", MB);
+        printf("Allocating %" PRI_SIZET "MB for the transposition table failed.\n", MB);
         fflush(stdout);
         exit(EXIT_FAILURE);
     }

--- a/src/types.h
+++ b/src/types.h
@@ -200,3 +200,14 @@ INLINE int PieceTypeOf(const int piece) {
 INLINE int MakePiece(const int color, const int type) {
     return (color << 3) + type;
 }
+
+// Macro for printing size_t
+#ifdef _WIN32
+#  ifdef _WIN64
+#    define PRI_SIZET PRIu64
+#  else
+#    define PRI_SIZET PRIu32
+#  endif
+#else
+#  define PRI_SIZET "zu"
+#endif

--- a/src/uci.c
+++ b/src/uci.c
@@ -113,7 +113,7 @@ static void UCISetoption(char *line) {
 
         TT.requestedMB = atoi(OptionValue(line));
 
-        printf("Hash will use %" PRIu64 "MB after next 'isready'.\n", TT.requestedMB);
+        printf("Hash will use %" PRI_SIZET "MB after next 'isready'.\n", TT.requestedMB);
 
     // Sets the syzygy tablebase path
     } else if (OptionName("SyzygyPath", line)) {


### PR DESCRIPTION
On systems where size_t is not 64 bits, master produces warnings and prints nonsense sizes and entry counts for the transposition table. This patch fixes this by using %zu to print size_t on non-windows systems. On windows, MingW doesn't support %zu as it uses MSVCRT which conforms to C89 while the 'z' length modifier was added in C99.

No functional change.