### PR TITLE
Evaluation tuneable in dev mode

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -28,27 +28,27 @@
 static Bitboard PassedMask[2][64];
 static Bitboard IsolatedMask[64];
 
-const int PieceValue[2][PIECE_NB] = {
+tuneable_const int PieceValue[2][PIECE_NB] = {
     { 0, P_MG, N_MG, B_MG, R_MG, Q_MG, 0, 0,
       0, P_MG, N_MG, B_MG, R_MG, Q_MG, 0, 0 },
     { 0, P_EG, N_EG, B_EG, R_EG, Q_EG, 0, 0,
       0, P_EG, N_EG, B_EG, R_EG, Q_EG, 0, 0 }
 };
 
-// Various bonuses and maluses
-static const int PawnIsolated          = S(-20,-18);
-static const int BishopPair            = S( 65, 65);
-static const int KingLineVulnerability = S(-10,  0);
+// Misc bonuses and maluses
+tuneable_static_const int PawnIsolated   = S(-20,-18);
+tuneable_static_const int BishopPair     = S( 65, 65);
+tuneable_static_const int KingLineDanger = S(-10,  0);
 
 // Passed pawn [rank]
-static const int PawnPassed[8] = { 0, S(6, 6), S(13, 13), S(25, 25), S(45, 45), S(75, 75), S(130, 130), 0 };
+tuneable_static_const int PawnPassed[8] = { 0, S(6, 6), S(13, 13), S(25, 25), S(45, 45), S(75, 75), S(130, 130), 0 };
 
 // (Semi) open file for rook and queen [pt-4]
-static const int OpenFile[2] =     { S(25, 13), S(13, 20) };
-static const int SemiOpenFile[2] = { S(13, 20), S(10,  6) };
+tuneable_static_const int OpenFile[2] =     { S(25, 13), S(13, 20) };
+tuneable_static_const int SemiOpenFile[2] = { S(13, 20), S(10,  6) };
 
 // Mobility [pt-2][mobility]
-static const int Mobility[5][15] = {
+tuneable_static_const int Mobility[5][15] = {
     // Knight (0-8)
     { S(-65,-65), S(-32,-32), S(-20,-20), S(  0,  0), S( 20, 20), S( 32, 32), S( 45, 45), S( 50, 50), S( 65, 65) },
     // Bishop (0-13)
@@ -207,7 +207,7 @@ INLINE int EvalKings(const Position *pos, const Color color) {
     Square kingSq = Lsb(colorPieceBB(color, KING));
 
     // King safety
-    eval += KingLineVulnerability * PopCount(AttackBB(QUEEN, kingSq, colorBB(color) | pieceBB(PAWN)));
+    eval += KingLineDanger * PopCount(AttackBB(QUEEN, kingSq, colorBB(color) | pieceBB(PAWN)));
 
     return eval;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -146,8 +146,7 @@ void Perft(char *line) {
 
 void PrintEval(Position *pos) {
 
-    printf("Eval     : %d\n", EvalPosition(pos)); MirrorBoard(pos);
-    printf("Mirrored : %d\n", EvalPosition(pos)); MirrorBoard(pos);
+    printf("%d\n", sideToMove == WHITE ? EvalPosition(pos) : -EvalPosition(pos)), fflush(stdout);
 }
 
 // Checks evaluation is symmetric

--- a/src/tune.c
+++ b/src/tune.c
@@ -1,0 +1,113 @@
+/*
+  Weiss is a UCI compliant chess engine.
+  Copyright (C) 2020  Terje Kirstihagen
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#ifdef DEV
+
+#include <stdio.h>
+#include <string.h>
+
+#include "evaluate.h"
+
+
+enum { NAME_MAX_CHAR = 64, PARSER_ENTRY_NB = 12 };
+
+typedef struct ParserEntry {
+    char name[NAME_MAX_CHAR];
+    int *values, count;
+} ParserEntry;
+
+ParserEntry ParserEntries[PARSER_ENTRY_NB];
+
+
+// Misc
+extern int PawnIsolated;
+extern int BishopPair;
+extern int KingLineDanger;
+
+// Passed pawn [rank]
+extern int PawnPassed[8];
+
+// (Semi) open file for rook and queen [pt-4]
+extern int OpenFile[2];
+extern int SemiOpenFile[2];
+
+// Mobility
+extern int Mobility[5][15];
+
+
+static void Declare(ParserEntry *pe, const char *name, void *buffer, int count) {
+
+    const int *values = buffer;
+
+    // Declare UCI options for all array elements
+    for (int i = 0; i < count; i++)
+        printf("option name %s_mg_%d type spin default %d min %d max %d\n"
+               "option name %s_eg_%d type spin default %d min %d max %d\n",
+                name, i, MgScore(values[i]), -10000, 10000,
+                name, i, EgScore(values[i]), -10000, 10000);
+
+    // Remember array information for parsing
+    strcpy(pe->name, name);
+    pe->values = buffer;
+    pe->count = count;
+}
+
+void TuneDeclareAll() {
+
+    ParserEntry *pe = ParserEntries;
+
+    // Mobility
+    Declare(pe++, "KMob", Mobility[KNIGHT-2],  9);
+    Declare(pe++, "BMob", Mobility[BISHOP-2], 14);
+    Declare(pe++, "RMob", Mobility[  ROOK-2], 15);
+    Declare(pe++, "QMob", Mobility[ QUEEN-2], 28);
+    // Open file
+    Declare(pe++, "ROpen", &OpenFile[ ROOK-4], 1);
+    Declare(pe++, "QOpen", &OpenFile[QUEEN-4], 1);
+    // Semi-open file
+    Declare(pe++, "RSemi", &SemiOpenFile[ ROOK-4], 1);
+    Declare(pe++, "QSemi", &SemiOpenFile[QUEEN-4], 1);
+    // Passed pawn
+    Declare(pe++, "Passed", &PawnPassed[1], 6);
+    // Misc
+    Declare(pe++, "Isolated", &PawnIsolated,   1);
+    Declare(pe++, "BPair",    &BishopPair,     1);
+    Declare(pe++, "KLDanger", &KingLineDanger, 1);
+
+    assert(pe == &ParserEntries[PARSER_ENTRY_NB]);
+}
+
+void TuneParseAll(const char *line, int value) {
+
+    char name[NAME_MAX_CHAR], phase[3];
+    int idx;
+
+    if (sscanf(line, "%[a-zA-Z]_%[a-zA-Z]_%d", name, phase, &idx) != 3)
+        return;
+
+    bool mg = strstr(phase, "mg");
+
+    // Test against each Parser Entry, and set array element on match
+    for (int i = 0; i < PARSER_ENTRY_NB; i++)
+        if (!strcmp(name, ParserEntries[i].name)) {
+            ParserEntries[i].values[idx] =
+                mg ? S(value, EgScore(ParserEntries[i].values[idx]))
+                   : S(MgScore(ParserEntries[i].values[idx]), value);
+        }
+}
+#endif

--- a/src/tune.h
+++ b/src/tune.h
@@ -18,35 +18,10 @@
 
 #pragma once
 
-#include "types.h"
-
-
-// Check for (likely) material draw
-#define CHECK_MAT_DRAW
-
-
-#define MakeScore(mg, eg) ((int)((unsigned int)(eg) << 16) + (mg))
-#define S(mg, eg) MakeScore((mg), (eg))
-#define MgScore(s) ((int16_t)((uint16_t)((unsigned)((s)))))
-#define EgScore(s) ((int16_t)((uint16_t)((unsigned)((s) + 0x8000) >> 16)))
-
 #ifdef DEV
-#define tuneable_const
-#define tuneable_static_const
+void TuneDeclareAll();
+void TuneParseAll(const char *line, int value);
 #else
-#define tuneable_const const
-#define tuneable_static_const static const
+static void TuneDeclareAll() {};
+static void TuneParseAll(__attribute__((unused))const char *line, __attribute__((unused))int value) {};
 #endif
-
-
-extern tuneable_const int PieceValue[2][PIECE_NB];
-
-
-typedef struct EvalInfo {
-
-    Bitboard mobilityArea[2];
-
-} EvalInfo;
-
-
-int EvalPosition(const Position *pos);

--- a/src/uci.c
+++ b/src/uci.c
@@ -29,6 +29,7 @@
 #include "tests.h"
 #include "time.h"
 #include "transposition.h"
+#include "tune.h"
 
 
 #define NAME "weiss 0.9-dev"
@@ -142,7 +143,9 @@ static void UCISetoption(char *line) {
 
         TB_LARGEST > 0 ? printf("TableBase init success - largest found: %d.\n", TB_LARGEST)
                        : printf("TableBase init failure - not found.\n");
-    }
+    // Sets evaluation parameters (dev mode)
+    } else
+        TuneParseAll(strstr(line, "name") + 5, atoi(OptionValue(line)));
     fflush(stdout);
 }
 
@@ -153,6 +156,7 @@ static void UCIInfo() {
     printf("option name Hash type spin default %d min %d max %d\n", DEFAULTHASH, MINHASH, MAXHASH);
     printf("option name SyzygyPath type string default <empty>\n");
     printf("option name Ponder type check default false\n"); // Turn on ponder stats in cutechess gui
+    TuneDeclareAll(); // Declares all evaluation parameters as options (dev mode)
     printf("uciok\n"); fflush(stdout);
 }
 


### PR DESCRIPTION
Weiss now has options to change evaluation parameters in dev mode. A 'uci' command must be sent before the options work, might change this in the future.

'eval' command now prints the score relative to white's point of view.