### PR TITLE
Add doubled pawns to evaluation

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -44,6 +44,7 @@ tuneable_const int Tempo = 20;
 
 // Misc bonuses and maluses
 tuneable_static_const int PawnIsolated   = S(-28,-16);
+tuneable_static_const int PawnDoubled    = S( -6,-32);
 tuneable_static_const int BishopPair     = S( 52, 72);
 tuneable_static_const int KingLineDanger = S(-12,  4);
 
@@ -123,9 +124,13 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
 
     int eval = 0;
 
-    Bitboard pieces = colorPieceBB(color, PAWN);
-    while (pieces) {
-        Square sq = PopLsb(&pieces);
+    Bitboard pawns = colorPieceBB(color, PAWN);
+
+    // Doubled pawns
+    eval += PawnDoubled * PopCount(pawns & ShiftBB(NORTH, pawns));
+
+    while (pawns) {
+        Square sq = PopLsb(&pawns);
 
         // Isolation penalty
         if (!(IsolatedMask[sq] & colorPieceBB(color, PAWN)))

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -43,8 +43,8 @@ tuneable_const int PieceValue[2][PIECE_NB] = {
 tuneable_const int Tempo = 20;
 
 // Misc bonuses and maluses
-tuneable_static_const int PawnIsolated   = S(-28,-16);
 tuneable_static_const int PawnDoubled    = S( -6,-32);
+tuneable_static_const int PawnIsolated   = S(-28,-16);
 tuneable_static_const int BishopPair     = S( 52, 72);
 tuneable_static_const int KingLineDanger = S(-12,  4);
 

--- a/src/tune.c
+++ b/src/tune.c
@@ -24,7 +24,7 @@
 #include "evaluate.h"
 
 
-enum { NAME_MAX_CHAR = 64, PARSER_ENTRY_NB = 19 };
+enum { NAME_MAX_CHAR = 64, PARSER_ENTRY_NB = 20 };
 
 typedef struct ParserEntry {
     char name[NAME_MAX_CHAR];
@@ -41,6 +41,7 @@ extern int PieceTypeValue[7];
 extern int PieceSqValue[7][64];
 
 // Misc
+extern int PawnDoubled;
 extern int PawnIsolated;
 extern int BishopPair;
 extern int KingLineDanger;
@@ -100,6 +101,7 @@ void TuneDeclareAll() {
     // Passed pawn
     Declare(pe++, "Passed", &PawnPassed[1], 6);
     // Misc
+    Declare(pe++, "Doubled",  &PawnDoubled,   1);
     Declare(pe++, "Isolated", &PawnIsolated,   1);
     Declare(pe++, "BPair",    &BishopPair,     1);
     Declare(pe++, "KLDanger", &KingLineDanger, 1);


### PR DESCRIPTION
Pawns on the same file are generally less effective than on separate files. This patch gives a penalty for having doubled pawns when one is right in front of the other.

ELO   | 4.42 +- 3.52 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 18880 W: 4889 L: 4649 D: 9342
http://chess.grantnet.us/test/5767/

ELO   | 3.61 +- 2.89 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23984 W: 5308 L: 5059 D: 13617
http://chess.grantnet.us/test/5768/