### PR TITLE
Remove ponder print

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,3 @@ Weiss supports the following:
 
 * #### NoobBook
   Allow Weiss to query and play moves suggested by [noobpwnftw's online opening database](https://www.chessdb.cn/queryc_en/).
-
-Note: Weiss will print a string indicating it supports Ponder, this is done to make cutechess GUI show pondermove accuracy. Weiss does not actually support this option.

--- a/src/uci.c
+++ b/src/uci.c
@@ -149,7 +149,6 @@ static void UCIInfo() {
     printf("option name Threads type spin default %d min %d max %d\n", 1, 1, 2048);
     printf("option name SyzygyPath type string default <empty>\n");
     printf("option name NoobBook type check default false\n");
-    printf("option name Ponder type check default false\n"); // Turn on ponder stats in cutechess gui
     TuneDeclareAll(); // Declares all evaluation parameters as options (dev mode)
     printf("uciok\n"); fflush(stdout);
 }


### PR DESCRIPTION
I made Weiss claim it supported ponder to turn on ponder move hitrate tracking in cutechess GUI, but I haven't bothered looking at that in a long time so now I remove it to avoid any confusion it may cause. Weiss never supported pondering and I have no plans to add it as I don't find it useful or interesting.