### PR TITLE
Improve cyclic time management

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -45,13 +45,25 @@ void InitTimeManagement() {
                         + Limits.inc * (mtg - 1)
                         - overhead * (2 + mtg));
 
-    // Time until we don't start the next depth iteration
-    double scale1 = 0.5;
-    Limits.optimalUsage = MIN(timeLeft * scale1, 0.2 * Limits.time);
+    double scale1, scale2;
 
-    // Time until we abort an iteration midway
-    double scale2 = 0.5;
-    Limits.maxUsage = MIN(timeLeft * scale2, 0.8 * Limits.time);
+    // Basetime for the whole game
+    if (!Limits.movestogo) {
+
+        scale1 = 0.5;
+        Limits.optimalUsage = MIN(timeLeft * scale1, 0.2 * Limits.time);
+
+        scale2 = 0.5;
+        Limits.maxUsage = MIN(timeLeft * scale2, 0.8 * Limits.time);
+
+    // X moves in Y time
+    } else {
+
+        scale1 = 0.9 / mtg;
+        Limits.optimalUsage = MIN(timeLeft * scale1, 0.8 * Limits.time);
+
+        Limits.maxUsage = MIN(4 * Limits.optimalUsage, 0.8 * Limits.time);
+    }
 
     Limits.timelimit = true;
 }


### PR DESCRIPTION
Watching Weiss play cyclic time control I saw it didn't spend close to all its time before getting the next time increase. This patch fixes that, and apparently gains 500 elo in self-play...

ELO   | 687.51 +- 420.43 (95%)
SPRT  | 40/10.0s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 160 W: 155 L: 1 D: 4
http://chess.grantnet.us/test/6180/

ELO   | 499.68 +- 123.02 (95%)
SPRT  | 40/40.0s Threads=1 Hash=32MB
LLR   | 3.09 (-2.94, 2.94) [0.00, 5.00]
Games | N: 150 W: 135 L: 1 D: 14
http://chess.grantnet.us/test/6181/