### PR TITLE
Check for time up more often

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -51,13 +51,9 @@ CONSTR InitReductions() {
 // Check time situation
 static bool OutOfTime(SearchInfo *info) {
 
-    if (  (info->nodes & 8191) == 8191
+    return (info->nodes & 4095) == 4095
         && Limits.timelimit
-        && TimeSince(Limits.start) >= Limits.maxUsage)
-
-        return true;
-
-    return false;
+        && TimeSince(Limits.start) >= Limits.maxUsage;
 }
 
 // Check if current position is a repetition


### PR DESCRIPTION
Check whether we have run out of time for the current search every 4k nodes down from 8k. Also slightly better code.

ELO   | 1.89 +- 3.99 (95%)
SPRT  | 5.0+0.05s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 15968 W: 4439 L: 4352 D: 7177
http://chess.grantnet.us/test/5110/