### PR TITLE
Cleanup eval bitmasks

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -40,6 +40,9 @@ Magic RookTable[64];
 Bitboard PseudoAttacks[TYPE_NB][64];
 Bitboard PawnAttacks[2][64];
 
+Bitboard PassedMask[2][64];
+Bitboard IsolatedMask[64];
+
 
 // Helper function that returns a bitboard with the landing square of
 // the step, or an empty bitboard if the step would go outside the board
@@ -118,11 +121,29 @@ static void InitSliderAttacks(Magic *m, Bitboard *table, const int *steps) {
     }
 }
 
+// Initializes evaluation bit masks
+static void InitEvalMasks() {
+
+    // For each square a pawn can be on
+    for (Square sq = A2; sq <= H7; ++sq) {
+
+        IsolatedMask[sq] = AdjacentFilesBB(sq);
+
+        PassedMask[WHITE][sq] = ShiftBB(NORTH * RelativeRank(WHITE, RankOf(sq)), ~rank1BB)
+                              & (FileBB[FileOf(sq)] | AdjacentFilesBB(sq));
+
+        PassedMask[BLACK][sq] = ShiftBB(SOUTH * RelativeRank(BLACK, RankOf(sq)), ~rank8BB)
+                              & (FileBB[FileOf(sq)] | AdjacentFilesBB(sq));
+    }
+}
+
 // Initializes all bitboard lookups
 CONSTR InitBitMasks() {
 
     for (Square sq = A1; sq <= H8; ++sq)
         SquareBB[sq] = (1ULL << sq);
+
+    InitEvalMasks();
 
     InitNonSliderAttacks();
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -114,10 +114,14 @@ extern Magic RookTable[64];
 extern Bitboard PseudoAttacks[8][64];
 extern Bitboard PawnAttacks[2][64];
 
+// Eval bit masks
+extern Bitboard PassedMask[2][64];
+extern Bitboard IsolatedMask[64];
+
 
 // Shifts a bitboard (protonspring version)
 // Doesn't work for shifting more than one step horizontally
-INLINE Bitboard ShiftBB(Direction dir, Bitboard bb) {
+INLINE Bitboard ShiftBB(const Direction dir, Bitboard bb) {
 
     // Horizontal shifts should not wrap around
     const int h = dir & 7;
@@ -128,6 +132,12 @@ INLINE Bitboard ShiftBB(Direction dir, Bitboard bb) {
     // Can only shift by positive numbers
     return dir > 0 ? bb <<  dir
                    : bb >> -dir;
+}
+
+INLINE Bitboard AdjacentFilesBB(const Square sq) {
+
+    return ShiftBB(WEST, FileBB[FileOf(sq)])
+         | ShiftBB(EAST, FileBB[FileOf(sq)]);
 }
 
 // Population count/Hamming weight

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -24,10 +24,6 @@
 #include "psqt.h"
 
 
-// Eval bit masks
-static Bitboard PassedMask[2][64];
-static Bitboard IsolatedMask[64];
-
 tuneable_const int PieceTypeValue[6] = { 0,
     S(P_MG, P_EG),
     S(N_MG, N_EG),
@@ -75,45 +71,6 @@ tuneable_static_const int Mobility[5][15] = {
       S( 76, 83), S( 92, 77), S(114, 98), S(116, 89), S(104,111), S(108,131) }
 };
 
-
-// Initialize evaluation bit masks
-CONSTR InitEvalMasks() {
-
-    // For each square a pawn can be on
-    for (Square sq = A2; sq <= H7; ++sq) {
-
-        // In front
-        for (Square tsq = sq + 8; tsq <= H8; tsq += 8)
-            PassedMask[WHITE][sq] |= (1ULL << tsq);
-
-        for (Square tsq = sq - 8; tsq <= H8; tsq -= 8)
-            PassedMask[BLACK][sq] |= (1ULL << tsq);
-
-        // Left side
-        if (FileOf(sq) > FILE_A) {
-
-            IsolatedMask[sq] |= FileBB[FileOf(sq) - 1];
-
-            for (Square tsq = sq + 7; tsq <= H8; tsq += 8)
-                PassedMask[WHITE][sq] |= (1ULL << tsq);
-
-            for (Square tsq = sq - 9; tsq <= H8; tsq -= 8)
-                PassedMask[BLACK][sq] |= (1ULL << tsq);
-        }
-
-        // Right side
-        if (FileOf(sq) < FILE_H) {
-
-            IsolatedMask[sq] |= FileBB[FileOf(sq) + 1];
-
-            for (Square tsq = sq + 9; tsq <= H8; tsq += 8)
-                PassedMask[WHITE][sq] |= (1ULL << tsq);
-
-            for (Square tsq = sq - 7; tsq <= H8; tsq -= 8)
-                PassedMask[BLACK][sq] |= (1ULL << tsq);
-        }
-    }
-}
 
 #ifdef CHECK_MAT_DRAW
 // Check if the board is (likely) drawn, logic from sjeng


### PR DESCRIPTION
Replace nested for-loops with smarter code inspired by SF, and moved the init code to bitboard.c. I have doubts about the results of the test, but maybe code layout is improved.

No functional change.

ELO   | 12.08 +- 7.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 4720 W: 1334 L: 1170 D: 2216
http://chess.grantnet.us/test/5165/