### PR TITLE
Cleaner pawn move code

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -138,7 +138,7 @@ bool SqAttacked(const int sq, const int color, const Position *pos) {
     const Bitboard bishops = colorBB(color) & (pieceBB(BISHOP) | pieceBB(QUEEN));
     const Bitboard rooks   = colorBB(color) & (pieceBB(ROOK)   | pieceBB(QUEEN));
 
-    if (   PawnAttacks[!color][sq]            & pieceBB(PAWN)   & colorBB(color)
+    if (   PawnAttackBB(!color, sq)          & pieceBB(PAWN)   & colorBB(color)
         || AttackBB(KNIGHT, sq, pieceBB(ALL)) & pieceBB(KNIGHT) & colorBB(color)
         || AttackBB(KING,   sq, pieceBB(ALL)) & pieceBB(KING)   & colorBB(color)
         || AttackBB(BISHOP, sq, pieceBB(ALL)) & bishops

--- a/src/attack.h
+++ b/src/attack.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "bitboards.h"
 #include "types.h"
 
 #ifdef USE_PEXT
@@ -101,6 +102,16 @@ INLINE Bitboard AttackBB(int piecetype, int sq, Bitboard occupied) {
 INLINE Bitboard PawnAttackBB(int color, int sq) {
 
     return PawnAttacks[color][sq];
+}
+
+INLINE Bitboard PawnBBAttackBB(Bitboard pawns, int color) {
+
+    const int up    = (color == WHITE ? NORTH : SOUTH);
+    const int left  = (color == WHITE ? WEST  : EAST);
+    const int right = (color == WHITE ? EAST  : WEST);
+
+    return ShiftBB(up+left, pawns) | ShiftBB(up+right, pawns);
+
 }
 
 bool SqAttacked(int sq, int side, const Position *pos);

--- a/src/attack.h
+++ b/src/attack.h
@@ -106,12 +106,9 @@ INLINE Bitboard PawnAttackBB(int color, int sq) {
 
 INLINE Bitboard PawnBBAttackBB(Bitboard pawns, int color) {
 
-    const int up    = (color == WHITE ? NORTH : SOUTH);
-    const int left  = (color == WHITE ? WEST  : EAST);
-    const int right = (color == WHITE ? EAST  : WEST);
+    const int up = (color == WHITE ? NORTH : SOUTH);
 
-    return ShiftBB(up+left, pawns) | ShiftBB(up+right, pawns);
-
+    return ShiftBB(up+WEST, pawns) | ShiftBB(up+EAST, pawns);
 }
 
 bool SqAttacked(int sq, int side, const Position *pos);

--- a/src/attack.h
+++ b/src/attack.h
@@ -98,4 +98,9 @@ INLINE Bitboard AttackBB(int piecetype, int sq, Bitboard occupied) {
     }
 }
 
+INLINE Bitboard PawnAttackBB(int color, int sq) {
+
+    return PawnAttacks[color][sq];
+}
+
 bool SqAttacked(int sq, int side, const Position *pos);

--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -43,6 +43,21 @@ extern const Bitboard RankBB[8];
 
 // void PrintBB(const Bitboard bb);
 
+// Shifts a bitboard (protonspring version)
+// Doesn't work for shifting more than one step horizontally
+INLINE Bitboard ShiftBB(Direction dir, Bitboard bb) {
+
+    // Horizontal shifts should not wrap around
+    const int h = dir & 7;
+    bb = (h == 1) ? bb & ~fileHBB
+       : (h == 7) ? bb & ~fileABB
+                  : bb;
+
+    // Can only shift by positive numbers
+    return dir > 0 ? bb <<  dir
+                   : bb >> -dir;
+}
+
 // Population count/Hamming weight
 INLINE int PopCount(const Bitboard bb) {
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -272,11 +272,9 @@ INLINE int EvalPieces(const EvalInfo ei, const Position *pos) {
 // Initializes the eval info struct
 INLINE void InitEvalInfo(const Position *pos, EvalInfo *ei, const int color) {
 
-    const int down  = (color == WHITE ? SOUTH : NORTH);
+    const int down = (color == WHITE ? SOUTH : NORTH);
 
-    Bitboard b;
-
-    b = RankBB[RelativeRank(color, RANK_2)] | ShiftBB(down, pieceBB(ALL));
+    Bitboard b = RankBB[RelativeRank(color, RANK_2)] | ShiftBB(down, pieceBB(ALL));
 
     b &= colorBB(color) & pieceBB(PAWN);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -272,15 +272,18 @@ INLINE int EvalPieces(const EvalInfo ei, const Position *pos) {
 // Initializes the eval info struct
 INLINE void InitEvalInfo(const Position *pos, EvalInfo *ei, const int color) {
 
+    const int down  = (color == WHITE ? SOUTH : NORTH);
+    const int left  = (color == WHITE ? WEST  : EAST);
+    const int right = (color == WHITE ? EAST  : WEST);
+
     Bitboard enemyPawnAttacks, b;
 
-    enemyPawnAttacks = color == WHITE ? ((colorBB(BLACK) & pieceBB(PAWN) & ~fileABB) >> 9)
-                                      | ((colorBB(BLACK) & pieceBB(PAWN) & ~fileHBB) >> 7)
-                                      : ((colorBB(WHITE) & pieceBB(PAWN) & ~fileABB) << 7)
-                                      | ((colorBB(WHITE) & pieceBB(PAWN) & ~fileHBB) << 9);
+    b = colorBB(!color) & pieceBB(PAWN);
 
-    b  = color == WHITE ? rank2BB | (pieceBB(ALL) >> 8)
-                        : rank7BB | (pieceBB(ALL) << 8);
+    enemyPawnAttacks = ShiftBB(down+left, b) | ShiftBB(down+right, b);
+
+    b = RankBB[RelativeRank(color, RANK_2)] | ShiftBB(down, pieceBB(ALL));
+
     b &= colorBB(color) & pieceBB(PAWN);
 
     // Mobility area is defined as any square not attacked by an enemy pawn,

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -273,14 +273,8 @@ INLINE int EvalPieces(const EvalInfo ei, const Position *pos) {
 INLINE void InitEvalInfo(const Position *pos, EvalInfo *ei, const int color) {
 
     const int down  = (color == WHITE ? SOUTH : NORTH);
-    const int left  = (color == WHITE ? WEST  : EAST);
-    const int right = (color == WHITE ? EAST  : WEST);
 
-    Bitboard enemyPawnAttacks, b;
-
-    b = colorBB(!color) & pieceBB(PAWN);
-
-    enemyPawnAttacks = ShiftBB(down+left, b) | ShiftBB(down+right, b);
+    Bitboard b;
 
     b = RankBB[RelativeRank(color, RANK_2)] | ShiftBB(down, pieceBB(ALL));
 
@@ -288,7 +282,7 @@ INLINE void InitEvalInfo(const Position *pos, EvalInfo *ei, const int color) {
 
     // Mobility area is defined as any square not attacked by an enemy pawn,
     // nor occupied by our own pawn on its starting square or blocked from advancing.
-    ei->mobilityArea[color] = ~(b | enemyPawnAttacks);
+    ei->mobilityArea[color] = ~(b | PawnBBAttackBB(colorBB(!color) & pieceBB(PAWN), !color));
 }
 
 // Calculate a static evaluation of a position

--- a/src/fathom/tbconfig.h
+++ b/src/fathom/tbconfig.h
@@ -104,7 +104,7 @@
  *       nothing.  Etc.
  * NOTE: This definition must not include en passant captures.
  */
-#define TB_PAWN_ATTACKS(square, color) PawnAttacks[color][square]
+#define TB_PAWN_ATTACKS(square, color) PawnAttackBB(color, square)
 
 /*
  * Define TB_KNIGHT_ATTACKS(square) to return the knight attacks bitboard for

--- a/src/move.c
+++ b/src/move.c
@@ -35,7 +35,7 @@ bool MoveIsPseudoLegal(const Position *pos, const int move) {
         case QUEEN : return SquareBB[to] & AttackBB(QUEEN,  from, pieceBB(ALL));
         case PAWN  : return (moveIsEnPas(move))   ? to == pos->enPas
                           : (moveIsPStart(move))  ? pieceOn(to ^ 8) == EMPTY
-                          : (moveIsCapture(move)) ? SquareBB[to] & PawnAttacks[color][from]
+                          : (moveIsCapture(move)) ? SquareBB[to] & PawnAttackBB(color, from)
                                                   : (to + 8 - 16 * color) == from;
         case KING  :
             if (moveIsCastle(move))

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -180,7 +180,7 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const int color, const 
         }
         // En passant
         if (pos->enPas != NO_SQ) {
-            Bitboard enPassers = not7th & PawnAttacks[!color][pos->enPas];
+            Bitboard enPassers = not7th & PawnAttackBB(!color, pos->enPas);
             while (enPassers)
                 AddSpecialPawn(pos, list, PopLsb(&enPassers), pos->enPas, color, ENPAS, NOISY);
         }

--- a/src/types.h
+++ b/src/types.h
@@ -78,6 +78,13 @@ typedef enum Square {
   A8, B8, C8, D8, E8, F8, G8, H8, NO_SQ = 99
 } Square;
 
+typedef enum Direction {
+    NORTH = 8,
+    EAST  = 1,
+    SOUTH = -NORTH,
+    WEST  = -EAST
+} Direction;
+
 enum CastlingRights { WKCA = 1, WQCA = 2, BKCA = 4, BQCA = 8 };
 
 /* Structs */


### PR DESCRIPTION
Introduces new functions dealing primarily with pawn movement. Improves readability and apparently also speed.

ShiftBB is based on clever code by @protonspring .

No functional change.

ELO   | 7.28 +- 5.96 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 7925 W: 2490 L: 2324 D: 3111
http://chess.grantnet.us/viewTest/4559/