### PR TITLE
Cleanup scores

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -234,7 +234,7 @@ int EvalPosition(const Position *pos) {
          / 256;
 
     // Static evaluation shouldn't spill into TB- or mate-scores
-    assert(-SLOWEST_TB_WIN < eval && eval < SLOWEST_TB_WIN);
+    assert(abs(eval) < TBWIN_IN_MAX);
 
     // Return the evaluation, negated if we are black
     return (sideToMove == WHITE ? eval : -eval) + Tempo;

--- a/src/search.c
+++ b/src/search.c
@@ -80,6 +80,12 @@ static void PrepareSearch(Position *pos, SearchInfo *info) {
     TT.dirty = true;
 }
 
+// Translates an internal mate score into distance to mate
+INLINE int MateScore(const int score) {
+    return score > 0 ?  ((MATE - score) / 2) + 1
+                     : -((MATE + score) / 2);
+}
+
 // Print thinking
 static void PrintThinking(const SearchInfo *info) {
 
@@ -88,10 +94,10 @@ static void PrintThinking(const SearchInfo *info) {
     // Determine whether we have a centipawn or mate score
     char *type = abs(score) >= MATE_IN_MAX ? "mate" : "cp";
 
-    // Convert score to mate score when applicable
-    score = score >=  MATE_IN_MAX ?  ((MATE - score) / 2) + 1
-          : score <= -MATE_IN_MAX ? -((MATE + score) / 2)
-                                  : score * 100 / P_MG;
+    // Translate internal score into printed score
+    score = abs(score) >=  MATE_IN_MAX ? MateScore(score)
+          : abs(score) >= TBWIN_IN_MAX ? score
+                                       : score * 100 / P_MG;
 
     TimePoint elapsed = TimeSince(Limits.start);
     Depth seldepth    = info->seldepth;

--- a/src/search.c
+++ b/src/search.c
@@ -86,12 +86,12 @@ static void PrintThinking(const SearchInfo *info) {
     int score = info->score;
 
     // Determine whether we have a centipawn or mate score
-    char *type = abs(score) >= SLOWEST_MATE ? "mate" : "cp";
+    char *type = abs(score) >= MATE_IN_MAX ? "mate" : "cp";
 
     // Convert score to mate score when applicable
-    score = score >=  SLOWEST_MATE ?  ((MATE - score) / 2) + 1
-          : score <= -SLOWEST_MATE ? -((MATE + score) / 2)
-                                   : score * 100 / P_MG;
+    score = score >=  MATE_IN_MAX ?  ((MATE - score) / 2) + 1
+          : score <= -MATE_IN_MAX ? -((MATE + score) / 2)
+                                  : score * 100 / P_MG;
 
     TimePoint elapsed = TimeSince(Limits.start);
     Depth seldepth    = info->seldepth;
@@ -345,7 +345,7 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
         // Cutoff
         if (score >= beta) {
             // Don't return unproven terminal win scores
-            return score >= SLOWEST_TB_WIN ? beta : score;
+            return score >= TBWIN_IN_MAX ? beta : score;
         }
     }
 

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -52,8 +52,8 @@ bool ProbeWDL(const Position *pos, int *score, int *bound) {
     if (tbresult == TB_RESULT_FAILED)
         return false;
 
-    *score = tbresult == TB_LOSS ? -FASTEST_TB_WIN + pos->ply
-           : tbresult == TB_WIN  ?  FASTEST_TB_WIN - pos->ply
+    *score = tbresult == TB_LOSS ? -TBWIN + pos->ply
+           : tbresult == TB_WIN  ?  TBWIN - pos->ply
                                  :  0;
 
     *bound = tbresult == TB_LOSS ? BOUND_UPPER

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -23,7 +23,7 @@
 #include "types.h"
 
 
-// Calls fathom to probe syzygy tablebases - heavily inspired by ethereal
+// Calls fathom to probe syzygy tablebases
 bool ProbeWDL(const Position *pos, int *score, int *bound) {
 
     // Don't probe at root, when en passant is possible, when castling is
@@ -52,12 +52,12 @@ bool ProbeWDL(const Position *pos, int *score, int *bound) {
     if (tbresult == TB_RESULT_FAILED)
         return false;
 
-    *score = tbresult == TB_LOSS ? -TBWIN + pos->ply
-           : tbresult == TB_WIN  ?  TBWIN - pos->ply
+    *score = tbresult == TB_WIN  ?  TBWIN - pos->ply
+           : tbresult == TB_LOSS ? -TBWIN + pos->ply
                                  :  0;
 
-    *bound = tbresult == TB_LOSS ? BOUND_UPPER
-           : tbresult == TB_WIN  ? BOUND_LOWER
+    *bound = tbresult == TB_WIN  ? BOUND_LOWER
+           : tbresult == TB_LOSS ? BOUND_UPPER
                                  : BOUND_EXACT;
 
     return true;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -64,17 +64,17 @@ extern TranspositionTable TT;
 // Mate scores are stored as mate in 0 as they depend on the current ply
 INLINE int ScoreToTT (const int score, const uint8_t ply) {
 
-    return score >=  SLOWEST_TB_WIN ? score + ply
-         : score <= -SLOWEST_TB_WIN ? score - ply
-                                    : score;
+    return score >=  TBWIN_IN_MAX ? score + ply
+         : score <= -TBWIN_IN_MAX ? score - ply
+                                  : score;
 }
 
 // Translates from mate in 0 to the proper mate score at current ply
 INLINE int ScoreFromTT (const int score, const uint8_t ply) {
 
-    return score >=  SLOWEST_TB_WIN ? score - ply
-         : score <= -SLOWEST_TB_WIN ? score + ply
-                                    : score;
+    return score >=  TBWIN_IN_MAX ? score - ply
+         : score <= -TBWIN_IN_MAX ? score + ply
+                                  : score;
 }
 
 INLINE TTEntry *GetEntry(Key posKey) {

--- a/src/types.h
+++ b/src/types.h
@@ -77,7 +77,7 @@ enum Limit {
 };
 
 enum Score {
-    TBWIN        = 32000,
+    TBWIN        = 30000,
     TBWIN_IN_MAX = TBWIN - MAXDEPTH,
 
     MATE        = TBWIN + MAXDEPTH + 1,

--- a/src/types.h
+++ b/src/types.h
@@ -77,13 +77,14 @@ enum Limit {
 };
 
 enum Score {
-    MATE     = 32500,
-    INFINITE = 32501,
-    NOSCORE  = 32502,
+    TBWIN        = 32000,
+    TBWIN_IN_MAX = TBWIN - MAXDEPTH,
 
-    SLOWEST_MATE   = INFINITE - MAXDEPTH,
-    FASTEST_TB_WIN = SLOWEST_MATE - 1,
-    SLOWEST_TB_WIN = INFINITE - MAXDEPTH * 2
+    MATE        = TBWIN + MAXDEPTH + 1,
+    MATE_IN_MAX = MATE - MAXDEPTH,
+
+    INFINITE = MATE + 1,
+    NOSCORE  = MATE + 2,
 };
 
 enum Color {


### PR DESCRIPTION
Printed TB win scores are now 30000 minus ply-distance from root, and they are not scaled by pawn value, making them easier to understand.

Also cleaned up the score constant enum and names.

No functional change.