### PR TITLE
Trivial cleanup

### DIFF
--- a/src/bitboards.h
+++ b/src/bitboards.h
@@ -96,8 +96,14 @@ INLINE int PopLsb(Bitboard *bb) {
     return lsb;
 }
 
+// Checks whether or not a bitboard has multiple set bits
+INLINE bool Multiple(Bitboard bb) {
+
+    return bb & (bb - 1);
+}
+
 // Checks whether or not a bitboard has a single set bit
 INLINE bool Single(Bitboard bb) {
 
-    return bb && !(bb & (bb - 1));
+    return bb && !Multiple(bb);
 }

--- a/src/board.c
+++ b/src/board.c
@@ -185,7 +185,7 @@ void ParseFen(const char *fen, Position *pos) {
     ClearPosition(pos);
 
     Piece piece;
-    int count = 0;
+    int count = 1;
     Square sq = A8;
 
     // Piece locations
@@ -217,11 +217,8 @@ void ParseFen(const char *fen, Position *pos) {
         }
 
         pieceOn(sq) = piece;
-        sq++;
-
-        // Skip count-1 extra squares
-        for (; count > 1; count--)
-            sq++;
+        sq += count;
+        count = 1;
 
         fen++;
     }

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -176,7 +176,7 @@ INLINE int EvalPiece(const Position *pos, const EvalInfo *ei, const Color color,
     Bitboard pieces = colorPieceBB(color, pt);
 
     // Bishop pair
-    if (pt == BISHOP && PopCount(pieces) >= 2)
+    if (pt == BISHOP && Multiple(pieces))
         eval += BishopPair;
 
     while (pieces) {

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -57,9 +57,9 @@ INLINE void AddMove(const Position *pos, MoveList *list, const Square from, cons
         *moveScore = MvvLvaScores[pieceOn(to)][pieceOn(from)];
 
     if (type == QUIET) {
-        if (killer1 == move)
+        if (move == killer1)
             *moveScore = 900000;
-        else if (killer2 == move)
+        else if (move == killer2)
             *moveScore = 800000;
         else
             *moveScore = pos->searchHistory[pieceOn(from)][to];


### PR DESCRIPTION
Add function to check if there are more than one set bits in a bitboard, simplify ParseFen, and split en passant and promotion generation into two functions as it makes no sense to combine them.

No functional change.