### PR TITLE
Support pawns

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -45,6 +45,7 @@ tuneable_const int Tempo = 20;
 // Misc bonuses and maluses
 tuneable_static_const int PawnDoubled    = S( -6,-32);
 tuneable_static_const int PawnIsolated   = S(-28,-16);
+tuneable_static_const int PawnSupport    = S(  5,  5);
 tuneable_static_const int BishopPair     = S( 52, 72);
 tuneable_static_const int KingLineDanger = S(-12,  4);
 
@@ -128,6 +129,8 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
 
     // Doubled pawns
     eval += PawnDoubled * PopCount(pawns & ShiftBB(NORTH, pawns));
+
+    eval += PawnSupport * PopCount(pawns & PawnBBAttackBB(pawns, color));
 
     while (pawns) {
         Square sq = PopLsb(&pawns);


### PR DESCRIPTION
Give a bonus to pawns supported by other pawns.

Value not tuned, probably more elo by tuning it and other related values.

ELO   | 3.15 +- 2.48 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 36736 W: 9133 L: 8800 D: 18803
http://chess.grantnet.us/test/6332/

ELO   | 2.29 +- 1.66 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 69059 W: 14511 L: 14055 D: 40493
http://chess.grantnet.us/test/6336/