### PR TITLE
Use score from TT instead of static eval if possible

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -258,7 +258,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
                                : lastMoveNullMove ? -history(-1).eval + 2 * Tempo
                                                   : EvalPosition(pos);
 
-    // Use ttScore as eval if useful
+    // Use ttScore as eval if it is more informative
     if (   ttScore != NOSCORE
         && (tte->bound & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
         eval = ttScore;

--- a/src/search.c
+++ b/src/search.c
@@ -282,6 +282,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     if (  !pvNode
         && history(-1).move != NOMOVE
         && eval >= beta
+        && history(0).eval >= beta
         && pos->nonPawnCount[sideToMove] > 0
         && depth >= 3
         && (!ttHit || !(tte->bound & BOUND_UPPER) || ttScore >= beta)) {

--- a/src/search.c
+++ b/src/search.c
@@ -258,6 +258,11 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
                                : lastMoveNullMove ? -history(-1).eval + 2 * Tempo
                                                   : EvalPosition(pos);
 
+    // Use ttScore as eval if useful
+    if (   ttScore != NOSCORE
+        && (tte->bound & (ttScore > eval ? BOUND_LOWER : BOUND_UPPER)))
+        eval = ttScore;
+
     // Improving if not in check, and current eval is higher than 2 plies ago
     bool improving = !inCheck && pos->ply >= 2 && eval > history(-2).eval;
 


### PR DESCRIPTION
A score gotten from the TT will almost certainly be a better evaluation of the position than the static eval. If the score+bounds suggest a better evaluation then use that instead for pruning heuristics.

ELO   | 10.78 +- 6.91 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4966 W: 1347 L: 1193 D: 2426
http://chess.grantnet.us/test/7212/

ELO   | 12.09 +- 6.83 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4052 W: 898 L: 757 D: 2397
http://chess.grantnet.us/test/7213/

ELO   | 21.44 +- 9.52 (95%)
SPRT  | 20.0+0.2s Threads=8 Hash=512MB
LLR   | 2.95 (-2.94, 2.94) [-2.00, 3.00]
Games | N: 2126 W: 507 L: 376 D: 1243
http://chess.grantnet.us/test/7214/