### PR TITLE
Prefetch TT entry

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -6,6 +6,7 @@
 
 #include "bitboards.h"
 #include "board.h"
+#include "move.h"
 #include "psqt.h"
 #include "validate.h"
 
@@ -259,6 +260,22 @@ void ParseFen(const char *fen, Position *pos) {
     UpdatePosition(pos);
 
     assert(CheckBoard(pos));
+}
+
+// Calculates the position key after a move. Fails
+// for special moves.
+Key KeyAfter(const Position *pos, const int move) {
+
+    int from = fromSq(move);
+    int to = toSq(move);
+    int pce = pieceOn(from);
+    int capt = capturing(move);
+    Key key = pos->key ^ SideKey;
+
+    if (capt)
+        key ^= PieceKeys[capt][to];
+
+    return key ^ PieceKeys[pce][from] ^ PieceKeys[pce][to];
 }
 
 #if defined DEV || !defined NDEBUG

--- a/src/board.h
+++ b/src/board.h
@@ -18,6 +18,7 @@ extern uint64_t SideKey;
 
 
 void ParseFen(const char *fen, Position *pos);
+Key KeyAfter(const Position *pos, int move);
 #ifndef NDEBUG
 void PrintBoard(const Position *pos);
 bool CheckBoard(const Position *pos);

--- a/src/search.c
+++ b/src/search.c
@@ -367,6 +367,8 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
         if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 4 * depth * depth / (1 + !improving))
             break;
 
+        __builtin_prefetch(GetEntry(KeyAfter(pos, move)));
+
         // Make the move, skipping to the next if illegal
         if (!MakeMove(pos, move)) continue;
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -62,8 +62,7 @@ void InitTT() {
 // Probe the transposition table
 TTEntry* ProbeTT(const Key posKey, bool *ttHit) {
 
-    // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
-    TTEntry* tte = &TT.table[((uint32_t)posKey * (uint64_t)TT.count) >> 32];
+    TTEntry* tte = GetEntry(posKey);
 
     *ttHit = tte->posKey == posKey;
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -45,6 +45,12 @@ INLINE int ScoreFromTT (const int score, const int ply) {
                             : score;
 }
 
+INLINE TTEntry *GetEntry(Key posKey) {
+
+    // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
+    return &TT.table[((uint32_t)posKey * (uint64_t)TT.count) >> 32];
+}
+
 void ClearTT();
 void InitTT();
 TTEntry* ProbeTT(Key posKey, bool *ttHit);


### PR DESCRIPTION
Speculative prefetching of transposition table entry inspired by SF/CFish.

ELO   | 10.54 +- 7.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5575 W: 1810 L: 1641 D: 2124
http://chess.grantnet.us/viewTest/4534/

ELO   | 7.36 +- 5.79 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 8450 W: 2677 L: 2498 D: 3275
http://chess.grantnet.us/viewTest/4535/