### PR TITLE
Reset 50mr on null move

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -387,7 +387,7 @@ bool CheckBoard(const Position *pos) {
 
     assert(pos->castlePerm >= 0 && pos->castlePerm <= 15);
 
-    assert(GeneratePosKey(pos) == pos->posKey);
+    assert(GeneratePosKey(pos) == pos->key);
 
     return true;
 }


### PR DESCRIPTION
Resets the 50mr after null moves.

ELO   | 4.72 +- 4.89 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 11788 W: 3675 L: 3515 D: 4598
http://chess.grantnet.us/viewTest/4545/