### PR TITLE
Improving reverse futility pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -330,7 +330,7 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
             return Quiescence(alpha, beta, pos, info);
 
         // Reverse Futility Pruning
-        if (!pvNode && depth < 7 && eval - 225 * depth >= beta)
+        if (!pvNode && depth < 7 && eval - 230 * (depth - improving) >= beta)
             return eval;
 
         // Null Move Pruning

--- a/src/search.c
+++ b/src/search.c
@@ -330,7 +330,7 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
             return Quiescence(alpha, beta, pos, info);
 
         // Reverse Futility Pruning
-        if (!pvNode && depth < 7 && eval - 230 * (depth - improving) >= beta)
+        if (!pvNode && depth < 7 && eval - 225 * depth + 100 * improving >= beta)
             return eval;
 
         // Null Move Pruning


### PR DESCRIPTION
Lower bar for pruning if our position is improving.

ELO   | 5.38 +- 4.23 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 15748 W: 4907 L: 4663 D: 6178
http://chess.grantnet.us/viewTest/4667/

ELO   | 3.14 +- 2.45 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 40480 W: 10784 L: 10418 D: 19278
http://chess.grantnet.us/viewTest/4675/