### PR TITLE
Print updates during longer searches

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -511,7 +511,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
         // Failed high, relax upper bound and search again
         } else if (score >= beta) {
             beta = MIN(beta + delta, INFINITE);
-            depth -= 1;
+            depth -= (abs(score) < TBWIN_IN_MAX);
 
         // Score within the bounds is accepted as correct
         } else

--- a/src/search.c
+++ b/src/search.c
@@ -489,9 +489,13 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
     const int initialWindow = 12;
     int delta = 16;
 
-    // Initial window
-    int alpha = MAX(score - initialWindow, -INFINITE);
-    int beta  = MIN(score + initialWindow,  INFINITE);
+    int alpha = -INFINITE;
+    int beta  =  INFINITE;
+
+    // Shrink the window at higher depths
+    if (depth > 6)
+        alpha = MAX(score - initialWindow, -INFINITE),
+        beta  = MIN(score + initialWindow,  INFINITE);
 
     // Search with aspiration window until the result is inside the window
     while (true) {
@@ -561,8 +565,7 @@ void SearchPosition(Position *pos, SearchInfo *info) {
         if (setjmp(info->jumpBuffer)) break;
 
         // Search position, using aspiration windows for higher depths
-        info->score = info->depth > 6 ? AspirationWindow(pos, info)
-                                      : AlphaBeta(pos, info, -INFINITE, INFINITE, info->depth, &info->pv);
+        info->score = AspirationWindow(pos, info);
 
         // Print thinking
         PrintThinking(info);

--- a/src/search.c
+++ b/src/search.c
@@ -434,17 +434,17 @@ move_loop:
             bestScore = score;
             bestMove  = move;
 
+            // Update the Principle Variation
+            if ((score > alpha && pvNode) || (root && moveCount == 1)) {
+                pv->length = 1 + pvFromHere.length;
+                pv->line[0] = move;
+                memcpy(pv->line + 1, pvFromHere.line, sizeof(int) * pvFromHere.length);
+            }
+
             // If score beats alpha we update alpha
             if (score > alpha) {
 
                 alpha = score;
-
-                // Update the Principle Variation
-                if (pvNode) {
-                    pv->length = 1 + pvFromHere.length;
-                    pv->line[0] = move;
-                    memcpy(pv->line + 1, pvFromHere.line, sizeof(int) * pvFromHere.length);
-                }
 
                 // Update search history
                 if (quiet)


### PR DESCRIPTION
Weiss will now give updates during longer searches when failing high/low in root.

Also avoids lowering depth when failing high with a TB/Mate score. When such a score is first found it causes a long chain of fail highs, resulting in severely reduced depth which in turn can make the search unable to reach the TB/mate position anymore. Inspired by Ethereal.