### PR TITLE
No history bonus for quiet moves that succeed on depth 1

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -413,7 +413,7 @@ move_loop:
                 alpha = score;
 
                 // Update search history
-                if (quiet)
+                if (quiet && depth > 1)
                     thread->history[pieceOn(fromSq(bestMove))][toSq(bestMove)] += depth * depth;
 
                 // If score beats beta we have a cutoff


### PR DESCRIPTION
Inspired by an Ethereal patch by Alayant avoiding history updates if the first quiet at depth one fails high. Depth 1 searches are not very reliable, yet makes up a big part of the search tree, and as such they add a lot of noise to the history.

ELO   | 8.96 +- 5.79 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6672 W: 1700 L: 1528 D: 3444
http://chess.grantnet.us/test/6303/

ELO   | 2.29 +- 1.68 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 65312 W: 13257 L: 12827 D: 39228
http://chess.grantnet.us/test/6307/