### PR TITLE
Wait for stop command in infinite search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -37,7 +37,7 @@
 int Reductions[32][32];
 
 SearchLimits Limits;
-extern bool ABORT_SIGNAL;
+extern volatile bool ABORT_SIGNAL;
 
 
 // Initializes the late move reduction array
@@ -566,6 +566,9 @@ void SearchPosition(Position *pos, SearchInfo *info) {
 
         info->seldepth = 0;
     }
+
+    // Wait for 'stop' in infinite search
+    while (!Limits.timelimit && !ABORT_SIGNAL) {}
 
     // Print conclusion
     PrintConclusion(info);

--- a/src/uci.c
+++ b/src/uci.c
@@ -37,7 +37,7 @@
 #define INPUT_SIZE 4096
 
 
-bool ABORT_SIGNAL = false;
+volatile bool ABORT_SIGNAL = false;
 
 
 // Checks if a string begins with another string


### PR DESCRIPTION
Properly wait for stop when reaching max depth in an infinite search.

No functional change.