### PR TITLE
Tweak ProbCut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -296,7 +296,8 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     // ProbCut
     if (  !pvNode
         && depth >= 5
-        && abs(beta) < TBWIN_IN_MAX) {
+        && abs(beta) < TBWIN_IN_MAX
+        && (!ttHit || !(tte->bound & BOUND_UPPER) || ttScore >= beta)) {
 
         int pbBeta = beta + 200;
 


### PR DESCRIPTION
Use the same condition as for NMP - don't try if the TT info indicates it will fail.

ELO   | 1.33 +- 1.51 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 96096 W: 23045 L: 22678 D: 50373
http://chess.grantnet.us/test/6233/

ELO   | 2.54 +- 1.97 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 47392 W: 9566 L: 9219 D: 28607
http://chess.grantnet.us/test/6237/