### PR TITLE
Graceful exit

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -201,12 +201,12 @@ int main(int argc, char **argv) {
         switch (HashInput(str)) {
             case GO         : UCIGo(&engine, str);        break;
             case UCI        : UCIInfo();                  break;
-            case STOP       : UCIStop(&engine);           break;
             case ISREADY    : UCIIsReady();               break;
             case POSITION   : UCIPosition(pos, str);      break;
             case SETOPTION  : UCISetOption(&engine, str); break;
             case UCINEWGAME : UCINewGame();               break;
-            case QUIT       : return 0;
+            case STOP       : UCIStop(&engine);           break;
+            case QUIT       : UCIStop(&engine);           return 0;
 #ifdef DEV
             // Non-UCI commands
             case EVAL       : PrintEval(pos);      break;


### PR DESCRIPTION
Signal search thread(s) to abort searching and wait for them to finish before exiting. The destructor for the TT would free the TT memory when the main thread exited, while search threads were still going, causing them to access free'd memory and crashing.