### PR TITLE
Fix broken PVs

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -493,14 +493,14 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
     while (true) {
         int result = AlphaBeta(alpha, beta, info->depth, pos, info, &info->pv);
         // Result within the bounds is accepted as correct
-        if (result >= alpha && result <= beta)
+        if (result > alpha && result < beta)
             return result;
         // Failed low, relax lower bound and search again
-        else if (result < alpha) {
+        else if (result <= alpha) {
             alpha -= delta << fails++;
             alpha  = MAX(alpha, -INFINITE);
         // Failed high, relax upper bound and search again
-        } else if (result > beta) {
+        } else if (result >= beta) {
             beta += delta << fails++;
             beta  = MIN(beta, INFINITE);
         }


### PR DESCRIPTION
PVs have been broken ever since switching away from fetching them from the transposition table (which also sometimes broke them due to hash collision). This was caused by the aspiration window accepting scores on the edge of the window, hence not re-searching when it was supposed to.

This patch fixes the problem, but loses around 25 elo. Everything in the search is tuned to the old behavior, so hopefully as parameters are retuned the elo will be recovered.

ELO   | -25.14 +- 9.62 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | -2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 2395 W: 485 L: 658 D: 1252
http://chess.grantnet.us/viewTest/4729/

ELO   | -27.63 +- 12.57 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1701 W: 423 L: 558 D: 720
http://chess.grantnet.us/viewTest/4656/