### PR TITLE
Speedup make/takemove

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -70,7 +70,7 @@ CONSTR InitHashKeys() {
     SideKey = Rand64();
 
     // En passant
-    for (Square sq = A1; sq <= H8; ++sq)
+    for (Square sq = A3; sq <= H6; ++sq)
         PieceKeys[0][sq] = Rand64();
 
     // White pieces

--- a/src/board.c
+++ b/src/board.c
@@ -106,8 +106,7 @@ static Key GeneratePosKey(const Position *pos) {
         posKey ^= SideKey;
 
     // En passant
-    if (pos->epSquare)
-        posKey ^= PieceKeys[EMPTY][pos->epSquare];
+    posKey ^= PieceKeys[EMPTY][pos->epSquare];
 
     // Castling rights
     posKey ^= CastleKeys[pos->castlingRights];

--- a/src/board.c
+++ b/src/board.c
@@ -106,7 +106,7 @@ static Key GeneratePosKey(const Position *pos) {
         posKey ^= SideKey;
 
     // En passant
-    if (pos->epSquare != NO_SQ)
+    if (pos->epSquare)
         posKey ^= PieceKeys[EMPTY][pos->epSquare];
 
     // Castling rights
@@ -242,8 +242,7 @@ void ParseFen(const char *fen, Position *pos) {
     Square ep = AlgebraicToSq(fen[0], fen[1]);
     bool epValid = *fen != '-' && (  PawnAttackBB(!sideToMove, ep)
                                    & colorPieceBB(sideToMove, PAWN));
-    pos->epSquare = epValid ? ep
-                            : NO_SQ;
+    pos->epSquare = epValid ? ep : 0;
     fen += 2;
 
     // 50 move rule
@@ -307,7 +306,7 @@ void PrintBoard(const Position *pos) {
     }
 
     char ep[3] = "-";
-    if (pos->epSquare != NO_SQ)
+    if (pos->epSquare)
         ep[0] = 'a' + FileOf(pos->epSquare),
         ep[1] = '1' + RankOf(pos->epSquare);
 
@@ -359,7 +358,7 @@ bool PositionOk(const Position *pos) {
 
     assert(sideToMove == WHITE || sideToMove == BLACK);
 
-    assert(pos->epSquare == NO_SQ
+    assert(!pos->epSquare
        || (RelativeRank(sideToMove, RankOf(pos->epSquare)) == RANK_6));
 
     assert(pos->castlingRights >= 0
@@ -383,7 +382,7 @@ void MirrorBoard(Position *pos) {
         board[sq] = MirrorPiece(pieceOn(MirrorSquare(sq)));
 
     Color stm = !sideToMove;
-    Square ep = pos->epSquare == NO_SQ ? NO_SQ : MirrorSquare(pos->epSquare);
+    Square ep = pos->epSquare == 0 ? 0 : MirrorSquare(pos->epSquare);
     uint8_t cr = (pos->castlingRights & WHITE_CASTLE) << 2
                | (pos->castlingRights & BLACK_CASTLE) >> 2;
 

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -199,10 +199,9 @@ bool MakeMove(Position *pos, const Move move) {
     pos->ply++;
     pos->rule50++;
 
-    // Hash out the old en passant if exist and unset it
-    if (pos->epSquare)
-        HASH_EP,
-        pos->epSquare = 0;
+    // Hash out en passant if there was one, and unset it
+    HASH_EP,
+    pos->epSquare = 0;
 
     const Square from = fromSq(move);
     const Square to = toSq(move);
@@ -292,9 +291,8 @@ void MakeNullMove(Position *pos) {
     HASH_SIDE;
 
     // Hash out en passant if there was one, and unset it
-    if (pos->epSquare)
-        HASH_EP,
-        pos->epSquare = 0;
+    HASH_EP,
+    pos->epSquare = 0;
 
     assert(PositionOk(pos));
 }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -154,8 +154,7 @@ void TakeMove(Position *pos) {
             case C1: MovePiece(pos, D1, A1, false); break;
             case C8: MovePiece(pos, D8, A8, false); break;
             case G1: MovePiece(pos, F1, H1, false); break;
-            case G8: MovePiece(pos, F8, H8, false); break;
-            default: assert(false); break;
+            default: MovePiece(pos, F8, H8, false); break;
         }
 
     // Make reverse move (from <-> to)
@@ -256,8 +255,7 @@ bool MakeMove(Position *pos, const Move move) {
             case C1: MovePiece(pos, A1, D1, true); break;
             case C8: MovePiece(pos, A8, D8, true); break;
             case G1: MovePiece(pos, H1, F1, true); break;
-            case G8: MovePiece(pos, H8, F8, true); break;
-            default: assert(false); break;
+            default: MovePiece(pos, H8, F8, true); break;
         }
 
     // Change turn to play

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -213,16 +213,6 @@ bool MakeMove(Position *pos, const Move move) {
     pos->castlingRights &= CastlePerm[from] & CastlePerm[to];
     HASH_CA;
 
-    // Move the rook during castling
-    if (moveIsCastle(move))
-        switch (to) {
-            case C1: MovePiece(pos, A1, D1, true); break;
-            case C8: MovePiece(pos, A8, D8, true); break;
-            case G1: MovePiece(pos, H1, F1, true); break;
-            case G8: MovePiece(pos, H8, F8, true); break;
-            default: assert(false); break;
-        }
-
     // Remove captured piece if any
     Piece capt = capturing(move);
     if (capt != EMPTY) {
@@ -259,7 +249,16 @@ bool MakeMove(Position *pos, const Move move) {
             ClearPiece(pos, to, true);
             AddPiece(pos, to, promo, true);
         }
-    }
+
+    // Move the rook during castling
+    } else if (moveIsCastle(move))
+        switch (to) {
+            case C1: MovePiece(pos, A1, D1, true); break;
+            case C8: MovePiece(pos, A8, D8, true); break;
+            case G1: MovePiece(pos, H1, F1, true); break;
+            case G8: MovePiece(pos, H8, F8, true); break;
+            default: assert(false); break;
+        }
 
     // Change turn to play
     sideToMove ^= 1;

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -200,9 +200,9 @@ bool MakeMove(Position *pos, const Move move) {
     pos->rule50++;
 
     // Hash out the old en passant if exist and unset it
-    if (pos->epSquare != NO_SQ)
+    if (pos->epSquare)
         HASH_EP,
-        pos->epSquare = NO_SQ;
+        pos->epSquare = 0;
 
     const Square from = fromSq(move);
     const Square to = toSq(move);
@@ -292,9 +292,9 @@ void MakeNullMove(Position *pos) {
     HASH_SIDE;
 
     // Hash out en passant if there was one, and unset it
-    if (pos->epSquare != NO_SQ)
+    if (pos->epSquare)
         HASH_EP,
-        pos->epSquare = NO_SQ;
+        pos->epSquare = 0;
 
     assert(PositionOk(pos));
 }

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -200,7 +200,7 @@ bool MakeMove(Position *pos, const Move move) {
     pos->rule50++;
 
     // Hash out en passant if there was one, and unset it
-    HASH_EP,
+    HASH_EP;
     pos->epSquare = 0;
 
     const Square from = fromSq(move);
@@ -291,7 +291,7 @@ void MakeNullMove(Position *pos) {
     HASH_SIDE;
 
     // Hash out en passant if there was one, and unset it
-    HASH_EP,
+    HASH_EP;
     pos->epSquare = 0;
 
     assert(PositionOk(pos));

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -208,13 +208,10 @@ bool MakeMove(Position *pos, const Move move) {
     const Square from = fromSq(move);
     const Square to = toSq(move);
 
-    // Rehash the castling rights if at least one side can castle,
-    // and either the to or from square is the original square of
-    // a king or rook.
-    if (pos->castlingRights && CastlePerm[from] ^ CastlePerm[to])
-        HASH_CA,
-        pos->castlingRights &= CastlePerm[from] & CastlePerm[to],
-        HASH_CA;
+    // Rehash the castling rights
+    HASH_CA;
+    pos->castlingRights &= CastlePerm[from] & CastlePerm[to];
+    HASH_CA;
 
     // Move the rook during castling
     if (moveIsCastle(move))

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -131,7 +131,7 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const Color color, cons
             AddMove(pos, list, to - (up+right), to, EMPTY, FLAG_NONE);
         }
         // En passant
-        if (pos->epSquare != NO_SQ) {
+        if (pos->epSquare) {
             Bitboard enPassers = not7th & PawnAttackBB(!color, pos->epSquare);
             while (enPassers)
                 AddMove(pos, list, PopLsb(&enPassers), pos->epSquare, EMPTY, FLAG_ENPAS);

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -41,11 +41,11 @@ bool ProbeWDL(const Position *pos, int *score, int *bound) {
     // possible, or when 50 move rule was not reset by the last move.
     // Finally, there is obviously no point if there are more pieces than
     // we have TBs for.
-    if (   (pos->ply            == 0)
-        || (pos->epSquare       != NO_SQ)
-        || (pos->castlingRights != 0)
-        || (pos->rule50         != 0)
-        || ((unsigned)PopCount(pieceBB(ALL)) > TB_LARGEST))
+    if (   !pos->ply
+        ||  pos->epSquare
+        ||  pos->castlingRights
+        ||  pos->rule50
+        || (unsigned)PopCount(pieceBB(ALL)) > TB_LARGEST)
         return false;
 
     // Call fathom
@@ -84,9 +84,7 @@ bool RootProbe(Position *pos, SearchInfo *info) {
         pieceBB(KING),   pieceBB(QUEEN),
         pieceBB(ROOK),   pieceBB(BISHOP),
         pieceBB(KNIGHT), pieceBB(PAWN),
-        pos->rule50,
-        pos->epSquare != NO_SQ ? pos->epSquare : 0,
-        sideToMove);
+        pos->rule50, pos->epSquare, sideToMove);
 
     // Probe failed
     if (   result == TB_RESULT_FAILED

--- a/src/types.h
+++ b/src/types.h
@@ -131,7 +131,7 @@ enum Square {
     A5, B5, C5, D5, E5, F5, G5, H5,
     A6, B6, C6, D6, E6, F6, G6, H6,
     A7, B7, C7, D7, E7, F7, G7, H7,
-    A8, B8, C8, D8, E8, F8, G8, H8, NO_SQ = 99
+    A8, B8, C8, D8, E8, F8, G8, H8
 };
 
 typedef enum Direction {

--- a/src/uci.c
+++ b/src/uci.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv) {
     // Benchmark
     if (argc > 1 && strstr(argv[1], "bench")) {
         InitTT();
-        Benchmark(pos, info, argc > 2 ? atoi(argv[2]) : 13);
+        Benchmark(pos, info, argc > 2 ? atoi(argv[2]) : 15);
         return 0;
     }
 


### PR DESCRIPTION
Reduce branching. Slightly cleaner code.

ELO   | 9.94 +- 6.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 5664 W: 1530 L: 1368 D: 2766
http://chess.grantnet.us/test/5531/