### PR TITLE
Cleanup attack.h

### DIFF
--- a/src/attack.h
+++ b/src/attack.h
@@ -23,7 +23,9 @@
 
 #ifdef USE_PEXT
 #include "x86intrin.h"
+#define AttackIndex(sq, occ, table) (_pext_u64(occ, table[sq].mask))
 #else
+#define AttackIndex(sq, occ, table) (((occ & table[sq].mask) * table[sq].magic) >> table[sq].shift)
 static const uint64_t RookMagics[64] = {
     0xA180022080400230ull, 0x0040100040022000ull, 0x0080088020001002ull, 0x0080080280841000ull,
     0x4200042010460008ull, 0x04800A0003040080ull, 0x0400110082041008ull, 0x008000A041000880ull,
@@ -78,28 +80,17 @@ extern Magic RookTable[64];
 extern Bitboard PseudoAttacks[8][64];
 extern Bitboard PawnAttacks[2][64];
 
+
 // Returns the attack bitboard for a bishop based on what squares are occupied
 INLINE Bitboard BishopAttackBB(const int sq, Bitboard occupied) {
-#ifdef USE_PEXT
-    return BishopTable[sq].attacks[_pext_u64(occupied, BishopTable[sq].mask)];
-#else
-    occupied  &= BishopTable[sq].mask;
-    occupied  *= BishopTable[sq].magic;
-    occupied >>= BishopTable[sq].shift;
-    return BishopTable[sq].attacks[occupied];
-#endif
+
+    return BishopTable[sq].attacks[AttackIndex(sq, occupied, BishopTable)];
 }
 
 // Returns the attack bitboard for a rook based on what squares are occupied
 INLINE Bitboard RookAttackBB(const int sq, Bitboard occupied) {
-#ifdef USE_PEXT
-    return RookTable[sq].attacks[_pext_u64(occupied, RookTable[sq].mask)];
-#else
-    occupied  &= RookTable[sq].mask;
-    occupied  *= RookTable[sq].magic;
-    occupied >>= RookTable[sq].shift;
-    return RookTable[sq].attacks[occupied];
-#endif
+
+    return RookTable[sq].attacks[AttackIndex(sq, occupied, RookTable)];
 }
 
 // Returns the attack bitboard for a piece of piecetype on square sq

--- a/src/attack.h
+++ b/src/attack.h
@@ -22,9 +22,11 @@
 #include "types.h"
 
 #ifdef USE_PEXT
+// Uses the bmi2 pext instruction in place of magic bitboards
 #include "x86intrin.h"
 #define AttackIndex(sq, occ, table) (_pext_u64(occ, table[sq].mask))
 #else
+// Uses magic bitboards as explained on https://www.chessprogramming.org/Magic_Bitboards
 #define AttackIndex(sq, occ, table) (((occ & table[sq].mask) * table[sq].magic) >> table[sq].shift)
 static const uint64_t RookMagics[64] = {
     0xA180022080400230ull, 0x0040100040022000ull, 0x0080088020001002ull, 0x0080080280841000ull,


### PR DESCRIPTION
Use a macro for attack index calculation for prettier code. Doing the full calculation as one formula was also a speedup for non-pext builds apparently.

ELO   | 6.74 +- 5.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 8711 W: 2772 L: 2603 D: 3336
http://chess.grantnet.us/viewTest/4577/