### PR TITLE
Fix syzygy init bug

### DIFF
--- a/src/fathom/tbprobe.c
+++ b/src/fathom/tbprobe.c
@@ -904,16 +904,17 @@ bool tb_init(const char *path)
           }
 
 finished:
-  /* TBD - assumes UCI
-  printf("info string Found %d WDL, %d DTM and %d DTZ tablebase files.\n",
-      numWdl, numDtm, numDtz);
-  fflush(stdout);
-  */
+
   // Set TB_LARGEST, for backward compatibility with pre-7-man Fathom
   TB_LARGEST = (unsigned)TB_MaxCardinality;
   if ((unsigned)TB_MaxCardinalityDTM > TB_LARGEST) {
     TB_LARGEST = TB_MaxCardinalityDTM;
   }
+
+  printf("info string Found %d WDL, %d DTM and %d DTZ tablebase files. Largest %u-men.\n",
+      numWdl, numDtm, numDtz, TB_LARGEST);
+  fflush(stdout);
+
   return true;
 }
 

--- a/src/fathom/tbprobe.c
+++ b/src/fathom/tbprobe.c
@@ -752,6 +752,8 @@ bool tb_init(const char *path)
     initialized = 1;
   }
 
+  TB_LARGEST = 0;
+
   // if pathString is set, we need to clean up first.
   if (pathString) {
     free(pathString);
@@ -794,7 +796,6 @@ bool tb_init(const char *path)
 
   tbNumPiece = tbNumPawn = 0;
   TB_MaxCardinality = TB_MaxCardinalityDTM = 0;
-  TB_LARGEST = 0;
 
   if (!pieceEntry) {
     pieceEntry = (struct PieceEntry*)malloc(TB_MAX_PIECE * sizeof(*pieceEntry));

--- a/src/uci.c
+++ b/src/uci.c
@@ -125,9 +125,6 @@ static void UCISetOption(Engine *engine, char *str) {
 
         tb_init(OptionValue(str));
 
-        TB_LARGEST ? printf("TableBase init success - largest found: %d.\n", TB_LARGEST)
-                   : printf("TableBase init failure - not found.\n");
-
     // Toggles probing of Chess Cloud Database
     } else if (OptionName(str, "NoobBook")) {
 


### PR DESCRIPTION
Unsetting the syzygy path after setting it once left TB_LARGEST as non-0. Fixed this and switched to using the internal init print of fathom with more details.