### PR TITLE
Speedup en passant square calculation

### DIFF
--- a/src/makemove.c
+++ b/src/makemove.c
@@ -167,7 +167,7 @@ void TakeMove(Position *pos) {
 
     // Add in pawn captured by en passant
     if (FLAG_ENPAS & move)
-        AddPiece(to + 8 - 16 * sideToMove(), pos, MakePiece(!sideToMove(), PAWN));
+        AddPiece(to ^ 8, pos, MakePiece(!sideToMove(), PAWN));
 
     // Move rook back if castling
     else if (move & FLAG_CASTLE)
@@ -283,12 +283,12 @@ bool MakeMove(Position *pos, const int move) {
 
         // If the move is a pawnstart we set the en passant square and hash it in
         if (move & FLAG_PAWNSTART) {
-            pos->enPas = to + 8 - 16 * side;
+            pos->enPas = to ^ 8;
             HASH_EP;
 
         // Remove pawn captured by en passant
         } else if (move & FLAG_ENPAS)
-            ClearPiece(to + 8 - 16 * side, pos);
+            ClearPiece(to ^ 8, pos);
 
         // Replace promoting pawn with new piece
         else if (promo != EMPTY) {

--- a/src/move.c
+++ b/src/move.c
@@ -34,7 +34,7 @@ bool MoveIsPseudoLegal(const Position *pos, const int move) {
         case ROOK  : return SquareBB[to] & AttackBB(ROOK,   from, pieceBB(ALL));
         case QUEEN : return SquareBB[to] & AttackBB(QUEEN,  from, pieceBB(ALL));
         case PAWN  : return (moveIsEnPas(move))   ? to == pos->enPas
-                          : (moveIsPStart(move))  ? pieceOn(to + 8 - 16 * color) == EMPTY
+                          : (moveIsPStart(move))  ? pieceOn(to ^ 8) == EMPTY
                           : (moveIsCapture(move)) ? SquareBB[to] & PawnAttacks[color][from]
                                                   : (to + 8 - 16 * color) == from;
         case KING  :


### PR DESCRIPTION
Xor'ing a square on rank 3 or 4 swaps it to the other one, and similarly for 5 and 6. Given the destination square of a pawn start we can calculate the en passant square this way. We can also calculate where the pawn we captured with an en passant move was. This is much cleaner, and faster, than the old method.

ELO   | 6.72 +- 6.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.07 (-2.94, 2.94) [-2.50, 2.50]
Games | N: 8062 W: 2621 L: 2465 D: 2976
http://chess.grantnet.us/viewTest/4528/