### PR TITLE
Quiet history malus

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -359,7 +359,7 @@ move_loop:
 
         // Increment counts
         moveCount++;
-        if (quiet)
+        if (quiet && quietCount < 32)
             quiets[quietCount++] = move;
 
         const Depth newDepth = depth - 1;


### PR DESCRIPTION
Give a malus to quiet moves that failed to produce a cutoff if another quiet move manages to produce one.

ELO   | 37.49 +- 12.19 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1228 W: 308 L: 176 D: 744
http://chess.grantnet.us/test/6067/