### PR TITLE
Fix unintended behavior

### DIFF
--- a/src/makemove.c
+++ b/src/makemove.c
@@ -155,9 +155,6 @@ void TakeMove(Position *pos) {
     pos->rule50         = history(0).rule50;
     pos->castlingRights = history(0).castlingRights;
 
-    assert(0 <= pos->gamePly && pos->gamePly < MAXGAMEMOVES);
-    assert(    0 <= pos->ply && pos->ply < MAXDEPTH);
-
     // Get the move from history
     const Move move = history(0).move;
     const Square from = fromSq(move);
@@ -217,8 +214,6 @@ bool MakeMove(Position *pos, const Move move) {
     assert(ValidSquare(to));
     assert(ValidSide(color));
     assert(ValidPiece(pieceOn(from)));
-    assert(0 <= pos->gamePly && pos->gamePly < MAXGAMEMOVES);
-    assert(    0 <= pos->ply && pos->ply < MAXDEPTH);
 
     // Save position
     history(0).posKey         = pos->key;
@@ -231,9 +226,6 @@ bool MakeMove(Position *pos, const Move move) {
     pos->gamePly++;
     pos->ply++;
     pos->rule50++;
-
-    assert(0 <= pos->gamePly && pos->gamePly < MAXGAMEMOVES);
-    assert(    0 <= pos->ply && pos->ply < MAXDEPTH);
 
     // Hash out the old en passant if exist and unset it
     if (pos->epSquare != NO_SQ) {

--- a/src/search.c
+++ b/src/search.c
@@ -80,8 +80,6 @@ static void PrepareSearch(Position *pos, SearchInfo *info) {
     memset(pos->searchHistory, 0, sizeof(pos->searchHistory));
     memset(pos->searchKillers, 0, sizeof(pos->searchKillers));
 
-    pos->ply = 0;
-
     // Mark TT as used
     TT.dirty = true;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -241,7 +241,7 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
 
     // Extend search if in check
     const bool inCheck = SqAttacked(pos, Lsb(colorPieceBB(sideToMove, KING)), !sideToMove);
-    if (inCheck) depth++;
+    if (inCheck && pos->ply ) depth++;
 
     // Quiescence at the end of search
     if (depth <= 0)
@@ -550,7 +550,7 @@ void SearchPosition(Position *pos, SearchInfo *info) {
     PrepareSearch(pos, info);
 
     // Iterative deepening
-    for (info->depth = 1; info->depth <= Limits.depth; ++info->depth) {
+    for (info->depth = 1; info->depth < Limits.depth; ++info->depth) {
 
         // Jump here and go straight to printing conclusion when time's up
         if (setjmp(info->jumpBuffer)) break;

--- a/src/search.c
+++ b/src/search.c
@@ -241,7 +241,7 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
 
     // Extend search if in check
     const bool inCheck = SqAttacked(pos, Lsb(colorPieceBB(sideToMove, KING)), !sideToMove);
-    if (inCheck && pos->ply ) depth++;
+    if (inCheck && depth + 1 < MAXDEPTH) depth++;
 
     // Quiescence at the end of search
     if (depth <= 0)

--- a/src/uci.c
+++ b/src/uci.c
@@ -106,6 +106,8 @@ static void UCIPosition(const char *line, Position *pos) {
             exit(EXIT_SUCCESS);
         }
 
+        pos->ply = 0;
+
         // Skip to the next move if any
         if ((line = strstr(line, " ")) == NULL)
             return;


### PR DESCRIPTION
During setup while parsing a 'position' command with more than 127 moves, pos->ply would temporarily go above the intended max value of 127 before being reset to 0 when starting the search. This didn't cause any problems, but triggered asserts in debug mode. Fixed by setting ply to 0 between each move instead of at the beginning of search.

Also fixed extending past MAXDEPTH when in check in root (in extremely simple positions, or positions where mate distance pruning took effect, where the search would reach MAXDEPTH). Also made iterative deepening stop before depth == MAXDEPTH as that seems to be the normal way to do it.