### PR TITLE
LMP tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -356,9 +356,9 @@ move_loop:
         bool quiet = moveIsQuiet(move);
 
         // Late move pruning
-        if (   !pvNode
-            && !inCheck
-            &&  quietCount > (3 + 2 * depth * depth) / (2 - improving))
+        if (  !pvNode
+            && bestScore > -TBWIN_IN_MAX
+            && quietCount > (3 + 2 * depth * depth) / (2 - improving))
             break;
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));


### PR DESCRIPTION
Allow LMP while in check, but make sure at least one move with a score better than TB loss or Mate has been found before pruning.

ELO   | 2.83 +- 2.86 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 29008 W: 7548 L: 7312 D: 14148
http://chess.grantnet.us/test/7231/

ELO   | 2.49 +- 2.53 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 30140 W: 6407 L: 6191 D: 17542
http://chess.grantnet.us/test/7233/