### PR TITLE
Tune misc pawn terms

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -43,14 +43,14 @@ tuneable_const int PieceValue[2][PIECE_NB] = {
 tuneable_const int Tempo = 20;
 
 // Misc bonuses and maluses
-tuneable_static_const int PawnDoubled    = S( -6,-32);
-tuneable_static_const int PawnIsolated   = S(-28,-16);
-tuneable_static_const int PawnSupport    = S(  5,  5);
+tuneable_static_const int PawnDoubled    = S( -6,-34);
+tuneable_static_const int PawnIsolated   = S(-27,-13);
+tuneable_static_const int PawnSupport    = S(  5,  4);
 tuneable_static_const int BishopPair     = S( 52, 72);
 tuneable_static_const int KingLineDanger = S(-12,  4);
 
 // Passed pawn [rank]
-tuneable_static_const int PawnPassed[8] = { 0, S(-10, 1), S(-18, 10), S( -2, 33), S( 28, 76), S( 77,116), S(121,153), 0 };
+tuneable_static_const int PawnPassed[8] = { 0, S(-13,  0), S(-19, 10), S( -2, 34), S( 31, 74), S( 76,116), S(122,154), 0 };
 
 // (Semi) open file for rook and queen [pt-4]
 tuneable_static_const int OpenFile[2] =     { S(51, 20), S(-13, 16) };

--- a/src/tune.c
+++ b/src/tune.c
@@ -24,7 +24,7 @@
 #include "evaluate.h"
 
 
-enum { NAME_MAX_CHAR = 64, PARSER_ENTRY_NB = 20 };
+enum { NAME_MAX_CHAR = 64, PARSER_ENTRY_NB = 21 };
 
 typedef struct ParserEntry {
     char name[NAME_MAX_CHAR];
@@ -43,6 +43,7 @@ extern int PieceSqValue[7][64];
 // Misc
 extern int PawnDoubled;
 extern int PawnIsolated;
+extern int PawnSupport;
 extern int BishopPair;
 extern int KingLineDanger;
 
@@ -101,8 +102,9 @@ void TuneDeclareAll() {
     // Passed pawn
     Declare(pe++, "Passed", &PawnPassed[1], 6);
     // Misc
-    Declare(pe++, "Doubled",  &PawnDoubled,   1);
+    Declare(pe++, "Doubled",  &PawnDoubled,    1);
     Declare(pe++, "Isolated", &PawnIsolated,   1);
+    Declare(pe++, "Support",  &PawnSupport,    1);
     Declare(pe++, "BPair",    &BishopPair,     1);
     Declare(pe++, "KLDanger", &KingLineDanger, 1);
 


### PR DESCRIPTION
Added PawnSupport to the tuner and tuned that along with some other misc pawn terms.

ELO   | 2.00 +- 1.44 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 107168 W: 25965 L: 25347 D: 55856
http://chess.grantnet.us/test/6869/

ELO   | 2.94 +- 2.35 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 33552 W: 6865 L: 6581 D: 20106
http://chess.grantnet.us/test/6871/