### PR TITLE
Fix useless en passants in search

### DIFF
--- a/src/makemove.c
+++ b/src/makemove.c
@@ -243,8 +243,9 @@ bool MakeMove(Position *pos, const Move move) {
         pos->rule50 = 0;
         Piece promo = promotion(move);
 
-        // If the move is a pawnstart we set the en passant square and hash it in
-        if (moveIsPStart(move)) {
+        // Set en passant square if applicable
+        if (moveIsPStart(move) && (  PawnAttackBB(sideToMove, to ^ 8)
+                                   & colorPieceBB(!sideToMove, PAWN))) {
             pos->epSquare = to ^ 8;
             HASH_EP;
 

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -244,10 +244,13 @@ bool MakeMove(Position *pos, const Move move) {
         Piece promo = promotion(move);
 
         // Set en passant square if applicable
-        if (moveIsPStart(move) && (  PawnAttackBB(sideToMove, to ^ 8)
-                                   & colorPieceBB(!sideToMove, PAWN))) {
-            pos->epSquare = to ^ 8;
-            HASH_EP;
+        if (moveIsPStart(move)) {
+            if ((  PawnAttackBB(sideToMove, to ^ 8)
+                 & colorPieceBB(!sideToMove, PAWN))) {
+
+                pos->epSquare = to ^ 8;
+                HASH_EP;
+            }
 
         // Remove pawn captured by en passant
         } else if (moveIsEnPas(move))


### PR DESCRIPTION
Avoid setting en passant if there is no pawn in position to actually use it. This allows slightly more transpositions as the same position right after a double pawn move will have the same hash as after shuffling pieces.

ELO   | 0.97 +- 2.56 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 34544 W: 8495 L: 8399 D: 17650
http://chess.grantnet.us/test/5335/