### PR TITLE
Fix crashing if 'quit' given directly after TT init

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -109,6 +109,8 @@ void ClearTT(Thread *threads) {
     for (int i = 0; i < threads->count; ++i)
         pthread_join(threads->pthreads[i], NULL);
 
+    threads->pthreads[0] = 0;
+
     TT.dirty = false;
 }
 


### PR DESCRIPTION
Quit would join a thread that had already been joined if given directly after a TT init occured.