### PR TITLE
Request huge pages on linux

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -56,7 +56,7 @@ void InitTT() {
     TT.count = size / sizeof(TTEntry);
 
     // Free memory if already allocated
-    if (TT.currentMB != 0)
+    if (TT.mem)
         free(TT.mem);
 
 #if defined(__linux__)

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -62,7 +62,7 @@ void InitTT() {
 #if defined(__linux__)
     // Align on 2MB boundaries and request Huge Pages
     TT.mem = aligned_alloc(2 * 1024 * 1024, size);
-    TT.table = TT.mem;
+    TT.table = (TTEntry *)TT.mem;
     madvise(TT.table, size, MADV_HUGEPAGE);
 #else
     // Align on cache line

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -21,8 +21,8 @@
 #include "types.h"
 
 
-// 1MB hash is a reasonable expectation.
-#define MINHASH 1
+// 2MB hash is a reasonable expectation.
+#define MINHASH 2
 // 65536MB = 2^32 * 16B / (1024 * 1024)
 // is the limit current indexing is able
 // to use given the 16B size of entries


### PR DESCRIPTION
Based on a recent patch for Ethereal by @skiminki , this patch aligns the transposition table to 2MB and requests the use of huge pages on linux. When huge pages are available and not used automatically this is potentially a big speedup. When huge pages are already used, the alignment will likely give a smaller speedup.

No functional change.

ELO   | 4.77 +- 4.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 10936 W: 2966 L: 2816 D: 5154
http://chess.grantnet.us/viewTest/4790/