### PR TITLE
Lower tempo bonus

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -50,7 +50,7 @@ const int PhaseValue[PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 20;
+const int Tempo = 15;
 
 // Misc bonuses and maluses
 const int PawnDoubled    = S(-11,-26);
@@ -290,8 +290,8 @@ int EvalPosition(const Position *pos) {
     assert(abs(eval) < TBWIN_IN_MAX);
 
     // Scale down eval for opposite-colored bishops endgames
-    if (    !pieceBB(QUEEN) && !pieceBB(ROOK) && !pieceBB(KNIGHT) 
-            && pos->nonPawnCount[WHITE] == 1 
+    if (    !pieceBB(QUEEN) && !pieceBB(ROOK) && !pieceBB(KNIGHT)
+            && pos->nonPawnCount[WHITE] == 1
             && pos->nonPawnCount[BLACK] == 1
             && (Single(pieceBB(BISHOP) & BlackSquaresBB)))
             eval = eval / 2;

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -290,11 +290,11 @@ int EvalPosition(const Position *pos) {
     assert(abs(eval) < TBWIN_IN_MAX);
 
     // Scale down eval for opposite-colored bishops endgames
-    if (    !pieceBB(QUEEN) && !pieceBB(ROOK) && !pieceBB(KNIGHT)
-            && pos->nonPawnCount[WHITE] == 1
-            && pos->nonPawnCount[BLACK] == 1
-            && (Single(pieceBB(BISHOP) & BlackSquaresBB)))
-            eval = eval / 2;
+    if (  !pieceBB(QUEEN) && !pieceBB(ROOK) && !pieceBB(KNIGHT)
+        && pos->nonPawnCount[WHITE] == 1
+        && pos->nonPawnCount[BLACK] == 1
+        && (Single(pieceBB(BISHOP) & BlackSquaresBB)))
+        eval = eval / 2;
 
     // Return the evaluation, negated if we are black
     return (sideToMove == WHITE ? eval : -eval) + Tempo;


### PR DESCRIPTION
Reduce tempo bonus from 20 to 15.

ELO   | 3.63 +- 3.50 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 19024 W: 4879 L: 4680 D: 9465
http://chess.grantnet.us/test/7308/

ELO   | 4.37 +- 3.77 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.02 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 13680 W: 2968 L: 2796 D: 7916
http://chess.grantnet.us/test/7310/