### PR TITLE
Tune misc and passed bonuses

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -44,12 +44,12 @@ tuneable_const int PieceValue[2][PIECE_NB] = {
 };
 
 // Misc bonuses and maluses
-tuneable_static_const int PawnIsolated   = S(-29,-13);
-tuneable_static_const int BishopPair     = S( 62, 68);
+tuneable_static_const int PawnIsolated   = S(-30,-14);
+tuneable_static_const int BishopPair     = S( 53, 74);
 tuneable_static_const int KingLineDanger = S(-12,  5);
 
 // Passed pawn [rank]
-tuneable_static_const int PawnPassed[8] = { 0, S(-13, 4), S(-11, 3), S(11, 23), S(43, 62), S(77, 99), S(127, 135), 0 };
+tuneable_static_const int PawnPassed[8] = { 0, S(-14, 1), S(-16, 10), S(3, 34), S( 30, 69), S( 74, 114), S(123, 146), 0 };
 
 // (Semi) open file for rook and queen [pt-4]
 tuneable_static_const int OpenFile[2] =     { S(46, 14), S(-4, 14) };


### PR DESCRIPTION
ELO   | 4.05 +- 3.23 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22992 W: 6079 L: 5811 D: 11102
http://chess.grantnet.us/test/5018/

ELO   | 4.40 +- 3.16 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.50]
Games | N: 20688 W: 4753 L: 4491 D: 11444
http://chess.grantnet.us/test/5019/