### PR TITLE
Improve NMP logic

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -280,7 +280,8 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
         && history(-1).move != NOMOVE
         && eval >= beta
         && pos->nonPawnCount[sideToMove] > 0
-        && depth >= 3) {
+        && depth >= 3
+        && (!ttHit || ttScore >= beta)) {
 
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 

--- a/src/search.c
+++ b/src/search.c
@@ -281,7 +281,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
         && eval >= beta
         && pos->nonPawnCount[sideToMove] > 0
         && depth >= 3
-        && (!ttHit || ttScore >= beta || tte->depth < depth)) {
+        && (!ttHit || !(tte->bound & BOUND_UPPER) || ttScore >= beta)) {
 
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 

--- a/src/search.c
+++ b/src/search.c
@@ -281,7 +281,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
         && eval >= beta
         && pos->nonPawnCount[sideToMove] > 0
         && depth >= 3
-        && (!ttHit || ttScore >= beta)) {
+        && (!ttHit || ttScore >= beta || tte->depth < depth)) {
 
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 


### PR DESCRIPTION
Avoid trying null move pruning if the transposition table indicates it will likely fail.

ELO   | 4.01 +- 3.21 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 22536 W: 5771 L: 5511 D: 11254
http://chess.grantnet.us/test/5863/

ELO   | 7.62 +- 5.06 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7520 W: 1645 L: 1480 D: 4395
http://chess.grantnet.us/test/5865/