### PR TITLE
Probe Syzygy DTZ in root

### DIFF
--- a/src/fathom/tbchess.c
+++ b/src/fathom/tbchess.c
@@ -485,7 +485,6 @@ static bool is_check(const Pos *pos)
 /*
  * Test if the position is valid.
  */
-#if 0
 static bool is_valid(const Pos *pos)
 {
     if (popcount(pos->kings) != 2)
@@ -534,7 +533,6 @@ static bool is_valid(const Pos *pos)
         return false;
     return is_legal(pos);
 }
-#endif
 
 #define do_bb_move(b, from, to)                                         \
     (((b) & (~board(to)) & (~board(from))) |                            \
@@ -606,7 +604,6 @@ static bool legal_move(const Pos *pos, TbMove move) {
 /*
  * Test if the king is in checkmate.
  */
-#if 0
 static bool is_mate(const Pos *pos)
 {
     if (!is_check(pos))
@@ -638,4 +635,3 @@ static TbMove *gen_legal(const Pos *pos, TbMove *moves)
   }
   return results;
 }
-#endif

--- a/src/fathom/tbprobe.c
+++ b/src/fathom/tbprobe.c
@@ -420,8 +420,8 @@ static int probe_wdl(Pos *pos, int *success);
 static int probe_dtz(Pos *pos, int *success);
 static int root_probe_wdl(const Pos *pos, bool useRule50, struct TbRootMoves *rm);
 static int root_probe_dtz(const Pos *pos, bool hasRepeated, bool useRule50, struct TbRootMoves *rm);
-static uint16_t probe_root(Pos *pos, int *score, unsigned *results);
 #endif
+static uint16_t probe_root(Pos *pos, int *score, unsigned *results);
 
 unsigned tb_probe_wdl_impl(
     uint64_t white,
@@ -456,7 +456,6 @@ unsigned tb_probe_wdl_impl(
     return (unsigned)(v + 2);
 }
 
-#if 0
 static unsigned dtz_to_wdl(int cnt50, int dtz)
 {
     int wdl = 0;
@@ -515,6 +514,7 @@ unsigned tb_probe_root_impl(
     return res;
 }
 
+#if 0
 int tb_probe_root_dtz(
     uint64_t white,
     uint64_t black,
@@ -1771,12 +1771,12 @@ static int probe_dtm_table(const Pos *pos, int won, int *success)
 {
   return probe_table(pos, won, success, DTM);
 }
+#endif
 
 static int probe_dtz_table(const Pos *pos, int wdl, int *success)
 {
   return probe_table(pos, wdl, success, DTZ);
 }
-#endif
 
 // probe_ab() is not called for positions with en passant captures.
 static int probe_ab(const Pos *pos, int alpha, int beta, int *success)
@@ -2078,6 +2078,7 @@ Value TB_probe_dtm2(const Pos *pos, int wdl, int *success)
   v = wdl > 0 ? TB_VALUE_MATE - 2 * dtm + 1 : -TB_VALUE_MATE + 2 * dtm;
   return max(bestCap,v);
 }
+#endif
 
 static int WdlToDtz[] = { -1, -101, 0, 101, 1 };
 
@@ -2197,6 +2198,7 @@ int probe_dtz(Pos *pos, int *success)
   return best;
 }
 
+#if 0
 // Use the DTZ tables to rank and score all root moves in the list.
 // A return value of 0 means that not all probes were successful.
 static int root_probe_dtz(const Pos *pos, bool hasRepeated, bool useRule50, struct TbRootMoves *rm)
@@ -2389,6 +2391,7 @@ void tb_expand_mate(Pos *pos, struct TbRootMove *move, Value moveScore, unsigned
   // Get back to the root position.
   *pos = root;
 }
+#endif
 
 static const int wdl_to_dtz[] =
 {
@@ -2518,4 +2521,3 @@ static uint16_t probe_root(Pos *pos, int *score, unsigned *results)
         return 0;
     }
 }
-#endif

--- a/src/fathom/tbprobe.h
+++ b/src/fathom/tbprobe.h
@@ -44,7 +44,6 @@ extern unsigned tb_probe_wdl_impl(
     unsigned _ep,
     bool     _turn);
 
-#if 0
 extern unsigned tb_probe_root_impl(
     uint64_t _white,
     uint64_t _black,
@@ -58,7 +57,7 @@ extern unsigned tb_probe_root_impl(
     unsigned _ep,
     bool     _turn,
     unsigned *_results);
-#endif
+
 
 /****************************************************************************/
 /* MAIN API                                                                 */
@@ -242,7 +241,7 @@ static inline unsigned tb_probe_wdl(
  * - This function is NOT thread safe.  For engines this function should only
  *   be called once at the root per search.
  */
-#if 0
+
 static inline unsigned tb_probe_root(
     uint64_t _white,
     uint64_t _black,
@@ -263,7 +262,7 @@ static inline unsigned tb_probe_root(
     return tb_probe_root_impl(_white, _black, _kings, _queens, _rooks,
         _bishops, _knights, _pawns, _rule50, _ep, _turn, _results);
 }
-#endif
+
 
 typedef uint16_t TbMove;
 

--- a/src/search.c
+++ b/src/search.c
@@ -594,10 +594,10 @@ void SearchPosition(Position *pos, SearchInfo *info) {
         info->seldepth = 0;
     }
 
+conclusion:
+
     // Wait for 'stop' in infinite search
     while (Limits.infinite && !ABORT_SIGNAL) {}
-
-conclusion:
 
     // Print conclusion
     PrintConclusion(info);

--- a/src/search.c
+++ b/src/search.c
@@ -572,6 +572,8 @@ void SearchPosition(Position *pos, SearchInfo *info) {
 
     PrepareSearch(pos, info);
 
+    if (RootProbe(pos, info)) goto conclusion;
+
     // Iterative deepening
     for (info->depth = 1; info->depth <= Limits.depth; ++info->depth) {
 
@@ -594,6 +596,8 @@ void SearchPosition(Position *pos, SearchInfo *info) {
 
     // Wait for 'stop' in infinite search
     while (Limits.infinite && !ABORT_SIGNAL) {}
+
+conclusion:
 
     // Print conclusion
     PrintConclusion(info);

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -89,7 +89,7 @@ bool RootProbe(Position *pos, SearchInfo *info) {
         || result == TB_RESULT_STALEMATE)
         return false;
 
-    unsigned wdl, dtz, from, to, ep, promo;
+    unsigned wdl, dtz, from, to, promo;
 
     // Extract information
     wdl   = TB_GET_WDL(result);


### PR DESCRIPTION
Probe Syzygy DTZ tablebases and use the recommended move in root when made to search a position found in the tablebases. This means Weiss won't mess up a win or draw, but it might not play the best defense when losing, choosing the slowest, but possibly trivially easy, loss over the most difficult.