### PR TITLE
Simplify time management

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -553,7 +553,7 @@ static void PrepareSearch(Position *pos, Thread *threads) {
 // Root of search
 void SearchPosition(Position *pos, Thread *threads) {
 
-    InitTimeManagement(0);
+    InitTimeManagement();
 
     PrepareSearch(pos, threads);
 

--- a/src/search.c
+++ b/src/search.c
@@ -553,7 +553,7 @@ static void PrepareSearch(Position *pos, Thread *threads) {
 // Root of search
 void SearchPosition(Position *pos, Thread *threads) {
 
-    InitTimeManagement(pos->gamePly);
+    InitTimeManagement(0);
 
     PrepareSearch(pos, threads);
 

--- a/src/time.c
+++ b/src/time.c
@@ -22,7 +22,7 @@
 
 
 // Decide how much time to spend this turn
-void InitTimeManagement(int ply) {
+void InitTimeManagement() {
 
     const int overhead = 5;
 
@@ -46,11 +46,11 @@ void InitTimeManagement(int ply) {
                         - overhead * (2 + mtg));
 
     // Time until we don't start the next depth iteration
-    double scale1 = MIN(0.5, 0.02 + ply * ply / 400000.0);
+    double scale1 = 0.5;
     Limits.optimalUsage = MIN(timeLeft * scale1, 0.2 * Limits.time);
 
     // Time until we abort an iteration midway
-    double scale2 = MIN(0.5, 0.10 + ply * ply / 30000.0);
+    double scale2 = 0.5;
     Limits.maxUsage = MIN(timeLeft * scale2, 0.8 * Limits.time);
 
     Limits.timelimit = true;

--- a/src/time.h
+++ b/src/time.h
@@ -31,5 +31,5 @@ INLINE int TimeSince(const TimePoint tp) {
     return Now() - tp;
 }
 
-void InitTimeManagement(int ply);
+void InitTimeManagement();
 bool OutOfTime(Thread *thread);


### PR DESCRIPTION
Currently game ply is reset to 0 whenever the 50 move rule resets, so the ply part of the time management which was intended to increase time usage as the game goes on, rather increases time usage the further we are from the last 50mr reset. Removing it shows no significant loss at normal time controls.

ELO   | -0.37 +- 1.15 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 165966 W: 39451 L: 39629 D: 86886
http://chess.grantnet.us/test/6173/

ELO   | -0.03 +- 2.09 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 1.34 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 41902 W: 8267 L: 8271 D: 25364
http://chess.grantnet.us/test/6174/