### PR TITLE
Adjust internal scores

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -79,10 +79,10 @@ enum Limit {
 
 enum Score {
     TBWIN        = 30000,
-    TBWIN_IN_MAX = TBWIN - MAXDEPTH,
+    TBWIN_IN_MAX = TBWIN - 2 * MAXDEPTH,
 
-    MATE        = TBWIN + MAXDEPTH + 1,
-    MATE_IN_MAX = MATE - MAXDEPTH,
+    MATE        = 31000,
+    MATE_IN_MAX = MATE - 2 * MAXDEPTH,
 
     INFINITE = MATE + 1,
     NOSCORE  = MATE + 2,

--- a/src/types.h
+++ b/src/types.h
@@ -79,10 +79,10 @@ enum Limit {
 
 enum Score {
     TBWIN        = 30000,
-    TBWIN_IN_MAX = TBWIN - 2 * MAXDEPTH,
+    TBWIN_IN_MAX = TBWIN - 999,
 
     MATE        = 31000,
-    MATE_IN_MAX = MATE - 2 * MAXDEPTH,
+    MATE_IN_MAX = MATE - 999,
 
     INFINITE = MATE + 1,
     NOSCORE  = MATE + 2,


### PR DESCRIPTION
Leave a gap between mate and tb win scores so there is less chance for extended mate scores from TT to be treated as tb win scores.