### PR TITLE
Faster TT index calculation

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -32,8 +32,7 @@ void InitTT() {
 
     size_t MB = TT.requestedMB;
 
-    size_t HashSize = MB * 1024 * 1024;
-    TT.count = HashSize / sizeof(TTEntry);
+    TT.count = MB * 1024 * 1024 / sizeof(TTEntry);
 
     // Free memory if already allocated
     if (TT.currentMB > 0)
@@ -63,7 +62,8 @@ void InitTT() {
 // Probe the transposition table
 TTEntry* ProbeTT(const uint64_t posKey, bool *ttHit) {
 
-    TTEntry* tte = &TT.table[posKey % TT.count];
+    // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+    TTEntry* tte = &TT.table[((uint32_t)posKey * (uint64_t)TT.count) >> 32];
 
     *ttHit = tte->posKey == posKey;
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -5,8 +5,12 @@
 #include "types.h"
 
 
-#define MINHASH 4
-#define MAXHASH 16384
+// 1MB hash is a reasonable expectation.
+#define MINHASH 1
+// 65536MB = 2^32 * 16B / (1024 * 1024)
+// is the limit current indexing is able
+// to use given the 16B size of entries
+#define MAXHASH 65536
 #define DEFAULTHASH 32
 
 


### PR DESCRIPTION
Inspired by SF, this patch introduces a faster TT index calculation formula. In SF this replaced a different fast method which has the drawback of limiting the hash size to powers of 2, and removing this limitation was the main pull. In weiss the modulo method already allowed any size hash, but is slow, and the speed increase is the reason for the change.

Also increases the max hash limit to 65536MB which is the limit the new formula can make use of given the 16B size entries used in Weiss.

ELO   | 3.89 +- 3.12 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 28638 W: 8814 L: 8493 D: 11331
http://chess.grantnet.us/viewTest/4507/

ELO   | 2.60 +- 1.83 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 71364 W: 18787 L: 18252 D: 34325
http://chess.grantnet.us/viewTest/4508/