### PR TITLE
Better score constants

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -267,7 +267,8 @@ int EvalPosition(const Position *pos) {
          +  (EgScore(eval) * (256 - pos->phase)))
          / 256;
 
-    assert(-INFINITE < eval && eval < INFINITE);
+    // Static evaluation shouldn't spill into TB- or mate-scores
+    assert(-SLOWEST_TB_WIN < eval && eval < SLOWEST_TB_WIN);
 
     // Return the evaluation, negated if we are black
     return sideToMove == WHITE ? eval : -eval;

--- a/src/search.c
+++ b/src/search.c
@@ -93,9 +93,9 @@ static void PrintThinking(const SearchInfo *info) {
     char *type = abs(score) > SLOWEST_MATE ? "mate" : "cp";
 
     // Convert score to mate score when applicable
-    score = score >  SLOWEST_MATE ?  ((MATE - score) / 2) + 1
-          : score < -SLOWEST_MATE ? -((MATE + score) / 2)
-          : score * 100 / P_MG;
+    score = score >=  SLOWEST_MATE ?  ((MATE - score) / 2) + 1
+          : score <= -SLOWEST_MATE ? -((MATE + score) / 2)
+                                   : score * 100 / P_MG;
 
     TimePoint elapsed = TimeSince(Limits.start);
     Depth seldepth    = info->seldepth > info->depth ? info->seldepth : info->depth;

--- a/src/search.c
+++ b/src/search.c
@@ -90,11 +90,11 @@ static void PrintThinking(const SearchInfo *info) {
     int score = info->score;
 
     // Determine whether we have a centipawn or mate score
-    char *type = abs(score) > ISMATE ? "mate" : "cp";
+    char *type = abs(score) > SLOWEST_MATE ? "mate" : "cp";
 
     // Convert score to mate score when applicable
-    score = score >  ISMATE ?  ((INFINITE - score) / 2) + 1
-          : score < -ISMATE ? -((INFINITE + score) / 2)
+    score = score >  SLOWEST_MATE ?  ((MATE - score) / 2) + 1
+          : score < -SLOWEST_MATE ? -((MATE + score) / 2)
           : score * 100 / P_MG;
 
     TimePoint elapsed = TimeSince(Limits.start);
@@ -266,8 +266,8 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
             return EvalPosition(pos);
 
         // Mate distance pruning
-        alpha = MAX(alpha, -INFINITE + pos->ply);
-        beta  = MIN(beta,   INFINITE - pos->ply - 1);
+        alpha = MAX(alpha, -MATE + pos->ply);
+        beta  = MIN(beta,   MATE - pos->ply - 1);
         if (alpha >= beta)
             return alpha;
     }
@@ -342,8 +342,8 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
 
         // Cutoff
         if (score >= beta) {
-            // Don't return unproven mate scores
-            return score >= ISMATE ? beta : score;
+            // Don't return unproven terminal win scores
+            return score >= SLOWEST_TB_WIN ? beta : score;
         }
     }
 
@@ -456,7 +456,7 @@ move_loop:
 
     // Checkmate or stalemate
     if (!moveCount)
-        return inCheck ? -INFINITE + pos->ply : 0;
+        return inCheck ? -MATE + pos->ply : 0;
 
     // Store in TT
     const int flag = bestScore >= beta ? BOUND_LOWER

--- a/src/search.c
+++ b/src/search.c
@@ -90,7 +90,7 @@ static void PrintThinking(const SearchInfo *info) {
     int score = info->score;
 
     // Determine whether we have a centipawn or mate score
-    char *type = abs(score) > SLOWEST_MATE ? "mate" : "cp";
+    char *type = abs(score) >= SLOWEST_MATE ? "mate" : "cp";
 
     // Convert score to mate score when applicable
     score = score >=  SLOWEST_MATE ?  ((MATE - score) / 2) + 1

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -52,8 +52,8 @@ bool ProbeWDL(const Position *pos, int *score, int *bound) {
     if (tbresult == TB_RESULT_FAILED)
         return false;
 
-    *score = tbresult == TB_LOSS ? -INFINITE + MAXDEPTH + pos->ply + 1
-           : tbresult == TB_WIN  ?  INFINITE - MAXDEPTH - pos->ply - 1
+    *score = tbresult == TB_LOSS ? -FASTEST_TB_WIN + pos->ply
+           : tbresult == TB_WIN  ?  FASTEST_TB_WIN - pos->ply
                                  :  0;
 
     *bound = tbresult == TB_LOSS ? BOUND_UPPER

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -30,7 +30,7 @@
 #define DEFAULTHASH 32
 
 #define ValidBound(bound) (bound >= BOUND_UPPER && bound <= BOUND_EXACT)
-#define ValidScore(score) (score >= -INFINITE && score <= INFINITE)
+#define ValidScore(score) (score >= -MATE && score <= MATE)
 #define ValidDepth(depth) (depth >= 1 && depth < MAXDEPTH)
 
 
@@ -64,17 +64,17 @@ extern TranspositionTable TT;
 // Mate scores are stored as mate in 0 as they depend on the current ply
 INLINE int ScoreToTT (const int score, const uint8_t ply) {
 
-    return score >=  ISMATE ? score + ply
-         : score <= -ISMATE ? score - ply
-                            : score;
+    return score >=  SLOWEST_TB_WIN ? score + ply
+         : score <= -SLOWEST_TB_WIN ? score - ply
+                                    : score;
 }
 
 // Translates from mate in 0 to the proper mate score at current ply
 INLINE int ScoreFromTT (const int score, const uint8_t ply) {
 
-    return score >=  ISMATE ? score - ply
-         : score <= -ISMATE ? score + ply
-                            : score;
+    return score >=  SLOWEST_TB_WIN ? score - ply
+         : score <= -SLOWEST_TB_WIN ? score + ply
+                                    : score;
 }
 
 INLINE TTEntry *GetEntry(Key posKey) {

--- a/src/types.h
+++ b/src/types.h
@@ -66,9 +66,13 @@ enum Limit {
 };
 
 enum Score {
-    INFINITE = 32500,
-    ISMATE   = INFINITE - MAXDEPTH,
-    NOSCORE  = INFINITE + 1
+    MATE     = 32500,
+    INFINITE = 32501,
+    NOSCORE  = 32502,
+
+    SLOWEST_MATE   = INFINITE - MAXDEPTH,
+    FASTEST_TB_WIN = SLOWEST_MATE - 1,
+    SLOWEST_TB_WIN = INFINITE - MAXDEPTH * 2
 };
 
 enum Color {


### PR DESCRIPTION
Changed up the score constants so they make more sense (mate in 0 is MATE, not INFINITE etc).

Also changed to not accept TB win scores from null move pruning as they represent number of moves to reach the TB win, and with a null move in the line that count is wrong.