### PR TITLE
Improved time management

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -530,7 +530,7 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 }
 
 // Decides when to stop a search
-static void InitTimeManagement() {
+static void InitTimeManagement(int ply) {
 
     const int overhead = 30;
     const int minTime = 10;
@@ -548,21 +548,28 @@ static void InitTimeManagement() {
         return;
     }
 
-    double ratio = Limits.movestogo ? MAX(1.0, Limits.movestogo * 0.75)
-                                    : 30.0;
+    int mtg = Limits.movestogo ? MIN(Limits.movestogo, 50) : 50;
 
-    int timeThisMove = Limits.time / ratio + 1.5 * Limits.inc;
+    int timeLeft = MAX(0, Limits.time
+                        + Limits.inc * (mtg - 1)
+                        - overhead * (2 + mtg));
 
-    // Try to save at least 10ms for each move left to go
-    // as well as a buffer of 30ms, while using at least 10ms
-    Limits.maxUsage  = MAX(minTime, MIN(Limits.time - overhead - Limits.movestogo * minTime, timeThisMove));
+    double scale1 = MIN(0.5, 0.02 + ply * ply / 400000.0);
+    Limits.optimalUsage = MIN(0.2 * Limits.time, timeLeft * scale1);
+
+    double scale2 = MIN(0.5, 0.10 + ply * ply / 30000.0);
+    Limits.maxUsage = MIN(0.8 * Limits.time, timeLeft * scale2);
+
     Limits.timelimit = true;
+
+    // printf("Ply: %d, Time: %d, TimeLeft: %d, Scale1: %f, Opt: %d, Scale2: %f, Max: %d\n",
+    //     ply, Limits.time, timeLeft, scale1, Limits.optimalUsage, scale2, Limits.maxUsage);
 }
 
 // Root of search
 void SearchPosition(Position *pos, SearchInfo *info) {
 
-    InitTimeManagement();
+    InitTimeManagement(pos->gamePly);
 
     PrepareSearch(pos, info);
 
@@ -578,6 +585,10 @@ void SearchPosition(Position *pos, SearchInfo *info) {
         // Save bestMove and ponderMove before overwriting the pv next iteration
         info->bestMove   = info->pv.line[0];
         info->ponderMove = info->pv.length > 1 ? info->pv.line[1] : NOMOVE;
+
+        if (   Limits.timelimit
+            && TimeSince(Limits.start) > Limits.optimalUsage)
+            break;
 
         info->seldepth = 0;
     }

--- a/src/search.c
+++ b/src/search.c
@@ -533,11 +533,10 @@ static int AspirationWindow(Position *pos, SearchInfo *info) {
 static void InitTimeManagement(int ply) {
 
     const int overhead = 30;
-    const int minTime = 10;
 
     // In movetime mode we use all the time given each turn
     if (Limits.movetime) {
-        Limits.maxUsage = MAX(minTime, Limits.movetime - overhead);
+        Limits.maxUsage = Limits.optimalUsage = MAX(10, Limits.movetime - overhead);
         Limits.timelimit = true;
         return;
     }
@@ -554,16 +553,15 @@ static void InitTimeManagement(int ply) {
                         + Limits.inc * (mtg - 1)
                         - overhead * (2 + mtg));
 
+    // Time until we don't start the next depth iteration
     double scale1 = MIN(0.5, 0.02 + ply * ply / 400000.0);
     Limits.optimalUsage = MIN(0.2 * Limits.time, timeLeft * scale1);
 
+    // Time until we abort an iteration midway
     double scale2 = MIN(0.5, 0.10 + ply * ply / 30000.0);
     Limits.maxUsage = MIN(0.8 * Limits.time, timeLeft * scale2);
 
     Limits.timelimit = true;
-
-    // printf("Ply: %d, Time: %d, TimeLeft: %d, Scale1: %f, Opt: %d, Scale2: %f, Max: %d\n",
-    //     ply, Limits.time, timeLeft, scale1, Limits.optimalUsage, scale2, Limits.maxUsage);
 }
 
 // Root of search

--- a/src/types.h
+++ b/src/types.h
@@ -237,7 +237,8 @@ typedef struct {
 typedef struct {
 
     TimePoint start;
-    int time, inc, movestogo, movetime, depth, maxUsage;
+    int time, inc, movestogo, movetime, depth;
+    int optimalUsage, maxUsage;
     bool timelimit, infinite;
 
 } SearchLimits;


### PR DESCRIPTION
Based on a simplification of Stockfish' time management by @protonspring . 

Spends slightly less time early, then more in the middle game. Also introduces a new timing after which the next iteration of search will not be started. This leads to fewer aborted iterations which cannot change the chosen move and are thus less worthwhile.

ELO   | 57.21 +- 16.75 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 864 W: 293 L: 152 D: 419
http://chess.grantnet.us/test/5367/

ELO   | 36.02 +- 12.15 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1326 W: 348 L: 211 D: 767
http://chess.grantnet.us/test/5369/

ELO   | 27.91 +- 11.43 (95%)
SPRT  | 40/10.0s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1846 W: 552 L: 404 D: 890
http://chess.grantnet.us/test/5371/