### PR TITLE
Tune misc eval terms

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -44,12 +44,12 @@ tuneable_const int PieceValue[2][PIECE_NB] = {
 };
 
 // Misc bonuses and maluses
-tuneable_static_const int PawnIsolated   = S(-30,-14);
-tuneable_static_const int BishopPair     = S( 53, 74);
-tuneable_static_const int KingLineDanger = S(-12,  5);
+tuneable_static_const int PawnIsolated   = S(-28,-16);
+tuneable_static_const int BishopPair     = S( 52, 72);
+tuneable_static_const int KingLineDanger = S(-12,  4);
 
 // Passed pawn [rank]
-tuneable_static_const int PawnPassed[8] = { 0, S(-14, 1), S(-16, 10), S(3, 34), S( 30, 69), S( 74, 114), S(123, 146), 0 };
+tuneable_static_const int PawnPassed[8] = { 0, S(-10, 1), S(-18, 10), S( -2, 33), S( 28, 76), S( 77,116), S(121,153), 0 };
 
 // (Semi) open file for rook and queen [pt-4]
 tuneable_static_const int OpenFile[2] =     { S(51, 20), S(-13, 16) };


### PR DESCRIPTION
ELO   | 1.18 +- 1.42 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -2.14 (-2.94, 2.94) [0.00, 4.00]
Games | N: 119200 W: 31346 L: 30942 D: 56912
http://chess.grantnet.us/test/5129/

ELO   | 2.95 +- 2.37 (95%)
SPRT  | 40.0+0.4s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 37986 W: 8935 L: 8613 D: 20438
http://chess.grantnet.us/test/5138/