### PR TITLE
Tune qs futility margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -123,7 +123,7 @@ static int Quiescence(Thread *thread, int alpha, const int beta) {
     if (score > alpha)
         alpha = score;
 
-    int futility = score + 155;
+    int futility = score + 60;
 
     InitNoisyMP(&mp, &list, thread);
 


### PR DESCRIPTION
Used https://github.com/kiudee/chess-tuning-tools to tune the qs futility margin for a pretty big gain.

ELO   | 12.70 +- 7.54 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4160 W: 1137 L: 985 D: 2038
http://chess.grantnet.us/test/7250/

ELO   | 12.00 +- 6.89 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4112 W: 939 L: 797 D: 2376
http://chess.grantnet.us/test/7251/