### PR TITLE
Cleanup board.c

### DIFF
--- a/src/bitboards.c
+++ b/src/bitboards.c
@@ -16,7 +16,6 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-
 #include "bitboards.h"
 
 

--- a/src/bitboards.c
+++ b/src/bitboards.c
@@ -16,8 +16,6 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include <stdio.h>
-#include <string.h>
 
 #include "bitboards.h"
 
@@ -39,6 +37,7 @@ CONSTR InitBitMasks() {
 
 // Unused, here for occasional print debugging
 // Prints a bitboard
+// #include <stdio.h>
 // void PrintBB(const Bitboard bb) {
 
 //     Bitboard bitmask = 1;

--- a/src/board.c
+++ b/src/board.c
@@ -160,35 +160,10 @@ static void UpdatePosition(Position *pos) {
 // Clears the board
 static void ClearPosition(Position *pos) {
 
-    // Array representation
-    memset(pos->board, EMPTY, sizeof(pos->board));
+    memset(pos, EMPTY, sizeof(Position));
 
-    // Bitboard representations
-    memset(pos->colorBB, 0ULL, sizeof(pos->colorBB));
-    memset(pos->pieceBB, 0ULL, sizeof(pos->pieceBB));
-
-    // Piece list
-    memset(pos->pieceCounts, 0, sizeof(pos->pieceCounts));
-    memset(pos->pieceList,   0, sizeof(pos->pieceList));
-    memset(pos->index,       0, sizeof(pos->index));
-
-    // Big piece counts
-    pos->nonPawns[BLACK] = pos->nonPawns[WHITE] = 0;
-
-    // Misc
-    pos->material   = 0;
     pos->basePhase  = 24;
-    pos->side       = -1;
     pos->enPas      = NO_SQ;
-    pos->fiftyMove  = 0;
-    pos->castlePerm = 0;
-
-    // Ply
-    pos->ply = 0;
-    pos->hisPly = 0;
-
-    // Position key
-    pos->key = 0ULL;
 }
 
 // Parse FEN and set up the position as described

--- a/src/board.c
+++ b/src/board.c
@@ -144,7 +144,7 @@ static void UpdatePosition(Position *pos) {
             pos->material += PSQT[piece][sq];
 
             // Phase
-            pos->basePhase -= PhaseValue[piece];
+            pos->basePhase += PhaseValue[piece];
 
             // Piece list
             pos->index[sq] = pos->pieceCounts[piece]++;
@@ -162,8 +162,7 @@ static void ClearPosition(Position *pos) {
 
     memset(pos, EMPTY, sizeof(Position));
 
-    pos->basePhase  = 24;
-    pos->enPas      = NO_SQ;
+    pos->enPas = NO_SQ;
 }
 
 // Parse FEN and set up the position as described

--- a/src/board.c
+++ b/src/board.c
@@ -161,8 +161,6 @@ static void UpdatePosition(Position *pos) {
 static void ClearPosition(Position *pos) {
 
     memset(pos, EMPTY, sizeof(Position));
-
-    pos->enPas = NO_SQ;
 }
 
 // Parse FEN and set up the position as described
@@ -216,7 +214,6 @@ void ParseFen(const char *fen, Position *pos) {
     fen++;
 
     // Side to move
-    assert(*fen == 'w' || *fen == 'b');
     sideToMove() = (*fen == 'w') ? WHITE : BLACK;
     fen += 2;
 
@@ -235,7 +232,9 @@ void ParseFen(const char *fen, Position *pos) {
     fen++;
 
     // En passant square
-    if (*fen != '-') {
+    if (*fen == '-')
+        pos->enPas = NO_SQ;
+    else {
         int file = fen[0] - 'a';
         int rank = fen[1] - '1';
 

--- a/src/board.c
+++ b/src/board.c
@@ -88,6 +88,8 @@ CONSTR InitHashKeys() {
         CastleKeys[i] = Rand64();
 }
 
+// Generates a hash key for the position. During
+// a search this is incrementally updated instead.
 static Key GeneratePosKey(const Position *pos) {
 
     Key posKey = 0;

--- a/src/board.c
+++ b/src/board.c
@@ -26,6 +26,7 @@
 #include "psqt.h"
 #include "validate.h"
 
+
 uint8_t SqDistance[64][64];
 
 //                                EMPTY,    bP,    bN,    bB,    bR,    bQ,    bK, EMPTY, EMPTY,    wP,    wN,    wB,    wR,    wQ,    wK, EMPTY
@@ -50,6 +51,7 @@ CONSTR InitDistance() {
         }
 }
 
+// Pseudo-random number generator
 static uint64_t Rand64() {
 
     // http://vigna.di.unimi.it/ftp/papers/xorshift.pdf
@@ -115,6 +117,28 @@ static Key GeneratePosKey(const Position *pos) {
     return posKey;
 }
 
+// Calculates the position key after a move. Fails
+// for special moves.
+Key KeyAfter(const Position *pos, const int move) {
+
+    int from = fromSq(move);
+    int to = toSq(move);
+    int pce = pieceOn(from);
+    int capt = capturing(move);
+    Key key = pos->key ^ SideKey;
+
+    if (capt)
+        key ^= PieceKeys[capt][to];
+
+    return key ^ PieceKeys[pce][from] ^ PieceKeys[pce][to];
+}
+
+// Clears the board
+static void ClearPosition(Position *pos) {
+
+    memset(pos, EMPTY, sizeof(Position));
+}
+
 // Update the rest of a position to match pos->board
 static void UpdatePosition(Position *pos) {
 
@@ -157,12 +181,6 @@ static void UpdatePosition(Position *pos) {
     pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     assert(CheckBoard(pos));
-}
-
-// Clears the board
-static void ClearPosition(Position *pos) {
-
-    memset(pos, EMPTY, sizeof(Position));
 }
 
 // Parse FEN and set up the position as described
@@ -251,22 +269,6 @@ void ParseFen(const char *fen, Position *pos) {
     UpdatePosition(pos);
 
     assert(CheckBoard(pos));
-}
-
-// Calculates the position key after a move. Fails
-// for special moves.
-Key KeyAfter(const Position *pos, const int move) {
-
-    int from = fromSq(move);
-    int to = toSq(move);
-    int pce = pieceOn(from);
-    int capt = capturing(move);
-    Key key = pos->key ^ SideKey;
-
-    if (capt)
-        key ^= PieceKeys[capt][to];
-
-    return key ^ PieceKeys[pce][from] ^ PieceKeys[pce][to];
 }
 
 #if defined DEV || !defined NDEBUG

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -319,7 +319,9 @@ int EvalPosition(const Position *pos) {
 
     // Adjust score by phase
     const int phase = pos->phase;
-    eval = ((MgScore(eval) * (256 - phase)) + (EgScore(eval) * phase)) / 256;
+    eval = ((MgScore(eval) * phase)
+         +  (EgScore(eval) * (256 - phase)))
+         / 256;
 
     assert(-INFINITE < eval && eval < INFINITE);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -17,7 +17,6 @@
 */
 
 #include <stdlib.h>
-#include <string.h>
 
 #include "attack.h"
 #include "bitboards.h"

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -63,7 +63,7 @@ static void ClearPiece(const int sq, Position *pos) {
     pos->material -= PSQT[piece][sq];
 
     // Update phase
-    pos->basePhase += PhaseValue[piece];
+    pos->basePhase -= PhaseValue[piece];
     pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     // Update various piece lists
@@ -101,7 +101,7 @@ static void AddPiece(const int sq, Position *pos, const int piece) {
     pos->material += PSQT[piece][sq];
 
     // Update phase
-    pos->basePhase -= PhaseValue[piece];
+    pos->basePhase += PhaseValue[piece];
     pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     // Update various piece lists


### PR DESCRIPTION
The main improvements are the cleaner ClearPosition, and the more intuitive phase calculation.

The slight loss will likely be fixed by future improvements to the size of the position struct, if it is indeed real.

No functional change.

ELO   | -2.78 +- 2.87 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -2.97 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 34215 W: 10319 L: 10593 D: 13303
http://chess.grantnet.us/viewTest/4597/