### PR TITLE
Tune eval

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -36,16 +36,16 @@ tuneable_const int PieceValue[2][PIECE_NB] = {
 };
 
 // Misc bonuses and maluses
-tuneable_static_const int PawnIsolated   = S(-20,-18);
-tuneable_static_const int BishopPair     = S( 65, 65);
-tuneable_static_const int KingLineDanger = S(-10,  0);
+tuneable_static_const int PawnIsolated   = S(-27,-14);
+tuneable_static_const int BishopPair     = S( 65, 72);
+tuneable_static_const int KingLineDanger = S(-13,  5);
 
 // Passed pawn [rank]
-tuneable_static_const int PawnPassed[8] = { 0, S(6, 6), S(13, 13), S(25, 25), S(45, 45), S(75, 75), S(130, 130), 0 };
+tuneable_static_const int PawnPassed[8] = { 0, S(0, 7), S(10, 9), S(25, 18), S(46, 51), S(75, 80), S(130, 131), 0 };
 
 // (Semi) open file for rook and queen [pt-4]
-tuneable_static_const int OpenFile[2] =     { S(25, 13), S(13, 20) };
-tuneable_static_const int SemiOpenFile[2] = { S(13, 20), S(10,  6) };
+tuneable_static_const int OpenFile[2] =     { S(40, 17), S( 8, 16) };
+tuneable_static_const int SemiOpenFile[2] = { S(12, 20), S(16,  5) };
 
 // Mobility [pt-2][mobility]
 tuneable_static_const int Mobility[5][15] = {


### PR DESCRIPTION
Tune various eval parameters.

ELO   | 25.78 +- 11.09 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2160 W: 696 L: 536 D: 928
http://chess.grantnet.us/test/4975/

ELO   | 27.64 +- 11.09 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1839 W: 520 L: 374 D: 945
http://chess.grantnet.us/test/4977/