### PR TITLE
Spend more time to finish iterations (cyclic)

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -62,7 +62,7 @@ void InitTimeManagement() {
         scale1 = 0.7 / mtg;
         Limits.optimalUsage = MIN(timeLeft * scale1, 0.8 * Limits.time);
 
-        Limits.maxUsage = MIN(4 * Limits.optimalUsage, 0.8 * Limits.time);
+        Limits.maxUsage = MIN(5 * Limits.optimalUsage, 0.8 * Limits.time);
     }
 
     Limits.timelimit = true;


### PR DESCRIPTION
Allow spending more time to finish a search iteration.

ELO   | 4.15 +- 3.18 (95%)
SPRT  | 40/10.0s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
Games | N: 21616 W: 5222 L: 4964 D: 11430
http://chess.grantnet.us/test/6205/

ELO   | 2.69 +- 2.16 (95%)
SPRT  | 40/40.0s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 41120 W: 8724 L: 8406 D: 23990
http://chess.grantnet.us/test/6207/