### PR TITLE
Refactor castling legality test

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -24,6 +24,9 @@
 #define SETBIT(bb, sq) ((bb) |= SquareBB[(sq)])
 #define CLRBIT(bb, sq) ((bb) ^= SquareBB[(sq)])
 
+#define MAKEBB2(sq1, sq2)      ((1ULL << sq1) | (1ULL << sq2))
+#define MAKEBB3(sq1, sq2, sq3) ((1ULL << sq1) | (1ULL << sq2) | (1ULL << sq3))
+
 #ifdef USE_PEXT
 // Uses the bmi2 pext instruction in place of magic bitboards
 #include "x86intrin.h"
@@ -112,12 +115,6 @@ extern Bitboard SquareBB[64];
 
 extern const Bitboard FileBB[8];
 extern const Bitboard RankBB[8];
-
-// Used for checking legality of castling
-static const Bitboard bitB1C1D1 = (1ULL << B1) | (1ULL << C1) | (1ULL << D1);
-static const Bitboard bitB8C8D8 = (1ULL << B8) | (1ULL << C8) | (1ULL << D8);
-static const Bitboard bitF1G1   = (1ULL << F1) | (1ULL << G1);
-static const Bitboard bitF8G8   = (1ULL << F8) | (1ULL << G8);
 
 
 // Shifts a bitboard (protonspring version)

--- a/src/move.c
+++ b/src/move.c
@@ -53,10 +53,10 @@ bool MoveIsPseudoLegal(const Position *pos, const Move move) {
         case KING:
             if (moveIsCastle(move))
                 switch (to) {
-                    case C1: return CastlePseudoLegal(pos, bitB1C1D1, WHITE_OOO, E1, D1, WHITE);
-                    case G1: return CastlePseudoLegal(pos, bitF1G1,   WHITE_OO,  E1, F1, WHITE);
-                    case C8: return CastlePseudoLegal(pos, bitB8C8D8, BLACK_OOO, E8, D8, BLACK);
-                    case G8: return CastlePseudoLegal(pos, bitF8G8,   BLACK_OO,  E8, F8, BLACK);
+                    case C1: return CastlePseudoLegal(pos, WHITE, OOO);
+                    case G1: return CastlePseudoLegal(pos, WHITE, OO);
+                    case C8: return CastlePseudoLegal(pos, BLACK, OOO);
+                    case G8: return CastlePseudoLegal(pos, BLACK, OO);
                     default: assert(0); return false;
                 }
             // fall through

--- a/src/move.h
+++ b/src/move.h
@@ -64,12 +64,25 @@
 
 
 // Checks legality of a specific castle move given the current position
-INLINE bool CastlePseudoLegal(const Position *pos, Bitboard between, int type, Square sq1, Square sq2, Color color) {
+INLINE bool CastlePseudoLegal(const Position *pos, Color color, int side) {
 
-    return (pos->castlingRights & type)
-        && !(pieceBB(ALL) & between)
-        && !SqAttacked(pos, sq1, !color)
-        && !SqAttacked(pos, sq2, !color);
+    uint8_t castle = color == WHITE ? side & WHITE_CASTLE
+                                    : side & BLACK_CASTLE;
+
+    Square kingSq = color == WHITE ? E1 : E8;
+
+    Square midway = side == OO ? kingSq + EAST
+                               : kingSq + WEST;
+
+    Bitboard blocking = castle == WHITE_OO  ? MAKEBB2(F1, G1)
+                      : castle == WHITE_OOO ? MAKEBB3(B1, C1, D1)
+                      : castle == BLACK_OO  ? MAKEBB2(F8, G8)
+                                            : MAKEBB3(B8, C8, D8);
+
+    return (pos->castlingRights & castle)
+        && !(pieceBB(ALL) & blocking)
+        && !SqAttacked(pos, kingSq, !color)
+        && !SqAttacked(pos, midway, !color);
 }
 
 bool MoveIsPseudoLegal(const Position *pos, Move move);

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -105,18 +105,14 @@ INLINE void GenCastling(const Position *pos, MoveList *list, const Color color, 
 
     if (type != QUIET) return;
 
-    const int OO             = color == WHITE ? WHITE_OO  : BLACK_OO;
-    const int OOO            = color == WHITE ? WHITE_OOO : BLACK_OOO;
-    const Square from        = color == WHITE ? E1        : E8;
-    const Bitboard betweenKS = color == WHITE ? bitF1G1   : bitF8G8;
-    const Bitboard betweenQS = color == WHITE ? bitB1C1D1 : bitB8C8D8;
+    const Square from = color == WHITE ? E1 : E8;
 
     // King side castle
-    if (CastlePseudoLegal(pos, betweenKS, OO, from, from+1, color))
+    if (CastlePseudoLegal(pos, color, OO))
         AddMove(pos, list, from, from+2, EMPTY, FLAG_CASTLE, QUIET);
 
     // Queen side castle
-    if (CastlePseudoLegal(pos, betweenQS, OOO, from, from-1, color))
+    if (CastlePseudoLegal(pos, color, OOO))
         AddMove(pos, list, from, from-2, EMPTY, FLAG_CASTLE, QUIET);
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -111,14 +111,14 @@ enum Rank {
 };
 
 enum Square {
-  A1, B1, C1, D1, E1, F1, G1, H1,
-  A2, B2, C2, D2, E2, F2, G2, H2,
-  A3, B3, C3, D3, E3, F3, G3, H3,
-  A4, B4, C4, D4, E4, F4, G4, H4,
-  A5, B5, C5, D5, E5, F5, G5, H5,
-  A6, B6, C6, D6, E6, F6, G6, H6,
-  A7, B7, C7, D7, E7, F7, G7, H7,
-  A8, B8, C8, D8, E8, F8, G8, H8, NO_SQ = 99
+    A1, B1, C1, D1, E1, F1, G1, H1,
+    A2, B2, C2, D2, E2, F2, G2, H2,
+    A3, B3, C3, D3, E3, F3, G3, H3,
+    A4, B4, C4, D4, E4, F4, G4, H4,
+    A5, B5, C5, D5, E5, F5, G5, H5,
+    A6, B6, C6, D6, E6, F6, G6, H6,
+    A7, B7, C7, D7, E7, F7, G7, H7,
+    A8, B8, C8, D8, E8, F8, G8, H8, NO_SQ = 99
 };
 
 typedef enum Direction {
@@ -129,7 +129,15 @@ typedef enum Direction {
 } Direction;
 
 enum CastlingRights {
-    WHITE_OO = 1, WHITE_OOO = 2, BLACK_OO = 4, BLACK_OOO = 8
+    WHITE_OO  = 1,
+    WHITE_OOO = 2,
+    BLACK_OO  = 4,
+    BLACK_OOO = 8,
+
+    OO  = WHITE_OO  | BLACK_OO,
+    OOO = WHITE_OOO | BLACK_OOO,
+    WHITE_CASTLE = WHITE_OO | WHITE_OOO,
+    BLACK_CASTLE = BLACK_OO | BLACK_OOO
 };
 
 /* Structs */


### PR DESCRIPTION
Move all the logic to find the relevant squares for the castling into CastlePseudoLegal() to achieve a much cleaner function signature. Should be just as fast due to inlining and constant propagation.

No functional change.