### PR TITLE
Bench 41123182

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -124,8 +124,6 @@ static int Quiescence(Thread *thread, int alpha, const int beta) {
 
     int futility = score + P_EG;
 
-    const bool inCheck = KingAttacked(pos, sideToMove);
-
     InitNoisyMP(&mp, &list, thread);
 
     int bestScore = score;
@@ -134,8 +132,7 @@ static int Quiescence(Thread *thread, int alpha, const int beta) {
     Move move;
     while ((move = NextMove(&mp))) {
 
-        if (   !inCheck
-            && futility + PieceValue[EG][pieceOn(toSq(move))] <= alpha
+        if (   futility + PieceValue[EG][pieceOn(toSq(move))] <= alpha
             && !(  PieceTypeOf(pieceOn(fromSq(move))) == PAWN
                 && RelativeRank(sideToMove, RankOf(toSq(move))) > 5))
             continue;


### PR DESCRIPTION
Weiss doesn't try all moves when in check in quiescence search, so there's no point avoiding pruning as we're not proving checkmates either way.

ELO   | 4.96 +- 4.70 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 10378 W: 2647 L: 2499 D: 5232
http://chess.grantnet.us/test/5876/

ELO   | 2.35 +- 3.22 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 18771 W: 4008 L: 3881 D: 10882
http://chess.grantnet.us/test/5877/