### PR TITLE
No null move pruning in pv nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -330,7 +330,8 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
         return eval;
 
     // Null Move Pruning
-    if (   history(-1).move != NOMOVE
+    if (  !pvNode
+        && history(-1).move != NOMOVE
         && eval >= beta
         && pos->nonPawnCount[sideToMove] > 0
         && depth >= 3) {


### PR DESCRIPTION
ELO   | 4.04 +- 3.20 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21840 W: 5422 L: 5168 D: 11250
http://chess.grantnet.us/test/5207/

ELO   | 0.24 +- 1.90 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 52776 W: 10871 L: 10834 D: 31071
http://chess.grantnet.us/test/5209/