### PR TITLE
Spend more time when uncertain

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -521,12 +521,14 @@ static void *IterativeDeepening(void *voidThread) {
         // Only the main thread concerns itself with the rest
         if (!mainThread) continue;
 
+        bool uncertain = thread->pv.line[0] != thread->bestMove;
+
         // Save bestMove and ponderMove before overwriting the pv next iteration
         thread->bestMove   = thread->pv.line[0];
         thread->ponderMove = thread->pv.length > 1 ? thread->pv.line[1] : NOMOVE;
 
         if (   Limits.timelimit
-            && TimeSince(Limits.start) > Limits.optimalUsage)
+            && TimeSince(Limits.start) > Limits.optimalUsage * (1 + uncertain))
             break;
 
         thread->seldepth = 0;


### PR DESCRIPTION
Whenever the best move returned by search is different from the previous iteration, allocate more time to keep searching.

ELO   | 7.42 +- 5.11 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8472 W: 2113 L: 1932 D: 4427
http://chess.grantnet.us/test/6089/

ELO   | 2.91 +- 2.31 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 35024 W: 7219 L: 6926 D: 20879
http://chess.grantnet.us/test/6091/