### PR TITLE
Retire piecelists

### DIFF
--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -95,3 +95,9 @@ INLINE int PopLsb(Bitboard *bb) {
 
     return lsb;
 }
+
+// Checks whether or not a bitboard has a single set bit
+INLINE bool Single(Bitboard bb) {
+
+    return bb && !(bb & (bb - 1));
+}

--- a/src/board.c
+++ b/src/board.c
@@ -169,10 +169,6 @@ static void UpdatePosition(Position *pos) {
 
             // Phase
             pos->basePhase += PhaseValue[piece];
-
-            // Piece list
-            pos->index[sq] = pos->pieceCounts[piece]++;
-            pos->pieceList[piece][pos->index[sq]] = sq;
         }
     }
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -201,8 +201,6 @@ INLINE int EvalBishops(const EvalInfo *ei, const Position *pos, const int color)
         eval += BishopMobility[PopCount(AttackBB(BISHOP, sq, pieceBB(ALL)) & ei->mobilityArea[color])];
     }
 
-
-
     return eval;
 }
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -120,7 +120,7 @@ static bool MaterialDraw(const Position *pos) {
 
         // No bishops
         if (!pieceBB(BISHOP)) {
-            // Draw with 0-2 knights each (both 0 => KvK) (all nonpawns are knights)
+            // Draw with 0-2 knights each (both 0 => KvK) (all nonpawns if any are knights)
             return pos->nonPawns[WHITE] <= 2 && pos->nonPawns[BLACK] <= 2;
 
         // No knights
@@ -133,11 +133,11 @@ static bool MaterialDraw(const Position *pos) {
             int bishopOwner = pieceBB(BISHOP) & colorBB(WHITE) ? WHITE : BLACK;
             return pos->nonPawns[bishopOwner] == 1 && pos->nonPawns[!bishopOwner] <= 2;
         }
-    // Draw with 1 rook each + up to 1 N or B each
+    // Draw with 1 rook + up to 1 minor each
     } else if (Single(pieceBB(ROOK) & colorBB(WHITE)) && Single(pieceBB(ROOK) & colorBB(BLACK))) {
         return pos->nonPawns[WHITE] <= 2 && pos->nonPawns[BLACK] <= 2;
 
-    // Draw with 1 rook vs 1-2 N/B
+    // Draw with 1 rook vs 1-2 minors
     } else if (Single(pieceBB(ROOK))) {
         int rookOwner = pieceBB(ROOK) & colorBB(WHITE) ? WHITE : BLACK;
         return pos->nonPawns[rookOwner] == 1 && pos->nonPawns[!rookOwner] >= 1 && pos->nonPawns[!rookOwner] <= 2;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -22,7 +22,7 @@
 
 
 // Check for (likely) material draw
-#define CHECK_MAT_DRAW
+// #define CHECK_MAT_DRAW
 
 
 #define MakeScore(mg, eg) ((int)((unsigned int)(eg) << 16) + (mg))

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -22,7 +22,7 @@
 
 
 // Check for (likely) material draw
-// #define CHECK_MAT_DRAW
+#define CHECK_MAT_DRAW
 
 
 #define MakeScore(mg, eg) ((int)((unsigned int)(eg) << 16) + (mg))

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -70,12 +70,6 @@ static void ClearPiece(Position *pos, const Square sq) {
     if (NonPawn[piece])
         pos->nonPawns[color]--;
 
-    // Update piece list
-    uint8_t lastSquare = pos->pieceList[piece][--pos->pieceCounts[piece]];
-    pos->index[lastSquare] = pos->index[sq];
-    pos->pieceList[piece][pos->index[lastSquare]] = lastSquare;
-    // pos->pieceList[piece][pos->pieceCounts[piece]] = NO_SQ;
-
     // Update bitboards
     CLRBIT(pieceBB(ALL), sq);
     CLRBIT(colorBB(color), sq);
@@ -108,9 +102,6 @@ static void AddPiece(Position *pos, const Square sq, const int piece) {
     if (NonPawn[piece])
         pos->nonPawns[color]++;
 
-    pos->index[sq] = pos->pieceCounts[piece]++;
-    pos->pieceList[piece][pos->index[sq]] = (uint8_t)sq;
-
     // Update bitboards
     SETBIT(pieceBB(ALL), sq);
     SETBIT(colorBB(color), sq);
@@ -134,10 +125,6 @@ static void MovePiece(Position *pos, const Square from, const Square to) {
     // Set old square to empty, new to piece
     pieceOn(from) = EMPTY;
     pieceOn(to)   = piece;
-
-    // Update square for the piece in pieceList
-    pos->index[to] = pos->index[from];
-    pos->pieceList[piece][pos->index[to]] = to;
 
     // Update material
     pos->material += PSQT[piece][to] - PSQT[piece][from];
@@ -321,7 +308,7 @@ bool MakeMove(Position *pos, const Move move) {
     assert(CheckBoard(pos));
 
     // If own king is attacked after the move, take it back immediately
-    if (SqAttacked(pos->pieceList[MakePiece(color, KING)][0], sideToMove(), pos)) {
+    if (SqAttacked(Lsb(colorBB(color) & pieceBB(KING)), sideToMove(), pos)) {
         TakeMove(pos);
         return false;
     }

--- a/src/search.c
+++ b/src/search.c
@@ -234,7 +234,7 @@ static int AlphaBeta(int alpha, int beta, int depth, Position *pos, SearchInfo *
     MoveList list;
 
     // Extend search if in check
-    const bool inCheck = SqAttacked(pos->pieceList[MakePiece(sideToMove(), KING)][0], !sideToMove(), pos);
+    const bool inCheck = SqAttacked(Lsb(colorBB(sideToMove()) & pieceBB(KING)), !sideToMove(), pos);
     if (inCheck) depth++;
 
     // Quiescence at the end of search

--- a/src/types.h
+++ b/src/types.h
@@ -148,10 +148,6 @@ typedef struct {
     Bitboard pieceBB[TYPE_NB];
     Bitboard colorBB[2];
 
-    uint8_t pieceCounts[PIECE_NB];
-    uint8_t pieceList[PIECE_NB][10];
-    uint8_t index[64];
-
     int nonPawns[2];
 
     int material;


### PR DESCRIPTION
The piecelist is an old relic inherited from VICE. Now with a full bitboard representation they add nothing in terms of functionality. In Stockfish they supposedly improve move ordering slightly, preventing their removal, but in Weiss they are not used for anything the bitboards can't do identically. Using them for movegen like in SF resulted in a regression, so there is no reason to keep them around.

Retires the piecelists, and refactors the code that relied on them. This results in a speedup.

No functional change.

ELO   | 6.05 +- 4.62 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13148 W: 4097 L: 3868 D: 5183
http://chess.grantnet.us/viewTest/4624/

Tests with no piecelists, but also no check material draw also showed a (smaller) gain:
STC: http://chess.grantnet.us/viewTest/4612/
LTC: http://chess.grantnet.us/viewTest/4615/