### PR TITLE
Fix SMP + TB bug

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -566,11 +566,10 @@ conclusion:
     if (Limits.infinite) Wait(threads, &ABORT_SIGNAL);
 
     // Signal any extra threads to stop and wait for them
-    if (threadsSpawned) {
-        ABORT_SIGNAL = true;
+    ABORT_SIGNAL = true;
+    if (threadsSpawned)
         for (int i = 1; i < threads->count; ++i)
             pthread_join(threads->pthreads[i], NULL);
-    }
 
     // Print conclusion
     PrintConclusion(threads);


### PR DESCRIPTION
Fixed a bug where threads that had already been joined were joined again when a move was gotten from DTZ tablebases or NoobBook.