### PR TITLE
Lookup for bitboards of squares between two squares

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -29,6 +29,7 @@ const Bitboard RankBB[8] = {
 };
 
 Bitboard SquareBB[64];
+Bitboard BetweenBB[64][64];
 
 static Bitboard BishopAttacks[0x1480];
 static Bitboard RookAttacks[0x19000];
@@ -140,6 +141,12 @@ CONSTR InitBitMasks() {
     InitSliderAttacks(BishopTable, BishopAttacks, BishopMagics, BSteps);
     InitSliderAttacks(  RookTable,   RookAttacks,   RookMagics, RSteps);
 #endif
+
+    for (Square sq1 = A1; sq1 <= H8; sq1++)
+        for (Square sq2 = A1; sq2 <= H8; sq2++)
+            for (PieceType pt = BISHOP; pt <= ROOK; pt++)
+                if (AttackBB(pt, sq1, SquareBB[sq2]) & SquareBB[sq2])
+                    BetweenBB[sq1][sq2] = AttackBB(pt, sq1, SquareBB[sq2]) & AttackBB(pt, sq2, SquareBB[sq1]);
 }
 
 // Checks whether a square is attacked by the given color

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -24,9 +24,6 @@
 #define SETBIT(bb, sq) ((bb) |= SquareBB[(sq)])
 #define CLRBIT(bb, sq) ((bb) ^= SquareBB[(sq)])
 
-#define MAKEBB2(sq1, sq2)      ((1ULL << sq1) | (1ULL << sq2))
-#define MAKEBB3(sq1, sq2, sq3) ((1ULL << sq1) | (1ULL << sq2) | (1ULL << sq3))
-
 #ifdef USE_PEXT
 // Uses the bmi2 pext instruction in place of magic bitboards
 #include "x86intrin.h"
@@ -112,6 +109,7 @@ extern Bitboard PseudoAttacks[8][64];
 extern Bitboard PawnAttacks[2][64];
 
 extern Bitboard SquareBB[64];
+extern Bitboard BetweenBB[64][64];
 
 extern const Bitboard FileBB[8];
 extern const Bitboard RankBB[8];

--- a/src/move.h
+++ b/src/move.h
@@ -71,13 +71,13 @@ INLINE bool CastlePseudoLegal(const Position *pos, Color color, int side) {
 
     Square kingSq = color == WHITE ? E1 : E8;
 
+    Square rookSq = side == OO ? kingSq + 3 * EAST
+                               : kingSq + 4 * WEST;
+
     Square midway = side == OO ? kingSq + EAST
                                : kingSq + WEST;
 
-    Bitboard blocking = castle == WHITE_OO  ? MAKEBB2(F1, G1)
-                      : castle == WHITE_OOO ? MAKEBB3(B1, C1, D1)
-                      : castle == BLACK_OO  ? MAKEBB2(F8, G8)
-                                            : MAKEBB3(B8, C8, D8);
+    Bitboard blocking = BetweenBB[kingSq][rookSq];
 
     return (pos->castlingRights & castle)
         && !(pieceBB(ALL) & blocking)


### PR DESCRIPTION
Currently only used for castling legality, but will probably be useful for evaluation and such in the future.

No functional change.