### PR TITLE
Per move futility pruning in queiscence search

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -30,6 +30,13 @@
 static Bitboard PassedMask[2][64];
 static Bitboard IsolatedMask[64];
 
+const int PieceValue[2][PIECE_NB] = {
+    { 0, P_MG, N_MG, B_MG, R_MG, Q_MG, 0, 0,
+      0, P_MG, N_MG, B_MG, R_MG, Q_MG, 0, 0 },
+    { 0, P_EG, N_EG, B_EG, R_EG, Q_EG, 0, 0,
+      0, P_EG, N_EG, B_EG, R_EG, Q_EG, 0, 0 }
+};
+
 // Various bonuses and maluses
 static const int PawnIsolated          = S(-20,-18);
 static const int BishopPair            = S( 65, 65);

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -31,6 +31,9 @@
 #define EgScore(s) ((int16_t)((uint16_t)((unsigned)((s) + 0x8000) >> 16)))
 
 
+extern const int PieceValue[2][PIECE_NB];
+
+
 typedef struct EvalInfo {
 
     Bitboard mobilityArea[2];

--- a/src/search.c
+++ b/src/search.c
@@ -135,22 +135,22 @@ INLINE bool PawnOn7th(const Position *pos) {
 }
 
 // Dynamic delta pruning margin
-static int QuiescenceDeltaMargin(const Position *pos) {
+// static int QuiescenceDeltaMargin(const Position *pos) {
 
-    // Optimistic we can improve our position by a pawn without capturing anything,
-    // or if we have a pawn on the 7th we can hope to improve by a queen instead
-    const int DeltaBase = PawnOn7th(pos) ? Q_MG : P_MG;
+//     // Optimistic we can improve our position by a pawn without capturing anything,
+//     // or if we have a pawn on the 7th we can hope to improve by a queen instead
+//     const int DeltaBase = PawnOn7th(pos) ? Q_MG : P_MG;
 
-    // Look for possible captures on the board
-    const Bitboard enemy = colorBB(!sideToMove());
+//     // Look for possible captures on the board
+//     const Bitboard enemy = colorBB(!sideToMove());
 
-    // Find the most valuable piece we could take and add to our base
-    return DeltaBase + ((enemy & pieceBB(QUEEN )) ? Q_MG
-                      : (enemy & pieceBB(ROOK  )) ? R_MG
-                      : (enemy & pieceBB(BISHOP)) ? B_MG
-                      : (enemy & pieceBB(KNIGHT)) ? N_MG
-                                                  : P_MG);
-}
+//     // Find the most valuable piece we could take and add to our base
+//     return DeltaBase + ((enemy & pieceBB(QUEEN )) ? Q_MG
+//                       : (enemy & pieceBB(ROOK  )) ? R_MG
+//                       : (enemy & pieceBB(BISHOP)) ? B_MG
+//                       : (enemy & pieceBB(KNIGHT)) ? N_MG
+//                                                   : P_MG);
+// }
 
 // Quiescence
 static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info) {
@@ -182,10 +182,12 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
     int score = EvalPosition(pos);
     if (score >= beta)
         return score;
-    if (score + QuiescenceDeltaMargin(pos) < alpha)
-        return alpha;
     if (score > alpha)
         alpha = score;
+
+    int futility = score + P_EG;
+
+    const bool inCheck = SqAttacked(Lsb(colorPieceBB(sideToMove(), KING)), !sideToMove(), pos);
 
     InitNoisyMP(&mp, &list, pos);
 
@@ -194,6 +196,9 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
     // Move loop
     Move move;
     while ((move = NextMove(&mp))) {
+
+        if (!inCheck && futility + PieceValue[EG][pieceOn(toSq(move))] <= alpha)
+            continue;
 
         // Recursively search the positions after making the moves, skipping illegal ones
         if (!MakeMove(pos, move)) continue;

--- a/src/search.c
+++ b/src/search.c
@@ -135,22 +135,22 @@ INLINE bool PawnOn7th(const Position *pos) {
 }
 
 // Dynamic delta pruning margin
-// static int QuiescenceDeltaMargin(const Position *pos) {
+static int QuiescenceDeltaMargin(const Position *pos) {
 
-//     // Optimistic we can improve our position by a pawn without capturing anything,
-//     // or if we have a pawn on the 7th we can hope to improve by a queen instead
-//     const int DeltaBase = PawnOn7th(pos) ? Q_MG : P_MG;
+    // Optimistic we can improve our position by a pawn without capturing anything,
+    // or if we have a pawn on the 7th we can hope to improve by a queen instead
+    const int DeltaBase = PawnOn7th(pos) ? Q_MG : P_MG;
 
-//     // Look for possible captures on the board
-//     const Bitboard enemy = colorBB(!sideToMove());
+    // Look for possible captures on the board
+    const Bitboard enemy = colorBB(!sideToMove());
 
-//     // Find the most valuable piece we could take and add to our base
-//     return DeltaBase + ((enemy & pieceBB(QUEEN )) ? Q_MG
-//                       : (enemy & pieceBB(ROOK  )) ? R_MG
-//                       : (enemy & pieceBB(BISHOP)) ? B_MG
-//                       : (enemy & pieceBB(KNIGHT)) ? N_MG
-//                                                   : P_MG);
-// }
+    // Find the most valuable piece we could take and add to our base
+    return DeltaBase + ((enemy & pieceBB(QUEEN )) ? Q_MG
+                      : (enemy & pieceBB(ROOK  )) ? R_MG
+                      : (enemy & pieceBB(BISHOP)) ? B_MG
+                      : (enemy & pieceBB(KNIGHT)) ? N_MG
+                                                  : P_MG);
+}
 
 // Quiescence
 static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info) {
@@ -182,6 +182,8 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
     int score = EvalPosition(pos);
     if (score >= beta)
         return score;
+    if (score + QuiescenceDeltaMargin(pos) < alpha)
+        return alpha;
     if (score > alpha)
         alpha = score;
 

--- a/src/types.h
+++ b/src/types.h
@@ -84,6 +84,10 @@ enum Piece {
     PIECE_NB = 16
 };
 
+enum Phase {
+    MG, EG
+};
+
 enum PieceValue {
     P_MG =  128, P_EG =  140,
     N_MG =  430, N_EG =  450,


### PR DESCRIPTION
Per move futility pruning based on the piece being captured by each move. This is very similar to delta pruning, but instead of pruning all moves at once based on an approximated ceiling for improvement possible in the position, the per move version uses an approximation of the improvement of each move to try to prune them individually. Delta pruning is still useful as it completely skips movegen whenever it works.

ELO   | 33.79 +- 12.56 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1547 W: 480 L: 330 D: 737
http://chess.grantnet.us/viewTest/4777/

ELO   | 6.10 +- 4.43 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10710 W: 2523 L: 2335 D: 5852
http://chess.grantnet.us/viewTest/4778/