### PR TITLE
No pruning advanced pawn pushes in QS

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -199,7 +199,10 @@ static int Quiescence(int alpha, const int beta, Position *pos, SearchInfo *info
     Move move;
     while ((move = NextMove(&mp))) {
 
-        if (!inCheck && futility + PieceValue[EG][pieceOn(toSq(move))] <= alpha)
+        if (   !inCheck
+            && futility + PieceValue[EG][pieceOn(toSq(move))] <= alpha
+            && !(  PieceTypeOf(pieceOn(fromSq(move))) == PAWN
+                && RelativeRank(sideToMove(), RankOf(toSq(move))) > 5))
             continue;
 
         // Recursively search the positions after making the moves, skipping illegal ones


### PR DESCRIPTION
Avoid pruning advanced pawn pushes in quiescence search.

ELO   | 8.15 +- 5.57 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7759 W: 2111 L: 1929 D: 3719
http://chess.grantnet.us/viewTest/4781/

ELO   | 5.36 +- 4.05 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12827 W: 3010 L: 2812 D: 7005
http://chess.grantnet.us/viewTest/4782/