### PR TITLE
Shrink aspiration delta

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -487,7 +487,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
     // delta based on the previous iteration's score
     const int bonus = score * score;
     const int initialWindow = 12 + bonus / 2048;
-    int delta = 64 + bonus / 256;
+    int delta = 16 + bonus / 256;
 
     // Initial window
     int alpha = MAX(score - initialWindow, -INFINITE);


### PR DESCRIPTION
Now that evaluation is much better, many parts of search can be retuned.

ELO   | 14.05 +- 7.75 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3960 W: 1095 L: 935 D: 1930
http://chess.grantnet.us/test/5053/

ELO   | 8.07 +- 5.29 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7360 W: 1724 L: 1553 D: 4083
http://chess.grantnet.us/test/5055/