### PR TITLE
Try killer moves before generating quiets

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -66,9 +66,7 @@ INLINE void AddMove(const Position *pos, MoveList *list, const Square from, cons
         *moveScore = MvvLvaScores[pieceOn(to)][pieceOn(from)];
 
     if (type == QUIET)
-        *moveScore = move == killer1 ? 900000
-                   : move == killer2 ? 800000
-                                     : pos->history[pieceOn(from)][to];
+        *moveScore = pos->history[pieceOn(from)][to];
 
     list->moves[list->count++].move = move;
 }

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -73,13 +73,15 @@ Move NextMove(MovePicker *mp) {
             // fall through
         case KILLER1:
             mp->stage++;
-            if (MoveIsPseudoLegal(mp->pos, mp->kill1))
+            if (   mp->kill1 != mp->ttMove
+                && MoveIsPseudoLegal(mp->pos, mp->kill1))
                 return mp->kill1;
 
             // fall through
         case KILLER2:
             mp->stage++;
-            if (MoveIsPseudoLegal(mp->pos, mp->kill2))
+            if (   mp->kill2 != mp->ttMove
+                && MoveIsPseudoLegal(mp->pos, mp->kill2))
                 return mp->kill2;
 
             // fall through

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -22,7 +22,7 @@
 
 
 // Return the next best move
-static Move PickNextMove(MoveList *list, const Move ttMove) {
+static Move PickNextMove(MoveList *list, const Move ttMove, const Move kill1, const Move kill2) {
 
     if (list->next == list->count)
         return NOMOVE;
@@ -39,8 +39,8 @@ static Move PickNextMove(MoveList *list, const Move ttMove) {
     list->moves[bestIdx] = list->moves[list->next++];
 
     // Avoid returning the ttMove again
-    if (bestMove == ttMove)
-        return PickNextMove(list, ttMove);
+    if (bestMove == ttMove || bestMove == kill1 || bestMove == kill2)
+        return PickNextMove(list, ttMove, kill1, kill2);
 
     return bestMove;
 }
@@ -65,10 +65,22 @@ Move NextMove(MovePicker *mp) {
 
             // fall through
         case NOISY:
-            if ((move = PickNextMove(mp->list, mp->ttMove)))
+            if ((move = PickNextMove(mp->list, mp->ttMove, NOMOVE, NOMOVE)))
                 return move;
 
             mp->stage++;
+
+            // fall through
+        case KILLER1:
+            mp->stage++;
+            if (MoveIsPseudoLegal(mp->pos, mp->kill1))
+                return mp->kill1;
+
+            // fall through
+        case KILLER2:
+            mp->stage++;
+            if (MoveIsPseudoLegal(mp->pos, mp->kill2))
+                return mp->kill2;
 
             // fall through
         case GEN_QUIET:
@@ -80,7 +92,7 @@ Move NextMove(MovePicker *mp) {
 
             // fall through
         case QUIET:
-            return PickNextMove(mp->list, mp->ttMove);
+            return PickNextMove(mp->list, mp->ttMove, mp->kill1, mp->kill2);
 
         default:
             assert(0);
@@ -89,12 +101,14 @@ Move NextMove(MovePicker *mp) {
 }
 
 // Init normal movepicker
-void InitNormalMP(MovePicker *mp, MoveList *list, Position *pos, Move ttMove) {
+void InitNormalMP(MovePicker *mp, MoveList *list, Position *pos, Move ttMove, Move kill1, Move kill2) {
     list->count   = list->next = 0;
     mp->list      = list;
     mp->pos       = pos;
     mp->ttMove    = MoveIsPseudoLegal(mp->pos, ttMove) ? ttMove : NOMOVE;
     mp->stage     = mp->ttMove ? TTMOVE : GEN_NOISY;
+    mp->kill1     = kill1;
+    mp->kill2     = kill2;
     mp->onlyNoisy = false;
 }
 
@@ -104,6 +118,8 @@ void InitNoisyMP(MovePicker *mp, MoveList *list, Position *pos) {
     mp->list      = list;
     mp->pos       = pos;
     mp->ttMove    = NOMOVE;
+    mp->kill1     = NOMOVE;
+    mp->kill2     = NOMOVE;
     mp->stage     = GEN_NOISY;
     mp->onlyNoisy = true;
 }

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -20,18 +20,18 @@
 
 
 typedef enum MPStage {
-    TTMOVE, GEN_NOISY, NOISY, GEN_QUIET, QUIET
+    TTMOVE, GEN_NOISY, NOISY, KILLER1, KILLER2, GEN_QUIET, QUIET
 } MPStage;
 
 typedef struct MovePicker {
     Position *pos;
     MoveList *list;
     MPStage stage;
-    Move ttMove;
+    Move ttMove, kill1, kill2;
     bool onlyNoisy;
 } MovePicker;
 
 
 Move NextMove(MovePicker *mp);
-void InitNormalMP(MovePicker *mp, MoveList *list, Position *pos, Move ttMove);
+void InitNormalMP(MovePicker *mp, MoveList *list, Position *pos, Move ttMove, Move kill1, Move kill2);
 void InitNoisyMP(MovePicker *mp, MoveList *list, Position *pos);

--- a/src/search.c
+++ b/src/search.c
@@ -370,7 +370,7 @@ static int AlphaBeta(Position *pos, SearchInfo *info, int alpha, int beta, Depth
 
 move_loop:
 
-    InitNormalMP(&mp, &list, pos, ttMove);
+    InitNormalMP(&mp, &list, pos, ttMove, killer1, killer2);
 
     const int oldAlpha = alpha;
     int moveCount = 0, quietCount = 0;


### PR DESCRIPTION
Move killer move logic from movegen to movepicker. No need to generate quiet moves before trying them. Fixes moves with very good history being tried before killers (even if killers had better history).

ELO   | 7.35 +- 5.56 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 7280 W: 1847 L: 1693 D: 3740
http://chess.grantnet.us/test/5504/