### PR TITLE
Improve makefile

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -77,13 +77,13 @@ pgo:
 basic:
 	$(BASIC)
 
-release:
-	$(RELEASE)-nopopcnt.exe
-	$(RELEASE)-popcnt.exe   $(POPCNT)
-	$(RELEASE)-pext.exe     $(PEXT)
-
 dev:
 	$(BASIC) -DDEV
 
 tune:
 	$(BASIC) -DTUNE -fopenmp
+
+release:
+	$(RELEASE)-nopopcnt.exe
+	$(RELEASE)-popcnt.exe   $(POPCNT)
+	$(RELEASE)-pext.exe     $(PEXT)

--- a/src/makefile
+++ b/src/makefile
@@ -39,6 +39,15 @@ PGODIR = "../pgo"
 PGOGEN = -fprofile-generate=$(PGODIR)
 PGOUSE = -fprofile-use=$(PGODIR)
 
+# Use pext if supported and not a ryzen cpu
+PROPS = $(shell echo | $(CC) -march=native -E -dM -)
+CPU   = $(shell echo | $(CC) -march=native -Q --help=target | grep march)
+ifneq ($(findstring __BMI2__, $(PROPS)),)
+	ifeq ($(findstring znver, $(CPU)),)
+		CFLAGS += -DUSE_PEXT
+	endif
+endif
+
 # Try to detect windows environment by seeing
 # whether the shell filters out " or not.
 ifeq ($(shell echo "test"), "test")
@@ -62,13 +71,10 @@ RELEASE = $(COMP) $(RFLAGS) $(SRC) $(LIBS) -o $(EXE)
 basic:
 	$(BASIC)
 
-pext:
-	$(BASIC) $(PEXT)
-
 pgo:
-	$(BASIC) $(PEXT) $(PGOGEN)
+	$(BASIC) $(PGOGEN)
 	$(RUNBENCH)
-	$(BASIC) $(PEXT) $(PGOUSE)
+	$(BASIC) $(PGOUSE)
 	$(CLEAN)
 
 release:
@@ -77,7 +83,7 @@ release:
 	$(RELEASE)-pext.exe     $(PEXT)
 
 dev:
-	$(BASIC)-dev $(PEXT) -DDEV
+	$(BASIC) -DDEV
 
 tune:
-	$(BASIC) $(PEXT) -DTUNE -fopenmp
+	$(BASIC) -DTUNE -fopenmp

--- a/src/makefile
+++ b/src/makefile
@@ -19,7 +19,7 @@
 # General
 EXE    = weiss
 SRC    = *.c pyrrhic/tbprobe.c noobprobe/noobprobe.c tuner/tuner.c
-COMP   = gcc
+CC     = gcc
 
 # Defines
 POPCNT = -msse3 -mpopcnt
@@ -64,8 +64,8 @@ ifeq ($(OS), Windows_NT)
 endif
 
 # Compilations
-BASIC   = $(COMP) $(CFLAGS) $(SRC) $(LIBS) -o $(EXE)
-RELEASE = $(COMP) $(RFLAGS) $(SRC) $(LIBS) -o $(EXE)
+BASIC   = $(CC) $(CFLAGS) $(SRC) $(LIBS) -o $(EXE)
+RELEASE = $(CC) $(RFLAGS) $(SRC) $(LIBS) -o $(EXE)
 
 # Targets
 pgo:

--- a/src/makefile
+++ b/src/makefile
@@ -68,14 +68,14 @@ BASIC   = $(COMP) $(CFLAGS) $(SRC) $(LIBS) -o $(EXE)
 RELEASE = $(COMP) $(RFLAGS) $(SRC) $(LIBS) -o $(EXE)
 
 # Targets
-basic:
-	$(BASIC)
-
 pgo:
 	$(BASIC) $(PGOGEN)
 	$(RUNBENCH)
 	$(BASIC) $(PGOUSE)
 	$(CLEAN)
+
+basic:
+	$(BASIC)
 
 release:
 	$(RELEASE)-nopopcnt.exe


### PR DESCRIPTION
Automatically detect whether pext can (and should) be used. PGO is default target. Some cleanup.

No functional change.