### PR TITLE
LMR captures

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -394,14 +394,16 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
 
         const Depth newDepth = depth - 1;
 
-        bool doLMR = depth > 2 && moveCount > (2 + pvNode) && quiet;
+        bool doLMR = depth > 2 && moveCount > (2 + pvNode);
 
         // Reduced depth zero-window search
         if (doLMR) {
             // Base reduction
             int R = Reductions[MIN(31, depth)][MIN(31, moveCount)];
             // Reduce more in non-pv nodes
-            R += !pvNode;
+            R -= pvNode;
+
+            R += quiet;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth RDepth = MAX(1, newDepth - MAX(R, 1));

--- a/src/search.c
+++ b/src/search.c
@@ -400,9 +400,11 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
         if (doLMR) {
             // Base reduction
             int R = Reductions[MIN(31, depth)][MIN(31, moveCount)];
-            // Reduce more in non-pv nodes
+            // Reduce less in pv nodes
             R -= pvNode;
+            // Reduce less when improving
             R -= improving;
+            // Reduce more for quiets
             R += quiet;
 
             // Depth after reductions, avoiding going straight to quiescence

--- a/src/search.c
+++ b/src/search.c
@@ -402,7 +402,7 @@ static int AlphaBeta(int alpha, int beta, Depth depth, Position *pos, SearchInfo
             int R = Reductions[MIN(31, depth)][MIN(31, moveCount)];
             // Reduce more in non-pv nodes
             R -= pvNode;
-
+            R -= improving;
             R += quiet;
 
             // Depth after reductions, avoiding going straight to quiescence


### PR DESCRIPTION
Allow LMR of captures, and tweak the reduction amount.

ELO   | 5.75 +- 4.38 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12813 W: 3508 L: 3296 D: 6009
http://chess.grantnet.us/viewTest/4750/

ELO   | 14.95 +- 7.72 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3487 W: 857 L: 707 D: 1923
http://chess.grantnet.us/viewTest/4751/