### PR TITLE
Rebel IID

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -322,15 +322,9 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
         }
     }
 
-    // Internal iterative deepening
-    if (depth >= 4 && !ttMove) {
-
-        AlphaBeta(thread, alpha, beta, CLAMP(depth-4, 1, depth/2), pv);
-
-        tte = ProbeTT(posKey, &ttHit);
-
-        ttMove = ttHit ? tte->move : NOMOVE;
-    }
+    // Internal iterative deepening based on Rebel's idea
+    if (depth >= 4 && !ttMove)
+        depth--;
 
 move_loop:
 


### PR DESCRIPTION
Rather than doing a shallow search to get a TT move before doing the search at current depth, just reduce current depth by 1. If the line is relevant and searched again later we will likely have a TT move and do a full depth search now with a TT move from the depth-1 search.

ELO   | 8.02 +- 4.95 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 4.00]
Games | N: 9104 W: 2297 L: 2087 D: 4720
http://chess.grantnet.us/test/6882/

ELO   | 5.61 +- 3.76 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 4.00]
Games | N: 13008 W: 2692 L: 2482 D: 7834
http://chess.grantnet.us/test/6884/

ELO   | 3.83 +- 2.89 (95%)
SPRT  | 20.0+0.2s Threads=8 Hash=512MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 21426 W: 4276 L: 4040 D: 13110
http://chess.grantnet.us/test/6886/