### PR TITLE
ProbCut pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -369,6 +369,34 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
         }
     }
 
+    // ProbCut
+    if (  !pvNode
+        && depth >= 5
+        && abs(beta) < TBWIN_IN_MAX) {
+
+        int pbBeta = beta + 200;
+
+        MovePicker pbMP;
+        MoveList pbList;
+        InitNoisyMP(&pbMP, &pbList, thread);
+
+        Move pbMove;
+        while ((pbMove = NextMove(&pbMP))) {
+
+            if (!MakeMove(pos, pbMove)) continue;
+
+            int pbScore = -Quiescence(thread, -pbBeta, -pbBeta+1);
+
+            if (pbScore >= pbBeta)
+                pbScore = -AlphaBeta(thread, -pbBeta, -pbBeta+1, depth-4, &pvFromHere);
+
+            TakeMove(pos);
+
+            if (pbScore >= pbBeta)
+                return pbScore;
+        }
+    }
+
     // Internal iterative deepening
     if (depth >= 4 && !ttMove) {
 


### PR DESCRIPTION
A shorter search is a decent predictor for the result of the full-depth search we are about to make. If a shorter search shows a result sufficiently higher than beta, we can assume the full-depth search would also score above beta and prune the node immediately.

ELO   | 6.36 +- 4.59 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10928 W: 2814 L: 2614 D: 5500
http://chess.grantnet.us/test/5806/

ELO   | 6.65 +- 4.63 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9098 W: 2006 L: 1832 D: 5260
http://chess.grantnet.us/test/5808/