### PR TITLE
Allow changing hash size for bench

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -46,10 +46,11 @@ static const char *BenchmarkFENs[] = {
 
 void Benchmark(int argc, char **argv) {
 
-    // Default depth 15, with 1 thread
-    Limits.depth     = argc > 2 ? atoi(argv[2]) : 15;
+    // Default depth 15, 1 thread, and 32MB hash
     Limits.timelimit = false;
+    Limits.depth     = argc > 2 ? atoi(argv[2]) : 15;
     int threadCount  = argc > 3 ? atoi(argv[3]) : 1;
+    TT.requestedMB   = argc > 4 ? atoi(argv[4]) : DEFAULTHASH;
 
     Position pos;
     Thread *threads = InitThreads(threadCount);


### PR DESCRIPTION
Can set hash size for bench by ./weiss bench [depth] [threads] [hash].

No functional change.