### PR TITLE
Tweak LMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -379,7 +379,7 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
         bool quiet = !moveIsNoisy(move);
 
         // Late move pruning
-        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > 4 * depth * depth / (1 + !improving))
+        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > (5 + depth * depth) / (2 - improving))
             break;
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));

--- a/src/search.c
+++ b/src/search.c
@@ -379,7 +379,7 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
         bool quiet = !moveIsNoisy(move);
 
         // Late move pruning
-        if (!pvNode && !inCheck && quiet && depth <= 3 && quietCount > (5 + depth * depth) / (2 - improving))
+        if (!pvNode && !inCheck && quiet && quietCount > (3 + 2 * depth * depth) / (2 - improving))
             break;
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));


### PR DESCRIPTION
Remove depth restriction, and increase pruning at higher depths. The formula effectively turns off LMP at very high depths anyway.

ELO   | 5.61 +- 4.28 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13314 W: 3611 L: 3396 D: 6307
http://chess.grantnet.us/viewTest/4742/

ELO   | 4.93 +- 3.78 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14942 W: 3554 L: 3342 D: 8046
http://chess.grantnet.us/viewTest/4743/