### PR TITLE
Graceful exit 2

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -129,10 +129,3 @@ void InitTT() {
     printf("HashTable init complete with %" PRI_SIZET " entries, using %" PRI_SIZET "MB.\n", TT.count, MB);
     fflush(stdout);
 }
-
-// Free allocated memory (if any) before exiting
-DESTR FreeTT() {
-
-    if (TT.mem)
-        free(TT.mem);
-}

--- a/src/types.h
+++ b/src/types.h
@@ -45,7 +45,6 @@
 
 #define INLINE static inline __attribute__((always_inline))
 #define CONSTR static __attribute__((constructor)) void
-#define DESTR static __attribute__((destructor)) void
 
 #define lastMoveNullMove (!root && history(-1).move == NOMOVE)
 #define history(offset) (pos->gameHistory[pos->gamePly + offset])


### PR DESCRIPTION
The last patch fixed the case when Weiss is killed by sending it 'quit', but it did not fix segfaulting when killed by ctrl+c. This destructor is more hassle than being nice and freeing allocated memory on exit is worth - any modern OS will free everything when the program exits anyway so I will just remove it.