### PR TITLE
Tune piece values

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -95,11 +95,11 @@ enum Phase {
 };
 
 enum PieceValue {
-    P_MG =  128, P_EG =  140,
-    N_MG =  430, N_EG =  450,
-    B_MG =  450, B_EG =  475,
-    R_MG =  700, R_EG =  740,
-    Q_MG = 1280, Q_EG = 1400
+    P_MG =  110, P_EG =  155,
+    N_MG =  437, N_EG =  448,
+    B_MG =  460, B_EG =  465,
+    R_MG =  670, R_EG =  755,
+    Q_MG = 1400, Q_EG = 1560
 };
 
 enum File {


### PR DESCRIPTION
Most notably, pawn value significantly down early and up late, and queen up overall.

ELO   | 3.79 +- 3.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 27446 W: 7673 L: 7374 D: 12399
http://chess.grantnet.us/test/4996/

ELO   | 6.80 +- 4.87 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9508 W: 2414 L: 2228 D: 4866
http://chess.grantnet.us/test/4997/