### PR TITLE
Tempo

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -43,6 +43,9 @@ tuneable_const int PieceValue[2][PIECE_NB] = {
       0, P_EG, N_EG, B_EG, R_EG, Q_EG, 0, 0 }
 };
 
+// Bonus for being the side to move
+tuneable_const int Tempo = 20;
+
 // Misc bonuses and maluses
 tuneable_static_const int PawnIsolated   = S(-28,-16);
 tuneable_static_const int BishopPair     = S( 52, 72);
@@ -277,5 +280,5 @@ int EvalPosition(const Position *pos) {
     assert(-SLOWEST_TB_WIN < eval && eval < SLOWEST_TB_WIN);
 
     // Return the evaluation, negated if we are black
-    return sideToMove == WHITE ? eval : -eval;
+    return (sideToMove == WHITE ? eval : -eval) + Tempo;
 }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -39,6 +39,8 @@
 #endif
 
 
+extern tuneable_const int Tempo;
+
 extern tuneable_const int PieceTypeValue[6];
 extern tuneable_const int PieceValue[2][PIECE_NB];
 

--- a/src/search.c
+++ b/src/search.c
@@ -311,7 +311,7 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
 
     // Do a static evaluation for pruning considerations
     int eval = history(0).eval = inCheck          ? NOSCORE
-                               : lastMoveNullMove ? -history(-1).eval
+                               : lastMoveNullMove ? -history(-1).eval + 2 * Tempo
                                                   : EvalPosition(pos);
 
     // Improving if not in check, and current eval is higher than 2 plies ago


### PR DESCRIPTION
Add a bonus for being the side to move in evaluation.

ELO   | 12.99 +- 7.35 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4416 W: 1220 L: 1055 D: 2141
http://chess.grantnet.us/test/5149/

ELO   | 6.67 +- 4.67 (95%)
SPRT  | 40.0+0.4s Threads=1 Hash=128MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9952 W: 2434 L: 2243 D: 5275
http://chess.grantnet.us/test/5150/