### PR TITLE
Remove minimum thinking time

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -25,11 +25,10 @@
 void InitTimeManagement(int ply) {
 
     const int overhead = 5;
-    const int minThink = 1;
 
     // In movetime mode we use all the time given each turn
     if (Limits.movetime) {
-        Limits.maxUsage = Limits.optimalUsage = MAX(minThink, Limits.movetime - overhead);
+        Limits.maxUsage = Limits.optimalUsage = Limits.movetime - overhead;
         Limits.timelimit = true;
         return;
     }
@@ -48,11 +47,11 @@ void InitTimeManagement(int ply) {
 
     // Time until we don't start the next depth iteration
     double scale1 = MIN(0.5, 0.02 + ply * ply / 400000.0);
-    Limits.optimalUsage = CLAMP(timeLeft * scale1, minThink, 0.2 * Limits.time);
+    Limits.optimalUsage = MIN(timeLeft * scale1, 0.2 * Limits.time);
 
     // Time until we abort an iteration midway
     double scale2 = MIN(0.5, 0.10 + ply * ply / 30000.0);
-    Limits.maxUsage = CLAMP(timeLeft * scale2, minThink, 0.8 * Limits.time);
+    Limits.maxUsage = MIN(timeLeft * scale2, 0.8 * Limits.time);
 
     Limits.timelimit = true;
 }


### PR DESCRIPTION
Weiss doesn't check the time situation before it has completed at least 1 search iteration (unless a depth 1 search takes more than 4096 nodes which is unlikely), so there's no reason to set a minimum thinking time.