### PR TITLE
LMP underpromotions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -375,7 +375,7 @@ move_loop:
         bool quiet = !moveIsNoisy(move);
 
         // Late move pruning
-        if (!pvNode && !inCheck && quiet && quietCount > (3 + 2 * depth * depth) / (2 - improving))
+        if (!pvNode && !inCheck && quietCount > (3 + 2 * depth * depth) / (2 - improving))
             break;
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));


### PR DESCRIPTION
Underpromotions are grouped with quiet moves, and are not expected to be good given that a queen promotion was not. They were already pruned by LMP given they were ordered behind enough quiet moves, but the pruning could not happen exactly when the current move was an underpromo. This patch removes that check, allowing pruning also directly of underpromotions.

ELO   | 4.90 +- 4.61 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 10496 W: 2604 L: 2456 D: 5436
http://chess.grantnet.us/test/5224/

ELO   | 1.05 +- 2.40 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 33072 W: 6867 L: 6767 D: 19438
http://chess.grantnet.us/test/5225/