### PR TITLE
Multi-threaded TT clear

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -54,7 +54,7 @@ void Benchmark(int argc, char **argv) {
 
     Position pos;
     Thread *threads = InitThreads(threadCount);
-    InitTT();
+    InitTT(threads);
 
     uint64_t nodes = 0;
     TimePoint elapsed = 1; // To avoid possible div/0
@@ -67,7 +67,7 @@ void Benchmark(int argc, char **argv) {
         SearchPosition(&pos, threads);
         elapsed += TimeSince(Limits.start);
         nodes += TotalNodes(threads);
-        ClearTT();
+        ClearTT(threads);
     }
 
     printf("Benchmark complete:"

--- a/src/threads.c
+++ b/src/threads.c
@@ -27,12 +27,10 @@ Thread *InitThreads(int count) {
 
     Thread *threads = calloc(count, sizeof(Thread));
 
-    // Each thread knows its own index
+    // Each thread knows its own index and total thread count
     for (int i = 0; i < count; ++i)
-        threads[i].index = i;
-
-    // The main thread keeps track of how many threads are in use
-    threads[0].count = count;
+        threads[i].index = i,
+        threads[i].count = count;
 
     // Used for letting the main thread sleep
     pthread_mutex_init(&threads->mutex, NULL);

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -86,5 +86,5 @@ INLINE TTEntry *GetEntry(Key posKey) {
 TTEntry* ProbeTT(Key posKey, bool *ttHit);
 void StoreTTEntry(TTEntry *tte, Key posKey, Move move, int score, Depth depth, int bound);
 int HashFull();
-void ClearTT();
-void InitTT();
+void ClearTT(Thread *threads);
+void InitTT(Thread *threads);

--- a/src/uci.c
+++ b/src/uci.c
@@ -161,15 +161,15 @@ static void UCIStop(Engine *engine) {
 }
 
 // Signals the engine is ready
-static void UCIIsReady() {
-    InitTT();
+static void UCIIsReady(Engine *engine) {
+    InitTT(engine->threads);
     printf("readyok\n");
     fflush(stdout);
 }
 
 // Reset for a new game
-static void UCINewGame() {
-    ClearTT();
+static void UCINewGame(Engine *engine) {
+    ClearTT(engine->threads);
     failedQueries = 0;
 }
 
@@ -202,10 +202,10 @@ int main(int argc, char **argv) {
         switch (HashInput(str)) {
             case GO         : UCIGo(&engine, str);        break;
             case UCI        : UCIInfo();                  break;
-            case ISREADY    : UCIIsReady();               break;
+            case ISREADY    : UCIIsReady(&engine);        break;
             case POSITION   : UCIPosition(pos, str);      break;
             case SETOPTION  : UCISetOption(&engine, str); break;
-            case UCINEWGAME : UCINewGame();               break;
+            case UCINEWGAME : UCINewGame(&engine);        break;
             case STOP       : UCIStop(&engine);           break;
             case QUIT       : UCIStop(&engine);           return 0;
 #ifdef DEV


### PR DESCRIPTION
When search is allowed multiple threads, use the same amount to clear the transposition table. Should reduce initialization time when using big transposition table.