### PR TITLE
Speedup + Cleanup

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -22,16 +22,15 @@
 #include "board.h"
 
 
-#define SETBIT(bb, sq) ((bb) |= SquareBB[(sq)])
-#define CLRBIT(bb, sq) ((bb) ^= SquareBB[(sq)])
-
 #ifdef USE_PEXT
 // Uses the bmi2 pext instruction in place of magic bitboards
 #include "x86intrin.h"
 #define AttackIndex(sq, occ, table) (_pext_u64(occ, table[sq].mask))
+
 #else
 // Uses magic bitboards as explained on https://www.chessprogramming.org/Magic_Bitboards
 #define AttackIndex(sq, occ, table) (((occ & table[sq].mask) * table[sq].magic) >> table[sq].shift)
+
 static const uint64_t RookMagics[64] = {
     0xA180022080400230ull, 0x0040100040022000ull, 0x0080088020001002ull, 0x0080080280841000ull,
     0x4200042010460008ull, 0x04800A0003040080ull, 0x0400110082041008ull, 0x008000A041000880ull,

--- a/src/board.c
+++ b/src/board.c
@@ -152,11 +152,12 @@ static void UpdatePosition(Position *pos) {
         if (piece != EMPTY) {
 
             Color color = ColorOf(piece);
+            PieceType pt = PieceTypeOf(piece);
 
             // Bitboards
-            SETBIT(pieceBB(ALL), sq);
-            SETBIT(colorBB(ColorOf(piece)), sq);
-            SETBIT(pieceBB(PieceTypeOf(piece)), sq);
+            pieceBB(ALL)   |= SquareBB[sq];
+            pieceBB(pt)    |= SquareBB[sq];
+            colorBB(color) |= SquareBB[sq];
 
             // Non pawn piece count
             if (NonPawn[piece])

--- a/src/board.h
+++ b/src/board.h
@@ -63,9 +63,14 @@ INLINE bool ValidPiece(const Piece piece) {
         || (bP <= piece && piece <= bK);
 }
 
-INLINE bool ValidPromotion(const Piece piece) {
-    return (wN <= piece && piece <= wQ)
-        || (bN <= piece && piece <= bQ);
+INLINE bool ValidCapture(const Piece capt) {
+    return (wP <= capt && capt <= wQ)
+        || (bP <= capt && capt <= bQ);
+}
+
+INLINE bool ValidPromotion(const Piece promo) {
+    return (wN <= promo && promo <= wQ)
+        || (bN <= promo && promo <= bQ);
 }
 
 INLINE int FileOf(const Square square) {

--- a/src/board.h
+++ b/src/board.h
@@ -63,6 +63,11 @@ INLINE bool ValidPiece(const Piece piece) {
         || (bP <= piece && piece <= bK);
 }
 
+INLINE bool ValidPromotion(const Piece piece) {
+    return (wN <= piece && piece <= wQ)
+        || (bN <= piece && piece <= bQ);
+}
+
 INLINE int FileOf(const Square square) {
     return square & 7;
 }

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -86,26 +86,32 @@ static bool MaterialDraw(const Position *pos) {
         // No bishops
         if (!pieceBB(BISHOP)) {
             // Draw with 0-2 knights each (both 0 => KvK) (all nonpawns if any are knights)
-            return pos->nonPawnCount[WHITE] <= 2 && pos->nonPawnCount[BLACK] <= 2;
+            return pos->nonPawnCount[WHITE] <= 2
+                && pos->nonPawnCount[BLACK] <= 2;
 
         // No knights
         } else if (!pieceBB(KNIGHT)) {
             // Draw unless one side has 2 extra bishops (all nonpawns are bishops)
-            return abs(pos->nonPawnCount[WHITE] - pos->nonPawnCount[BLACK]) < 2;
+            return abs(  pos->nonPawnCount[WHITE]
+                       - pos->nonPawnCount[BLACK]) < 2;
 
         // Draw with 1-2 knights vs 1 bishop (there is at least 1 bishop, and at last 1 knight)
         } else if (Single(pieceBB(BISHOP))) {
             Color bishopOwner = colorPieceBB(WHITE, BISHOP) ? WHITE : BLACK;
-            return pos->nonPawnCount[bishopOwner] == 1 && pos->nonPawnCount[!bishopOwner] <= 2;
+            return pos->nonPawnCount[ bishopOwner] == 1
+                && pos->nonPawnCount[!bishopOwner] <= 2;
         }
     // Draw with 1 rook + up to 1 minor each
     } else if (Single(colorPieceBB(WHITE, ROOK)) && Single(colorPieceBB(BLACK, ROOK))) {
-        return pos->nonPawnCount[WHITE] <= 2 && pos->nonPawnCount[BLACK] <= 2;
+        return pos->nonPawnCount[WHITE] <= 2
+            && pos->nonPawnCount[BLACK] <= 2;
 
     // Draw with 1 rook vs 1-2 minors
     } else if (Single(pieceBB(ROOK))) {
         Color rookOwner = colorPieceBB(WHITE, ROOK) ? WHITE : BLACK;
-        return pos->nonPawnCount[rookOwner] == 1 && pos->nonPawnCount[!rookOwner] >= 1 && pos->nonPawnCount[!rookOwner] <= 2;
+        return pos->nonPawnCount[ rookOwner] == 1
+            && pos->nonPawnCount[!rookOwner] >= 1
+            && pos->nonPawnCount[!rookOwner] <= 2;
     }
 
     return false;

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -164,7 +164,7 @@ void TakeMove(Position *pos) {
     // Add back captured piece if any
     Piece capt = capturing(move);
     if (capt != EMPTY) {
-        assert(ValidPiece(capt));
+        assert(ValidCapture(capt));
         AddPiece(pos, to, capt, false);
     }
 
@@ -229,7 +229,7 @@ bool MakeMove(Position *pos, const Move move) {
     // Remove captured piece if any
     Piece capt = capturing(move);
     if (capt != EMPTY) {
-        assert(ValidPiece(capt));
+        assert(ValidCapture(capt));
         ClearPiece(pos, to, true);
         pos->rule50 = 0;
     }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -171,7 +171,7 @@ void TakeMove(Position *pos) {
     // Remove promoted piece and put back the pawn
     Piece promo = promotion(move);
     if (promo != EMPTY) {
-        assert(ValidPiece(promo) && NonPawn[promo]);
+        assert(ValidPromotion(promo));
         ClearPiece(pos, from, false);
         AddPiece(pos, from, MakePiece(sideToMove, PAWN), false);
     }
@@ -254,7 +254,7 @@ bool MakeMove(Position *pos, const Move move) {
 
         // Replace promoting pawn with new piece
         else if (promo != EMPTY) {
-            assert(ValidPiece(promo) && NonPawn[promo]);
+            assert(ValidPromotion(promo));
             ClearPiece(pos, to, true);
             AddPiece(pos, to, promo, true);
         }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -62,8 +62,7 @@ static void ClearPiece(Position *pos, const Square sq) {
     pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     // Update non-pawn count
-    if (NonPawn[piece])
-        pos->nonPawnCount[color]--;
+    pos->nonPawnCount[color] -= NonPawn[piece];
 
     // Update bitboards
     CLRBIT(pieceBB(ALL), sq);
@@ -90,8 +89,7 @@ static void AddPiece(Position *pos, const Square sq, const Piece piece) {
     pos->phase = (pos->basePhase * 256 + 12) / 24;
 
     // Update non-pawn count
-    if (NonPawn[piece])
-        pos->nonPawnCount[color]++;
+    pos->nonPawnCount[color] += NonPawn[piece];
 
     // Update bitboards
     SETBIT(pieceBB(ALL), sq);

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -22,10 +22,10 @@
 #include "psqt.h"
 
 
-#define HASH_PCE(piece, sq) (pos->key ^= (PieceKeys[(piece)][(sq)]))
-#define HASH_CA             (pos->key ^= (CastleKeys[(pos->castlingRights)]))
-#define HASH_SIDE           (pos->key ^= (SideKey))
-#define HASH_EP             (pos->key ^= (PieceKeys[EMPTY][(pos->epSquare)]))
+#define HASH_PCE(piece, sq) (pos->key ^= PieceKeys[(piece)][(sq)])
+#define HASH_CA             (pos->key ^= CastleKeys[pos->castlingRights])
+#define HASH_SIDE           (pos->key ^= SideKey)
+#define HASH_EP             (pos->key ^= PieceKeys[EMPTY][pos->epSquare])
 
 
 static const uint8_t CastlePerm[64] = {
@@ -201,23 +201,20 @@ bool MakeMove(Position *pos, const Move move) {
     pos->rule50++;
 
     // Hash out the old en passant if exist and unset it
-    if (pos->epSquare != NO_SQ) {
-        HASH_EP;
+    if (pos->epSquare != NO_SQ)
+        HASH_EP,
         pos->epSquare = NO_SQ;
-    }
 
     const Square from = fromSq(move);
-    const Square to   = toSq(move);
+    const Square to = toSq(move);
 
     // Rehash the castling rights if at least one side can castle,
     // and either the to or from square is the original square of
     // a king or rook.
-    if (pos->castlingRights && CastlePerm[from] ^ CastlePerm[to]) {
+    if (pos->castlingRights && CastlePerm[from] ^ CastlePerm[to])
+        HASH_CA,
+        pos->castlingRights &= CastlePerm[from] & CastlePerm[to],
         HASH_CA;
-        pos->castlingRights &= CastlePerm[from];
-        pos->castlingRights &= CastlePerm[to];
-        HASH_CA;
-    }
 
     // Move the rook during castling
     if (moveIsCastle(move))
@@ -297,10 +294,9 @@ void MakeNullMove(Position *pos) {
     HASH_SIDE;
 
     // Hash out en passant if there was one, and unset it
-    if (pos->epSquare != NO_SQ) {
-        HASH_EP;
+    if (pos->epSquare != NO_SQ)
+        HASH_EP,
         pos->epSquare = NO_SQ;
-    }
 
     assert(PositionOk(pos));
 }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -45,6 +45,7 @@ static void ClearPiece(Position *pos, const Square sq) {
 
     const Piece piece = pieceOn(sq);
     const Color color = ColorOf(piece);
+    const PieceType pt = PieceTypeOf(piece);
 
     assert(ValidPiece(piece));
 
@@ -65,15 +66,16 @@ static void ClearPiece(Position *pos, const Square sq) {
     pos->nonPawnCount[color] -= NonPawn[piece];
 
     // Update bitboards
-    CLRBIT(pieceBB(ALL), sq);
-    CLRBIT(colorBB(color), sq);
-    CLRBIT(pieceBB(PieceTypeOf(piece)), sq);
+    pieceBB(ALL)   ^= SquareBB[sq];
+    pieceBB(pt)    ^= SquareBB[sq];
+    colorBB(color) ^= SquareBB[sq];
 }
 
 // Add a piece piece to a square
 static void AddPiece(Position *pos, const Square sq, const Piece piece) {
 
     const Color color = ColorOf(piece);
+    const PieceType pt = PieceTypeOf(piece);
 
     // Hash in piece at square
     HASH_PCE(piece, sq);
@@ -92,15 +94,17 @@ static void AddPiece(Position *pos, const Square sq, const Piece piece) {
     pos->nonPawnCount[color] += NonPawn[piece];
 
     // Update bitboards
-    SETBIT(pieceBB(ALL), sq);
-    SETBIT(colorBB(color), sq);
-    SETBIT(pieceBB(PieceTypeOf(piece)), sq);
+    pieceBB(ALL)   |= SquareBB[sq];
+    pieceBB(pt)    |= SquareBB[sq];
+    colorBB(color) |= SquareBB[sq];
 }
 
 // Move a piece from one square to another
 static void MovePiece(Position *pos, const Square from, const Square to) {
 
     const Piece piece = pieceOn(from);
+    const Color color = ColorOf(piece);
+    const PieceType pt = PieceTypeOf(piece);
 
     assert(ValidPiece(piece));
     assert(pieceOn(to) == EMPTY);
@@ -117,14 +121,9 @@ static void MovePiece(Position *pos, const Square from, const Square to) {
     pos->material += PSQT[piece][to] - PSQT[piece][from];
 
     // Update bitboards
-    CLRBIT(pieceBB(ALL), from);
-    SETBIT(pieceBB(ALL), to);
-
-    CLRBIT(colorBB(ColorOf(piece)), from);
-    SETBIT(colorBB(ColorOf(piece)), to);
-
-    CLRBIT(pieceBB(PieceTypeOf(piece)), from);
-    SETBIT(pieceBB(PieceTypeOf(piece)), to);
+    pieceBB(ALL)   ^= SquareBB[from] ^ SquareBB[to];
+    pieceBB(pt)    ^= SquareBB[from] ^ SquareBB[to];
+    colorBB(color) ^= SquareBB[from] ^ SquareBB[to];
 }
 
 // Take back the previous move

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -162,15 +162,16 @@ void TakeMove(Position *pos) {
     MovePiece(pos, to, from, false);
 
     // Add back captured piece if any
-    Piece captured = capturing(move);
-    if (captured != EMPTY) {
-        assert(ValidPiece(captured));
-        AddPiece(pos, to, captured, false);
+    Piece capt = capturing(move);
+    if (capt != EMPTY) {
+        assert(ValidPiece(capt));
+        AddPiece(pos, to, capt, false);
     }
 
     // Remove promoted piece and put back the pawn
-    if (promotion(move) != EMPTY) {
-        assert(ValidPiece(promotion(move)) && NonPawn[promotion(move)]);
+    Piece promo = promotion(move);
+    if (promo != EMPTY) {
+        assert(ValidPiece(promo) && NonPawn[promo]);
         ClearPiece(pos, from, false);
         AddPiece(pos, from, MakePiece(sideToMove, PAWN), false);
     }
@@ -186,10 +187,6 @@ void TakeMove(Position *pos) {
 
 // Make a move - take it back and return false if move was illegal
 bool MakeMove(Position *pos, const Move move) {
-
-    const Square from = fromSq(move);
-    const Square to   = toSq(move);
-    const Piece capt  = capturing(move);
 
     // Save position
     history(0).posKey         = pos->key;
@@ -208,6 +205,9 @@ bool MakeMove(Position *pos, const Move move) {
         HASH_EP;
         pos->epSquare = NO_SQ;
     }
+
+    const Square from = fromSq(move);
+    const Square to   = toSq(move);
 
     // Rehash the castling rights if at least one side can castle,
     // and either the to or from square is the original square of
@@ -230,7 +230,8 @@ bool MakeMove(Position *pos, const Move move) {
         }
 
     // Remove captured piece if any
-    else if (capt != EMPTY) {
+    Piece capt = capturing(move);
+    if (capt != EMPTY) {
         assert(ValidPiece(capt));
         ClearPiece(pos, to, true);
         pos->rule50 = 0;
@@ -267,10 +268,8 @@ bool MakeMove(Position *pos, const Move move) {
     HASH_SIDE;
 
     // If own king is attacked after the move, take it back immediately
-    if (KingAttacked(pos, sideToMove^1)) {
-        TakeMove(pos);
-        return false;
-    }
+    if (KingAttacked(pos, sideToMove^1))
+        return TakeMove(pos), false;
 
     assert(PositionOk(pos));
 


### PR DESCRIPTION
A ~10% speedup of perft achieved by reducing branching, not updating hash while taking back moves (the final hash is retrieved from history array), and using ^ for both updates in MovePiece, allowing smarter code than using ^ for unsetting and | for setting.

A lot of cosmetic code refactoring.

ELO   | 2.20 +- 3.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 20368 W: 5138 L: 5009 D: 10221
http://chess.grantnet.us/test/5325/