### PR TITLE
Improved LMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -359,17 +359,17 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
         bool quiet = !moveIsNoisy(move);
 
-        if (quiet)
-            quietCount++;
-
         // Late move pruning
-        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 4 * depth * depth)
+        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 3 * depth * depth)
             break;
 
         // Make the move, skipping to the next if illegal
         if (!MakeMove(pos, move)) continue;
 
+        // Increment counts
         moveCount++;
+        if (quiet)
+            quietCount++;
 
         const int newDepth = depth - 1;
 

--- a/src/search.c
+++ b/src/search.c
@@ -296,6 +296,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
 
     int score = -INFINITE;
     int eval = NOSCORE;
+    bool improving = false;
 
     // Skip pruning while in check and at the root
     if (!inCheck && !root) {
@@ -305,6 +306,9 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
             history(0).eval = eval = -history(-1).eval;
         else
             history(0).eval = eval = EvalPosition(pos);
+
+        if (pos->ply >= 2 && eval > history(-2).eval)
+            improving = true;
 
         // Razoring
         if (!pvNode && depth < 2 && eval + 640 < alpha)
@@ -360,7 +364,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         bool quiet = !moveIsNoisy(move);
 
         // Late move pruning
-        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 2.5 * depth * depth)
+        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 4 * depth * depth / (1 + !improving))
             break;
 
         // Make the move, skipping to the next if illegal

--- a/src/search.c
+++ b/src/search.c
@@ -295,7 +295,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     }
 
     int score = -INFINITE;
-    int eval = NOSCORE;
+    int eval = history(0).eval = NOSCORE;
     bool improving = false;
 
     // Skip pruning while in check and at the root

--- a/src/search.c
+++ b/src/search.c
@@ -360,7 +360,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         bool quiet = !moveIsNoisy(move);
 
         // Late move pruning
-        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 3 * depth * depth)
+        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 2.5 * depth * depth)
             break;
 
         // Make the move, skipping to the next if illegal


### PR DESCRIPTION
Introduces the concept of improving - evaluation rising since our previous turn - and uses it to apply LMP more aggressively when we are not. Also moves the quiet count increment until after a move is proven legal, so only legal moves are counted.

ELO   | 7.20 +- 5.25 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10141 W: 3169 L: 2959 D: 4013
http://chess.grantnet.us/viewTest/4522/

ELO   | 9.77 +- 6.30 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6192 W: 1731 L: 1557 D: 2904
http://chess.grantnet.us/viewTest/4523/