### PR TITLE
Spend time slower (cyclic)

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -59,7 +59,7 @@ void InitTimeManagement() {
     // X moves in Y time
     } else {
 
-        scale1 = 0.9 / mtg;
+        scale1 = 0.8 / mtg;
         Limits.optimalUsage = MIN(timeLeft * scale1, 0.8 * Limits.time);
 
         Limits.maxUsage = MIN(4 * Limits.optimalUsage, 0.8 * Limits.time);


### PR DESCRIPTION
ELO   | 3.91 +- 3.05 (95%)
SPRT  | 40/10.0s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 24464 W: 6142 L: 5867 D: 12455
http://chess.grantnet.us/test/6185/

ELO   | 12.57 +- 6.26 (95%)
SPRT  | 40/40.0s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 5034 W: 1164 L: 982 D: 2888
http://chess.grantnet.us/test/6187/