### PR TITLE
Resolve an issue where main threads may not be pthread_join()'ed

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -109,8 +109,6 @@ void ClearTT(Thread *threads) {
     for (int i = 0; i < threads->count; ++i)
         pthread_join(threads->pthreads[i], NULL);
 
-    threads->pthreads[0] = 0;
-
     TT.dirty = false;
 }
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -73,6 +73,7 @@ INLINE void UCIGo(Engine *engine, char *str) {
     ABORT_SIGNAL = false;
     ParseTimeControl(str, engine->pos.stm);
     pthread_create(&engine->threads->pthreads[0], NULL, &BeginSearch, engine);
+    pthread_detach(engine->threads->pthreads[0]);
 }
 
 // Parses a 'position' and sets up the board
@@ -157,8 +158,6 @@ static void UCIInfo() {
 static void UCIStop(Engine *engine) {
     ABORT_SIGNAL = true;
     Wake(engine->threads);
-    if (engine->threads->pthreads[0])
-        pthread_join(engine->threads->pthreads[0], NULL);
 }
 
 // Signals the engine is ready


### PR DESCRIPTION
Over time, this issue led to a crash. On average, after about ~1800 games played on 8 Threads with 10+.01s time control, Weiss would crash due to resource issues caused by the hanging pthreads. This patch detaches the main search thread so that we can trust it to clean up its own resources. It removes a corresponding pthread_join() when issued a "stop" or "quit" command. 

A self-play test of ~5600 games with the same settings as above was done to confirm the fix. This same patch was applied to Ethereal to address the very same issue.