### PR TITLE
Move scoring to movepicker

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -26,20 +26,6 @@
 
 enum { QUIET, NOISY };
 
-#ifndef NDEBUG
-static bool MoveListOk(const MoveList *list, const Position *pos) {
-
-    if (list->count >= MAXPOSITIONMOVES)
-        return false;
-
-    for (int i = 0; i < list->count; ++i)
-        if (!MoveIsPseudoLegal(pos, list->moves[i].move))
-            return PrintBoard(pos), false;
-
-    return true;
-}
-#endif
-
 // Constructs and adds a move to the move list
 INLINE void AddMove(const Position *pos, MoveList *list, const Square from, const Square to, const Piece promo, const int flag) {
 
@@ -183,8 +169,6 @@ static void GenMoves(const Position *pos, MoveList *list, const Color color, con
     GenPieceType(pos, list, color, type, BISHOP);
     GenPieceType(pos, list, color, type, QUEEN);
     GenPieceType(pos, list, color, type, KING);
-
-    assert(MoveListOk(list, pos));
 }
 
 // Generate quiet moves

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -30,8 +30,8 @@ CONSTR InitMvvLva() {
     const int VictimScore[PIECE_NB]   = {0, 106, 206, 306, 406, 506, 606, 0, 0, 106, 206, 306, 406, 506, 606, 0};
     const int AttackerScore[PIECE_NB] = {0,   1,   2,   3,   4,   5,   6, 0, 0,   1,   2,   3,   4,   5,   6, 0};
 
-    for (Piece Attacker = PIECE_MIN; Attacker < PIECE_NB; ++Attacker)
-        for (Piece Victim = PIECE_MIN; Victim < PIECE_NB; ++Victim)
+    for (Piece Attacker = EMPTY; Attacker < PIECE_NB; ++Attacker)
+        for (Piece Victim = EMPTY; Victim < PIECE_NB; ++Victim)
             MvvLvaScores[Victim][Attacker] = VictimScore[Victim] - AttackerScore[Attacker];
 }
 

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -52,7 +52,7 @@ static Move PickNextMove(MoveList *list, const Move ttMove, const Move kill1, co
     Move bestMove = list->moves[bestIdx].move;
     list->moves[bestIdx] = list->moves[list->next++];
 
-    // Avoid returning the ttMove again
+    // Avoid returning the TT or killer moves again
     if (bestMove == ttMove || bestMove == kill1 || bestMove == kill2)
         return PickNextMove(list, ttMove, kill1, kill2);
 

--- a/src/types.h
+++ b/src/types.h
@@ -97,7 +97,7 @@ enum PieceType {
 };
 
 enum Piece {
-    EMPTY = 0, ALL = 0, PIECE_MIN,
+    EMPTY = 0, ALL = 0,
     bP = 1, bN, bB, bR, bQ, bK,
     wP = 9, wN, wB, wR, wQ, wK,
     PIECE_NB = 16

--- a/src/types.h
+++ b/src/types.h
@@ -93,11 +93,11 @@ enum Color {
 };
 
 enum PieceType {
-    NO_TYPE, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING, TYPE_NB = 8
+    ALL, PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING, TYPE_NB = 8
 };
 
 enum Piece {
-    EMPTY = 0, ALL = 0,
+    EMPTY,
     bP = 1, bN, bB, bR, bQ, bK,
     wP = 9, wN, wB, wR, wQ, wK,
     PIECE_NB = 16


### PR DESCRIPTION
Move the scoring of moves out of movegen and into movepicker. Underpromotions now scored by history rather than MvvLva.

Plus a few small cleanups.

ELO   | 5.27 +- 4.79 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 9888 W: 2498 L: 2348 D: 5042
http://chess.grantnet.us/test/5521/

ELO   | 1.01 +- 2.34 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.02 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 34539 W: 7121 L: 7021 D: 20397
http://chess.grantnet.us/test/5522/