### PR TITLE
Use smaller ints

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -394,7 +394,8 @@ void MirrorBoard(Position *pos) {
 
     int SwapPiece[PIECE_NB] = {EMPTY, wP, wN, wB, wR, wQ, wK, EMPTY, EMPTY, bP, bN, bB, bR, bQ, bK, EMPTY};
     int tempPiecesArray[64];
-    int tempEnPas, tempCastlePerm, tempSide, sq;
+    int tempSide, sq;
+    uint8_t tempEnPas, tempCastlePerm;
 
     // Save the necessary position info mirrored
     for (sq = A1; sq <= H8; ++sq)

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -71,7 +71,7 @@ static void ClearPiece(const int sq, Position *pos) {
         pos->nonPawns[color]--;
 
     // Update piece list
-    int lastSquare = pos->pieceList[piece][--pos->pieceCounts[piece]];
+    uint8_t lastSquare = pos->pieceList[piece][--pos->pieceCounts[piece]];
     pos->index[lastSquare] = pos->index[sq];
     pos->pieceList[piece][pos->index[lastSquare]] = lastSquare;
     // pos->pieceList[piece][pos->pieceCounts[piece]] = NO_SQ;
@@ -109,7 +109,7 @@ static void AddPiece(const int sq, Position *pos, const int piece) {
         pos->nonPawns[color]++;
 
     pos->index[sq] = pos->pieceCounts[piece]++;
-    pos->pieceList[piece][pos->index[sq]] = sq;
+    pos->pieceList[piece][pos->index[sq]] = (uint8_t)sq;
 
     // Update bitboards
     SETBIT(pieceBB(ALL), sq);
@@ -237,11 +237,11 @@ bool MakeMove(Position *pos, const int move) {
     assert(   0 <= pos->ply && pos->ply < MAXDEPTH);
 
     // Save position
+    history(0).posKey     = pos->key;
     history(0).move       = move;
     history(0).enPas      = pos->enPas;
     history(0).fiftyMove  = pos->fiftyMove;
     history(0).castlePerm = pos->castlePerm;
-    history(0).posKey     = pos->key;
 
     // Increment hisPly, ply and 50mr
     pos->hisPly++;
@@ -335,11 +335,11 @@ void MakeNullMove(Position *pos) {
     assert(CheckBoard(pos));
 
     // Save misc info for takeback
+    history(0).posKey     = pos->key;
     history(0).move       = NOMOVE;
     history(0).enPas      = pos->enPas;
     history(0).fiftyMove  = pos->fiftyMove;
     history(0).castlePerm = pos->castlePerm;
-    history(0).posKey     = pos->key;
 
     // Increase ply
     pos->ply++;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -48,14 +48,14 @@ extern TranspositionTable TT;
 
 
 // Mate scores are stored as mate in 0 as they depend on the current ply
-INLINE int ScoreToTT (const int score, const int ply) {
+INLINE int ScoreToTT (const int score, const uint8_t ply) {
     return score >=  ISMATE ? score + ply
          : score <= -ISMATE ? score - ply
                             : score;
 }
 
 // Translates from mate in 0 to the proper mate score at current ply
-INLINE int ScoreFromTT (const int score, const int ply) {
+INLINE int ScoreFromTT (const int score, const uint8_t ply) {
     return score >=  ISMATE ? score - ply
          : score <= -ISMATE ? score + ply
                             : score;

--- a/src/types.h
+++ b/src/types.h
@@ -116,17 +116,18 @@ typedef struct {
 } MoveListEntry;
 
 typedef struct {
-    MoveListEntry moves[MAXPOSITIONMOVES];
     unsigned int count;
     unsigned int next;
+    MoveListEntry moves[MAXPOSITIONMOVES];
 } MoveList;
 
 typedef struct {
-    int move;
-    int enPas;
-    int fiftyMove;
-    int castlePerm;
     Key posKey;
+    int move;
+    uint8_t enPas;
+    uint8_t fiftyMove;
+    uint8_t castlePerm;
+    uint8_t padding; // not used
     int eval;
 } History;
 
@@ -140,13 +141,13 @@ typedef struct {
 
 typedef struct {
 
-    int board[64];
+    uint8_t board[64];
     Bitboard pieceBB[TYPE_NB];
     Bitboard colorBB[2];
 
-    int pieceCounts[PIECE_NB];
-    int pieceList[PIECE_NB][10];
-    int index[64];
+    uint8_t pieceCounts[PIECE_NB];
+    uint8_t pieceList[PIECE_NB][10];
+    uint8_t index[64];
 
     int nonPawns[2];
 
@@ -155,12 +156,12 @@ typedef struct {
     int phase;
 
     int side;
-    int enPas;
-    int fiftyMove;
-    int castlePerm;
+    uint8_t enPas;
+    uint8_t fiftyMove;
+    uint8_t castlePerm;
 
-    int ply;
-    int hisPly;
+    uint8_t ply;
+    uint16_t hisPly;
 
     Key key;
 


### PR DESCRIPTION
Improve memory/cache usage with smaller ints.

No functional change.

ELO   | 3.92 +- 4.59 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 13470 W: 4200 L: 4048 D: 5222
http://chess.grantnet.us/viewTest/4602/