### PR TITLE
Square and Move types

### DIFF
--- a/src/attack.c
+++ b/src/attack.c
@@ -34,21 +34,21 @@ Bitboard PawnAttacks[2][64];
 
 // Helper function that returns a bitboard with the landing square of
 // the step, or an empty bitboard if the step would go outside the board
-INLINE Bitboard LandingSquare(int sq, int step) {
+INLINE Bitboard LandingSquare(Square sq, int step) {
 
-    const int to = sq + step;
+    const Square to = sq + step;
     return (Bitboard)((unsigned)to <= H8 && Distance(sq, to) <= 2) << to;
 }
 
 // Helper function that makes slider attack bitboards
-static Bitboard MakeSliderAttacks(const int sq, const Bitboard occupied, const int steps[]) {
+static Bitboard MakeSliderAttacks(const Square sq, const Bitboard occupied, const int steps[]) {
 
     Bitboard result = 0;
 
     for (int dir = 0; dir < 4; ++dir)
 
-        for (int to = sq + steps[dir];
-             (A1 <= to) && (to <= H8) && (Distance(to, to - steps[dir]) == 1);
+        for (Square to = sq + steps[dir];
+             to <= H8 && (Distance(to, to - steps[dir]) == 1);
              to += steps[dir]) {
 
             result |= (1ULL << to);
@@ -67,7 +67,7 @@ static void InitNonSliderAttacks() {
     int NSteps[8] = { -17,-15,-10, -6,  6, 10, 15, 17 };
     int PSteps[2][2] = { { -9, -7 }, { 7, 9 } };
 
-    for (int sq = A1; sq <= H8; ++sq) {
+    for (Square sq = A1; sq <= H8; ++sq) {
 
         // Kings and knights
         for (int i = 0; i < 8; ++i) {
@@ -90,7 +90,7 @@ static void InitSliderAttacks(Magic *m, Bitboard *table, const int *dir) {
 static void InitSliderAttacks(Magic *m, Bitboard *table, const uint64_t *magics, const int *steps) {
 #endif
 
-    for (int sq = A1; sq <= H8; ++sq) {
+    for (Square sq = A1; sq <= H8; ++sq) {
 
         m[sq].attacks = table;
 
@@ -132,7 +132,7 @@ CONSTR InitAttacks() {
 }
 
 // Returns true if sq is attacked by color
-bool SqAttacked(const int sq, const int color, const Position *pos) {
+bool SqAttacked(const Square sq, const int color, const Position *pos) {
 
     assert(ValidSquare(sq));
     assert(ValidSide(color));

--- a/src/attack.c
+++ b/src/attack.c
@@ -85,7 +85,7 @@ static void InitNonSliderAttacks() {
 
 // Initializes rook or bishop attack lookups
 #ifdef USE_PEXT
-static void InitSliderAttacks(Magic *m, Bitboard *table, const int *dir) {
+static void InitSliderAttacks(Magic *m, Bitboard *table, const int *steps) {
 #else
 static void InitSliderAttacks(Magic *m, Bitboard *table, const uint64_t *magics, const int *steps) {
 #endif

--- a/src/attack.h
+++ b/src/attack.h
@@ -84,19 +84,19 @@ extern Bitboard PawnAttacks[2][64];
 
 
 // Returns the attack bitboard for a bishop based on what squares are occupied
-INLINE Bitboard BishopAttackBB(const int sq, Bitboard occupied) {
+INLINE Bitboard BishopAttackBB(const Square sq, Bitboard occupied) {
 
     return BishopTable[sq].attacks[AttackIndex(sq, occupied, BishopTable)];
 }
 
 // Returns the attack bitboard for a rook based on what squares are occupied
-INLINE Bitboard RookAttackBB(const int sq, Bitboard occupied) {
+INLINE Bitboard RookAttackBB(const Square sq, Bitboard occupied) {
 
     return RookTable[sq].attacks[AttackIndex(sq, occupied, RookTable)];
 }
 
 // Returns the attack bitboard for a piece of piecetype on square sq
-INLINE Bitboard AttackBB(int piecetype, int sq, Bitboard occupied) {
+INLINE Bitboard AttackBB(int piecetype, Square sq, Bitboard occupied) {
 
     assert(piecetype != PAWN);
 
@@ -108,7 +108,7 @@ INLINE Bitboard AttackBB(int piecetype, int sq, Bitboard occupied) {
     }
 }
 
-INLINE Bitboard PawnAttackBB(int color, int sq) {
+INLINE Bitboard PawnAttackBB(int color, Square sq) {
 
     return PawnAttacks[color][sq];
 }
@@ -120,4 +120,4 @@ INLINE Bitboard PawnBBAttackBB(Bitboard pawns, int color) {
     return ShiftBB(up+WEST, pawns) | ShiftBB(up+EAST, pawns);
 }
 
-bool SqAttacked(int sq, int side, const Position *pos);
+bool SqAttacked(Square sq, int side, const Position *pos);

--- a/src/bitboards.c
+++ b/src/bitboards.c
@@ -30,7 +30,7 @@ Bitboard SquareBB[64];
 
 CONSTR InitBitMasks() {
 
-    for (int sq = A1; sq <= H8; ++sq)
+    for (Square sq = A1; sq <= H8; ++sq)
         SquareBB[sq] = (1ULL << sq);
 }
 

--- a/src/board.c
+++ b/src/board.c
@@ -119,7 +119,7 @@ static Key GeneratePosKey(const Position *pos) {
 
 // Calculates the position key after a move. Fails
 // for special moves.
-Key KeyAfter(const Position *pos, const int move) {
+Key KeyAfter(const Position *pos, const Move move) {
 
     Square from = fromSq(move);
     Square to = toSq(move);

--- a/src/board.c
+++ b/src/board.c
@@ -43,8 +43,8 @@ uint64_t SideKey;
 // Initialize distance lookup table
 CONSTR InitDistance() {
 
-    for (int sq1 = A1; sq1 <= H8; ++sq1)
-        for (int sq2 = A1; sq2 <= H8; ++sq2) {
+    for (Square sq1 = A1; sq1 <= H8; ++sq1)
+        for (Square sq2 = A1; sq2 <= H8; ++sq2) {
             int vertical   = abs(RankOf(sq1) - RankOf(sq2));
             int horizontal = abs(FileOf(sq1) - FileOf(sq2));
             SqDistance[sq1][sq2] = MAX(vertical, horizontal);
@@ -72,17 +72,17 @@ CONSTR InitHashKeys() {
     SideKey = Rand64();
 
     // En passant
-    for (int sq = A1; sq <= H8; ++sq)
+    for (Square sq = A1; sq <= H8; ++sq)
         PieceKeys[0][sq] = Rand64();
 
     // White pieces
     for (int piece = wP; piece <= wK; ++piece)
-        for (int sq = A1; sq <= H8; ++sq)
+        for (Square sq = A1; sq <= H8; ++sq)
             PieceKeys[piece][sq] = Rand64();
 
     // Black pieces
     for (int piece = bP; piece <= bK; ++piece)
-        for (int sq = A1; sq <= H8; ++sq)
+        for (Square sq = A1; sq <= H8; ++sq)
             PieceKeys[piece][sq] = Rand64();
 
     // Castling rights
@@ -97,7 +97,7 @@ static Key GeneratePosKey(const Position *pos) {
     Key posKey = 0;
 
     // Pieces
-    for (int sq = A1; sq <= H8; ++sq) {
+    for (Square sq = A1; sq <= H8; ++sq) {
         int piece = pieceOn(sq);
         if (piece != EMPTY)
             posKey ^= PieceKeys[piece][sq];
@@ -121,8 +121,8 @@ static Key GeneratePosKey(const Position *pos) {
 // for special moves.
 Key KeyAfter(const Position *pos, const int move) {
 
-    int from = fromSq(move);
-    int to = toSq(move);
+    Square from = fromSq(move);
+    Square to = toSq(move);
     int pce = pieceOn(from);
     int capt = capturing(move);
     Key key = pos->key ^ SideKey;
@@ -142,20 +142,18 @@ static void ClearPosition(Position *pos) {
 // Update the rest of a position to match pos->board
 static void UpdatePosition(Position *pos) {
 
-    int sq, piece, color;
-
     // Generate the position key
     pos->key = GeneratePosKey(pos);
 
     // Loop through each square on the board
-    for (sq = A1; sq <= H8; ++sq) {
+    for (Square sq = A1; sq <= H8; ++sq) {
 
-        piece = pieceOn(sq);
+        int piece = pieceOn(sq);
 
         // If it isn't empty we update the relevant lists
         if (piece != EMPTY) {
 
-            color = ColorOf(piece);
+            int color = ColorOf(piece);
 
             // Bitboards
             SETBIT(pieceBB(ALL), sq);
@@ -192,7 +190,7 @@ void ParseFen(const char *fen, Position *pos) {
 
     int piece;
     int count = 0;
-    int sq = A8;
+    Square sq = A8;
 
     // Piece locations
     while (*fen != ' ') {
@@ -277,14 +275,14 @@ void PrintBoard(const Position *pos) {
 
     const char PceChar[]  = ".pnbrqk..PNBRQK";
     const char SideChar[] = "bw-";
-    int sq, file, rank, piece;
+    int file, rank, piece;
 
     printf("\nGame Board:\n\n");
 
     for (rank = RANK_8; rank >= RANK_1; --rank) {
         printf("%d  ", rank + 1);
         for (file = FILE_A; file <= FILE_H; ++file) {
-            sq = (rank * 8) + file;
+            Square sq = (rank * 8) + file;
             piece = pieceOn(sq);
             printf("%3c", PceChar[piece]);
         }
@@ -318,7 +316,7 @@ bool CheckBoard(const Position *pos) {
     int t_pieceCounts[PIECE_NB] = { 0 };
     int t_bigPieces[2] = { 0, 0 };
 
-    int sq, t_piece, t_pce_num, color;
+    int t_piece, t_pce_num, color;
 
     // Bitboards
     assert(PopCount(pieceBB(KING)) == 2);
@@ -354,12 +352,12 @@ bool CheckBoard(const Position *pos) {
     // check piece lists
     for (t_piece = PIECE_MIN; t_piece < PIECE_NB; ++t_piece)
         for (t_pce_num = 0; t_pce_num < pos->pieceCounts[t_piece]; ++t_pce_num) {
-            sq = pos->pieceList[t_piece][t_pce_num];
+            Square sq = pos->pieceList[t_piece][t_pce_num];
             assert(pieceOn(sq) == t_piece);
         }
 
     // check piece count and other counters
-    for (sq = A1; sq <= H8; ++sq) {
+    for (Square sq = A1; sq <= H8; ++sq) {
 
         t_piece = pieceOn(sq);
         t_pieceCounts[t_piece]++;

--- a/src/board.h
+++ b/src/board.h
@@ -34,7 +34,7 @@ extern uint64_t SideKey;
 
 
 void ParseFen(const char *fen, Position *pos);
-Key KeyAfter(const Position *pos, int move);
+Key KeyAfter(const Position *pos, Move move);
 #ifndef NDEBUG
 void PrintBoard(const Position *pos);
 bool CheckBoard(const Position *pos);

--- a/src/board.h
+++ b/src/board.h
@@ -45,12 +45,12 @@ void MirrorBoard(Position *pos);
 #endif
 
 // Mirrors a square horizontally
-INLINE int MirrorSquare(const int sq) {
+INLINE int MirrorSquare(const Square sq) {
     return sq ^ 56;
 }
 
 // Returns distance between sq1 and sq2
-INLINE int Distance(const int sq1, const int sq2) {
+INLINE int Distance(const Square sq1, const Square sq2) {
     return SqDistance[sq1][sq2];
 }
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -69,16 +69,14 @@ static const int QueenMobility[28] = {
 // Initialize evaluation bit masks
 CONSTR InitEvalMasks() {
 
-    int sq, tsq;
-
     // For each square a pawn can be on
-    for (sq = A2; sq <= H7; ++sq) {
+    for (Square sq = A2; sq <= H7; ++sq) {
 
         // In front
-        for (tsq = sq + 8; tsq <= H8; tsq += 8)
+        for (Square tsq = sq + 8; tsq <= H8; tsq += 8)
             PassedMask[WHITE][sq] |= (1ULL << tsq);
 
-        for (tsq = sq - 8; tsq >= A1; tsq -= 8)
+        for (Square tsq = sq - 8; tsq <= H8; tsq -= 8)
             PassedMask[BLACK][sq] |= (1ULL << tsq);
 
         // Left side
@@ -86,10 +84,10 @@ CONSTR InitEvalMasks() {
 
             IsolatedMask[sq] |= FileBB[FileOf(sq) - 1];
 
-            for (tsq = sq + 7; tsq <= H8; tsq += 8)
+            for (Square tsq = sq + 7; tsq <= H8; tsq += 8)
                 PassedMask[WHITE][sq] |= (1ULL << tsq);
 
-            for (tsq = sq - 9; tsq >= A1; tsq -= 8)
+            for (Square tsq = sq - 9; tsq <= H8; tsq -= 8)
                 PassedMask[BLACK][sq] |= (1ULL << tsq);
         }
 
@@ -98,10 +96,10 @@ CONSTR InitEvalMasks() {
 
             IsolatedMask[sq] |= FileBB[FileOf(sq) + 1];
 
-            for (tsq = sq + 9; tsq <= H8; tsq += 8)
+            for (Square tsq = sq + 9; tsq <= H8; tsq += 8)
                 PassedMask[WHITE][sq] |= (1ULL << tsq);
 
-            for (tsq = sq - 7; tsq >= A1; tsq -= 8)
+            for (Square tsq = sq - 7; tsq <= H8; tsq -= 8)
                 PassedMask[BLACK][sq] |= (1ULL << tsq);
         }
     }
@@ -163,7 +161,7 @@ INLINE int EvalPawns(const Position *pos, const int color) {
     int pawns = MakePiece(color, PAWN);
 
     for (int i = 0; i < pos->pieceCounts[pawns]; ++i) {
-        int sq = pos->pieceList[pawns][i];
+        Square sq = pos->pieceList[pawns][i];
 
         // Isolation penalty
         if (!(IsolatedMask[sq] & colorBB(color) & pieceBB(PAWN)))
@@ -183,7 +181,7 @@ INLINE int EvalKnights(const EvalInfo *ei, const Position *pos, const int color)
     int knights = MakePiece(color, KNIGHT);
 
     for (int i = 0; i < pos->pieceCounts[knights]; ++i) {
-        int sq = pos->pieceList[knights][i];
+        Square sq = pos->pieceList[knights][i];
 
         // Mobility
         eval += KnightMobility[PopCount(AttackBB(KNIGHT, sq, pieceBB(ALL)) & ei->mobilityArea[color])];
@@ -199,7 +197,7 @@ INLINE int EvalBishops(const EvalInfo *ei, const Position *pos, const int color)
     int bishops = MakePiece(color, BISHOP);
 
     for (int i = 0; i < pos->pieceCounts[bishops]; ++i) {
-        int sq = pos->pieceList[bishops][i];
+        Square sq = pos->pieceList[bishops][i];
 
         // Mobility
         eval += BishopMobility[PopCount(AttackBB(BISHOP, sq, pieceBB(ALL)) & ei->mobilityArea[color])];
@@ -219,7 +217,7 @@ INLINE int EvalRooks(const EvalInfo *ei, const Position *pos, const int color) {
     int rooks = MakePiece(color, ROOK);
 
     for (int i = 0; i < pos->pieceCounts[rooks]; ++i) {
-        int sq = pos->pieceList[rooks][i];
+        Square sq = pos->pieceList[rooks][i];
 
         // Open/Semi-open file bonus
         if (!(pieceBB(PAWN) & FileBB[FileOf(sq)]))
@@ -241,7 +239,7 @@ INLINE int EvalQueens(const EvalInfo *ei, const Position *pos, const int color) 
     int queens = MakePiece(color, QUEEN);
 
     for (int i = 0; i < pos->pieceCounts[queens]; ++i) {
-        int sq = pos->pieceList[queens][i];
+        Square sq = pos->pieceList[queens][i];
 
         // Open/Semi-open file bonus
         if (!(pieceBB(PAWN) & FileBB[FileOf(sq)]))

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -174,7 +174,7 @@ void TakeMove(Position *pos) {
     assert(   0 <= pos->ply && pos->ply < MAXDEPTH);
 
     // Get the move from history
-    const int move = history(0).move;
+    const Move move = history(0).move;
     const Square from = fromSq(move);
     const Square to = toSq(move);
 
@@ -219,7 +219,7 @@ void TakeMove(Position *pos) {
 }
 
 // Make a move - take it back and return false if move was illegal
-bool MakeMove(Position *pos, const int move) {
+bool MakeMove(Position *pos, const Move move) {
 
     assert(CheckBoard(pos));
 

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -30,7 +30,7 @@
 #define HASH_EP             (pos->key ^= (PieceKeys[EMPTY][(pos->enPas)]))
 
 
-static const int CastlePerm[64] = {
+static const uint8_t CastlePerm[64] = {
     13, 15, 15, 15, 12, 15, 15, 14,
     15, 15, 15, 15, 15, 15, 15, 15,
     15, 15, 15, 15, 15, 15, 15, 15,
@@ -43,7 +43,7 @@ static const int CastlePerm[64] = {
 
 
 // Remove a piece from a square sq
-static void ClearPiece(Position *pos, const int sq) {
+static void ClearPiece(Position *pos, const Square sq) {
 
     assert(ValidSquare(sq));
 
@@ -83,7 +83,7 @@ static void ClearPiece(Position *pos, const int sq) {
 }
 
 // Add a piece piece to a square
-static void AddPiece(Position *pos, const int sq, const int piece) {
+static void AddPiece(Position *pos, const Square sq, const int piece) {
 
     assert(ValidPiece(piece));
     assert(ValidSquare(sq));
@@ -118,7 +118,7 @@ static void AddPiece(Position *pos, const int sq, const int piece) {
 }
 
 // Move a piece from one square to another
-static void MovePiece(Position *pos, const int from, const int to) {
+static void MovePiece(Position *pos, const Square from, const Square to) {
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
@@ -175,8 +175,8 @@ void TakeMove(Position *pos) {
 
     // Get the move from history
     const int move = history(0).move;
-    const int from = fromSq(move);
-    const int   to =   toSq(move);
+    const Square from = fromSq(move);
+    const Square to = toSq(move);
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
@@ -223,8 +223,8 @@ bool MakeMove(Position *pos, const int move) {
 
     assert(CheckBoard(pos));
 
-    const int from     = fromSq(move);
-    const int to       = toSq(move);
+    const Square from  = fromSq(move);
+    const Square to    = toSq(move);
     const int captured = capturing(move);
 
     const int color = sideToMove();
@@ -308,7 +308,7 @@ bool MakeMove(Position *pos, const int move) {
 
         // Replace promoting pawn with new piece
         else if (promo != EMPTY) {
-            assert(ValidPiece(promo) && !PiecePawn[promo]);
+            assert(ValidPiece(promo) && NonPawn[promo]);
             ClearPiece(pos, to);
             AddPiece(pos, to, promo);
         }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -43,7 +43,7 @@ static const int CastlePerm[64] = {
 
 
 // Remove a piece from a square sq
-static void ClearPiece(const int sq, Position *pos) {
+static void ClearPiece(Position *pos, const int sq) {
 
     assert(ValidSquare(sq));
 
@@ -83,7 +83,7 @@ static void ClearPiece(const int sq, Position *pos) {
 }
 
 // Add a piece piece to a square
-static void AddPiece(const int sq, Position *pos, const int piece) {
+static void AddPiece(Position *pos, const int sq, const int piece) {
 
     assert(ValidPiece(piece));
     assert(ValidSquare(sq));
@@ -118,7 +118,7 @@ static void AddPiece(const int sq, Position *pos, const int piece) {
 }
 
 // Move a piece from one square to another
-static void MovePiece(const int from, const int to, Position *pos) {
+static void MovePiece(Position *pos, const int from, const int to) {
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
@@ -183,33 +183,33 @@ void TakeMove(Position *pos) {
 
     // Add in pawn captured by en passant
     if (moveIsEnPas(move))
-        AddPiece(to ^ 8, pos, MakePiece(!sideToMove(), PAWN));
+        AddPiece(pos, to ^ 8, MakePiece(!sideToMove(), PAWN));
 
     // Move rook back if castling
     else if (moveIsCastle(move))
         switch (to) {
-            case C1: MovePiece(D1, A1, pos); break;
-            case C8: MovePiece(D8, A8, pos); break;
-            case G1: MovePiece(F1, H1, pos); break;
-            case G8: MovePiece(F8, H8, pos); break;
+            case C1: MovePiece(pos, D1, A1); break;
+            case C8: MovePiece(pos, D8, A8); break;
+            case G1: MovePiece(pos, F1, H1); break;
+            case G8: MovePiece(pos, F8, H8); break;
             default: assert(false); break;
         }
 
     // Make reverse move (from <-> to)
-    MovePiece(to, from, pos);
+    MovePiece(pos, to, from);
 
     // Add back captured piece if any
     int captured = capturing(move);
     if (captured != EMPTY) {
         assert(ValidPiece(captured));
-        AddPiece(to, pos, captured);
+        AddPiece(pos, to, captured);
     }
 
     // Remove promoted piece and put back the pawn
     if (promotion(move) != EMPTY) {
         assert(ValidPiece(promotion(move)) && !PiecePawn[promotion(move)]);
-        ClearPiece(from, pos);
-        AddPiece(from, pos, MakePiece(ColorOf(promotion(move)), PAWN));
+        ClearPiece(pos, from);
+        AddPiece(pos, from, MakePiece(ColorOf(promotion(move)), PAWN));
     }
 
     // Get old poskey from history
@@ -270,24 +270,24 @@ bool MakeMove(Position *pos, const int move) {
     // Move the rook during castling
     if (moveIsCastle(move))
         switch (to) {
-            case C1: MovePiece(A1, D1, pos); break;
-            case C8: MovePiece(A8, D8, pos); break;
-            case G1: MovePiece(H1, F1, pos); break;
-            case G8: MovePiece(H8, F8, pos); break;
+            case C1: MovePiece(pos, A1, D1); break;
+            case C8: MovePiece(pos, A8, D8); break;
+            case G1: MovePiece(pos, H1, F1); break;
+            case G8: MovePiece(pos, H8, F8); break;
             default: assert(false); break;
         }
 
     // Remove captured piece if any
     else if (captured != EMPTY) {
         assert(ValidPiece(captured));
-        ClearPiece(to, pos);
+        ClearPiece(pos, to);
 
         // Reset 50mr after a capture
         pos->fiftyMove = 0;
     }
 
     // Move the piece
-    MovePiece(from, to, pos);
+    MovePiece(pos, from, to);
 
     // Pawn move specifics
     if (PiecePawn[pieceOn(to)]) {
@@ -304,13 +304,13 @@ bool MakeMove(Position *pos, const int move) {
 
         // Remove pawn captured by en passant
         } else if (moveIsEnPas(move))
-            ClearPiece(to ^ 8, pos);
+            ClearPiece(pos, to ^ 8);
 
         // Replace promoting pawn with new piece
         else if (promo != EMPTY) {
             assert(ValidPiece(promo) && !PiecePawn[promo]);
-            ClearPiece(to, pos);
-            AddPiece(to, pos, promo);
+            ClearPiece(pos, to);
+            AddPiece(pos, to, promo);
         }
     }
 

--- a/src/makemove.h
+++ b/src/makemove.h
@@ -21,7 +21,7 @@
 #include "types.h"
 
 
-bool MakeMove(Position *pos, int move);
+bool MakeMove(Position *pos, Move move);
 void TakeMove(Position *pos);
 void MakeNullMove(Position *pos);
 void TakeNullMove(Position *pos);

--- a/src/move.c
+++ b/src/move.c
@@ -29,7 +29,7 @@
 
 
 // Checks whether a move is pseudo-legal (assuming it is pseudo-legal in some position)
-bool MoveIsPseudoLegal(const Position *pos, const int move) {
+bool MoveIsPseudoLegal(const Position *pos, const Move move) {
 
     if (!move) return false;
 
@@ -67,7 +67,7 @@ bool MoveIsPseudoLegal(const Position *pos, const int move) {
 }
 
 // Translates a move to a string
-char *MoveToStr(const int move) {
+char *MoveToStr(const Move move) {
 
     static char moveStr[6];
 
@@ -156,7 +156,7 @@ int ParseEPDMove(const char *ptrChar, const Position *pos) {
 
     for (unsigned int moveNum = 0; moveNum < list->count; ++moveNum) {
 
-        int move = list->moves[moveNum].move;
+        Move move = list->moves[moveNum].move;
 
         if ( fromSq(move) == from
             && toSq(move) == to

--- a/src/move.c
+++ b/src/move.c
@@ -34,8 +34,8 @@ bool MoveIsPseudoLegal(const Position *pos, const int move) {
     if (!move) return false;
 
     const int color = sideToMove();
-    const int from  = fromSq(move);
-    const int to    = toSq(move);
+    const Square from = fromSq(move);
+    const Square to = toSq(move);
 
     // Must move our own piece to a square not occupied by our own pieces
     if (  !(colorBB(color) & SquareBB[from])
@@ -96,8 +96,8 @@ int ParseMove(const char *str, const Position *pos) {
     assert(CheckBoard(pos));
 
     // Translate coordinates into square numbers
-    int from = (str[0] - 'a') + (8 * (str[1] - '1'));
-    int to   = (str[2] - 'a') + (8 * (str[3] - '1'));
+    Square from = (str[0] - 'a') + (8 * (str[1] - '1'));
+    Square to   = (str[2] - 'a') + (8 * (str[3] - '1'));
 
     int promo = str[4] == 'q' ? MakePiece(sideToMove(), QUEEN)
               : str[4] == 'n' ? MakePiece(sideToMove(), KNIGHT)
@@ -139,8 +139,8 @@ int ParseEPDMove(const char *ptrChar, const Position *pos) {
     }
 
     // Translate coordinates into square numbers
-    int from = (ptrChar[0] - 'a') + (8 * (ptrChar[1] - '1'));
-    int to   = (ptrChar[3] - 'a') + (8 * (ptrChar[4] - '1'));
+    Square from = (ptrChar[0] - 'a') + (8 * (ptrChar[1] - '1'));
+    Square to   = (ptrChar[3] - 'a') + (8 * (ptrChar[4] - '1'));
 
     // Type of promotion if any
     int promoType = ptrChar[5] == 'Q' ? QUEEN

--- a/src/move.h
+++ b/src/move.h
@@ -72,8 +72,8 @@ INLINE bool CastlePseudoLegal(const Position *pos, Bitboard between, int type, S
         && !SqAttacked(sq2, !color, pos);
 }
 
-bool MoveIsPseudoLegal(const Position *pos, int move);
-char *MoveToStr(int move);
+bool MoveIsPseudoLegal(const Position *pos, Move move);
+char *MoveToStr(Move move);
 int ParseMove(const char *ptrChar, const Position *pos);
 #ifdef DEV
 int ParseEPDMove(const char *ptrChar, const Position *pos);

--- a/src/move.h
+++ b/src/move.h
@@ -64,7 +64,7 @@
 
 
 // Checks legality of a specific castle move given the current position
-INLINE bool CastlePseudoLegal(const Position *pos, Bitboard between, int type, int sq1, int sq2, int color) {
+INLINE bool CastlePseudoLegal(const Position *pos, Bitboard between, int type, Square sq1, Square sq2, int color) {
 
     return (pos->castlePerm & type)
         && !(pieceBB(ALL) & between)

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -50,7 +50,7 @@ INLINE void AddMove(const Position *pos, MoveList *list, const Square from, cons
 
     int *moveScore = &list->moves[list->count].score;
 
-    const int move = MOVE(from, to, pieceOn(to), promo, flag);
+    const Move move = MOVE(from, to, pieceOn(to), promo, flag);
 
     // Add scores to help move ordering based on search history heuristics / mvvlva
     if (type == NOISY)

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -43,7 +43,7 @@ CONSTR InitMvvLva() {
 }
 
 // Constructs and adds a move to the move list
-INLINE void AddMove(const Position *pos, MoveList *list, const int from, const int to, const int promo, const int flag, const int type) {
+INLINE void AddMove(const Position *pos, MoveList *list, const Square from, const Square to, const int promo, const int flag, const int type) {
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
@@ -69,7 +69,7 @@ INLINE void AddMove(const Position *pos, MoveList *list, const int from, const i
 }
 
 // Adds promotions and en passant pawn moves
-INLINE void AddSpecialPawn(const Position *pos, MoveList *list, const int from, const int to, const int color, const int flag, const int type) {
+INLINE void AddSpecialPawn(const Position *pos, MoveList *list, const Square from, const Square to, const int color, const int flag, const int type) {
 
     assert(ValidSquare(from));
     assert(ValidSquare(to));
@@ -94,9 +94,9 @@ INLINE void GenCastling(const Position *pos, MoveList *list, const int color, co
 
     if (type != QUIET) return;
 
-    const int from = color == WHITE ? E1   : E8;
-    const int KCA  = color == WHITE ? WKCA : BKCA;
-    const int QCA  = color == WHITE ? WQCA : BQCA;
+    const int KCA = color            == WHITE ? WKCA      : BKCA;
+    const int QCA = color            == WHITE ? WQCA      : BQCA;
+    const Square from = color        == WHITE ? E1        : E8;
     const Bitboard betweenKS = color == WHITE ? bitF1G1   : bitF8G8;
     const Bitboard betweenQS = color == WHITE ? bitB1C1D1 : bitB8C8D8;
 
@@ -132,12 +132,12 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const int color, const 
 
         // Normal pawn moves
         while (pawnMoves) {
-            int to = PopLsb(&pawnMoves);
+            Square to = PopLsb(&pawnMoves);
             AddMove(pos, list, to - up, to, EMPTY, FLAG_NONE, QUIET);
         }
         // Pawn starts
         while (pawnStarts) {
-            int to = PopLsb(&pawnStarts);
+            Square to = PopLsb(&pawnStarts);
             AddMove(pos, list, to - up * 2, to, EMPTY, FLAG_PAWNSTART, QUIET);
         }
     }
@@ -151,16 +151,16 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const int color, const 
 
         // Promoting captures
         while (lPromoCap) {
-            int to = PopLsb(&lPromoCap);
+            Square to = PopLsb(&lPromoCap);
             AddSpecialPawn(pos, list, to - (up+left), to, color, FLAG_NONE, type);
         }
         while (rPromoCap) {
-            int to = PopLsb(&rPromoCap);
+            Square to = PopLsb(&rPromoCap);
             AddSpecialPawn(pos, list, to - (up+right), to, color, FLAG_NONE, type);
         }
         // Promotions
         while (promotions) {
-            int to = PopLsb(&promotions);
+            Square to = PopLsb(&promotions);
             AddSpecialPawn(pos, list, to - up, to, color, FLAG_NONE, type);
         }
     }
@@ -171,11 +171,11 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const int color, const 
         Bitboard rAttacks = enemies & ShiftBB(up+right, not7th);
 
         while (lAttacks) {
-            int to = PopLsb(&lAttacks);
+            Square to = PopLsb(&lAttacks);
             AddMove(pos, list, to - (up+left), to, EMPTY, FLAG_NONE, NOISY);
         }
         while (rAttacks) {
-            int to = PopLsb(&rAttacks);
+            Square to = PopLsb(&rAttacks);
             AddMove(pos, list, to - (up+right), to, EMPTY, FLAG_NONE, NOISY);
         }
         // En passant
@@ -198,7 +198,7 @@ INLINE void GenPieceType(const Position *pos, MoveList *list, const int color, c
 
     while (pieces) {
 
-        int from = PopLsb(&pieces);
+        Square from = PopLsb(&pieces);
 
         Bitboard moves = targets & AttackBB(pt, from, occupied);
 

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -52,7 +52,7 @@ static int PickNextMove(MoveList *list, int ttMove) {
 // Returns the next move to try in a position
 int NextMove(MovePicker *mp) {
 
-    int move;
+    Move move;
 
     // Switch on stage, falls through to the next stage
     // if a move isn't returned in the current stage.

--- a/src/psqt.c
+++ b/src/psqt.c
@@ -89,7 +89,7 @@ CONSTR InitPSQT() {
 
     // Black scores are negative (white double negated -> positive)
     for (int pt = PAWN; pt <= KING; ++pt)
-        for (int sq = A1; sq <= H8; ++sq) {
+        for (Square sq = A1; sq <= H8; ++sq) {
             // Base piece value + the piece square value
             PSQT[MakePiece(BLACK, pt)][sq] = -(pieceValue[pt] + pieceSqValue[pt][sq]);
             // Same score inverted used for white on the square mirrored horizontally

--- a/src/search.c
+++ b/src/search.c
@@ -192,7 +192,7 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
     int bestScore = score;
 
     // Move loop
-    int move;
+    Move move;
     while ((move = NextMove(&mp))) {
 
         // Recursively search the positions after making the moves, skipping illegal ones
@@ -271,7 +271,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     Key posKey = pos->key;
     TTEntry *tte = ProbeTT(posKey, &ttHit);
 
-    int ttMove  = ttHit ? tte->move : NOMOVE;
+    Move ttMove = ttHit ? tte->move : NOMOVE;
     int ttScore = ttHit ? ScoreFromTT(tte->score, pos->ply) : NOSCORE;
 
     // Trust the ttScore in non-pvNodes as long as the entry depth is equal or higher
@@ -374,7 +374,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     int bestScore = score = -INFINITE;
 
     // Move loop
-    int move;
+    Move move;
     while ((move = NextMove(&mp))) {
 
         bool quiet = !moveIsNoisy(move);

--- a/src/tests.c
+++ b/src/tests.c
@@ -119,7 +119,7 @@ void Perft(char *line) {
 
     for (unsigned int MoveNum = 0; MoveNum < list->count; ++MoveNum) {
 
-        int move = list->moves[MoveNum].move;
+        Move move = list->moves[MoveNum].move;
 
         if (!MakeMove(pos, move)){
             printf("move %d : %s : Illegal\n", MoveNum + 1, MoveToStr(move));

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -86,7 +86,7 @@ TTEntry* ProbeTT(const Key posKey, bool *ttHit) {
 }
 
 // Store an entry in the transposition table
-void StoreTTEntry(TTEntry *tte, const Key posKey, const int move, const int score, const int depth, const int flag) {
+void StoreTTEntry(TTEntry *tte, const Key posKey, const Move move, const int score, const int depth, const int flag) {
 
     assert(BOUND_UPPER <= flag && flag <= BOUND_EXACT);
     assert( -INFINITE <= score && score <= INFINITE);

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -70,5 +70,5 @@ INLINE TTEntry *GetEntry(Key posKey) {
 void ClearTT();
 void InitTT();
 TTEntry* ProbeTT(Key posKey, bool *ttHit);
-void StoreTTEntry(TTEntry *tte, Key posKey, int move, int score, int depth, int flag);
+void StoreTTEntry(TTEntry *tte, Key posKey, Move move, int score, int depth, int flag);
 int HashFull();

--- a/src/types.h
+++ b/src/types.h
@@ -46,6 +46,8 @@
 typedef uint64_t Bitboard;
 typedef uint64_t Key;
 
+typedef uint32_t Square;
+
 typedef int64_t TimePoint;
 
 enum Limit { MAXGAMEMOVES     = 512,
@@ -83,7 +85,7 @@ enum File { FILE_A, FILE_B, FILE_C, FILE_D, FILE_E, FILE_F, FILE_G, FILE_H, FILE
 
 enum Rank { RANK_1, RANK_2, RANK_3, RANK_4, RANK_5, RANK_6, RANK_7, RANK_8, RANK_NONE };
 
-typedef enum Square {
+enum Square {
   A1, B1, C1, D1, E1, F1, G1, H1,
   A2, B2, C2, D2, E2, F2, G2, H2,
   A3, B3, C3, D3, E3, F3, G3, H3,
@@ -92,7 +94,7 @@ typedef enum Square {
   A6, B6, C6, D6, E6, F6, G6, H6,
   A7, B7, C7, D7, E7, F7, G7, H7,
   A8, B8, C8, D8, E8, F8, G8, H8, NO_SQ = 99
-} Square;
+};
 
 typedef enum Direction {
     NORTH = 8,
@@ -207,11 +209,11 @@ typedef struct {
 
 /* Functions */
 
-INLINE int FileOf(const int square) {
+INLINE int FileOf(const Square square) {
     return square & 7;
 }
 
-INLINE int RankOf(const int square) {
+INLINE int RankOf(const Square square) {
     return square >> 3;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -46,6 +46,7 @@
 typedef uint64_t Bitboard;
 typedef uint64_t Key;
 
+typedef uint32_t Move;
 typedef uint32_t Square;
 
 typedef int64_t TimePoint;
@@ -109,11 +110,11 @@ enum CastlingRights { WKCA = 1, WQCA = 2, BKCA = 4, BQCA = 8 };
 
 typedef struct PV {
     int length;
-    int line[MAXDEPTH];
+    Move line[MAXDEPTH];
 } PV;
 
 typedef struct {
-    int move;
+    Move move;
     int score;
 } MoveListEntry;
 
@@ -125,7 +126,7 @@ typedef struct {
 
 typedef struct {
     Key posKey;
-    int move;
+    Move move;
     uint8_t enPas;
     uint8_t fiftyMove;
     uint8_t castlePerm;
@@ -135,7 +136,7 @@ typedef struct {
 
 typedef struct {
     Key posKey;
-    int move;
+    Move move;
     int16_t score;
     uint8_t depth;
     uint8_t flag;
@@ -170,7 +171,7 @@ typedef struct {
     History history[MAXGAMEMOVES];
 
     int searchHistory[PIECE_NB][64];
-    int searchKillers[MAXDEPTH][2];
+    Move searchKillers[MAXDEPTH][2];
 
 } Position;
 
@@ -181,8 +182,8 @@ typedef struct {
 
     int score;
     int depth;
-    int bestMove;
-    int ponderMove;
+    Move bestMove;
+    Move ponderMove;
     int seldepth;
 
     PV pv;

--- a/src/uci.c
+++ b/src/uci.c
@@ -97,7 +97,7 @@ static void UCIPosition(const char *line, Position *pos) {
     while (*line) {
 
         // Parse a move
-        int move = ParseMove(line, pos);
+        Move move = ParseMove(line, pos);
 
         // Make the move
         if (!MakeMove(pos, move)) {

--- a/src/validate.c
+++ b/src/validate.c
@@ -21,9 +21,8 @@
 
 #ifndef NDEBUG
 
-bool ValidSquare(const int sq) {
-    return A1 <= sq
-        && sq <= H8;
+bool ValidSquare(const Square sq) {
+    return sq <= H8;
 }
 
 bool ValidSide(const int side) {

--- a/src/validate.h
+++ b/src/validate.h
@@ -22,7 +22,7 @@
 
 
 #ifndef NDEBUG
-bool ValidSquare(int sq);
+bool ValidSquare(Square sq);
 bool ValidSide(int side);
 bool ValidPiece(int piece);
 bool MoveListOk(const MoveList *list, const Position *pos);


### PR DESCRIPTION
Adds typedefs for square and moves (uint32_t) for clearer code. Also fixes a bug from earlier today with the pext compile.

No functional change.

http://chess.grantnet.us/viewTest/4603/