### PR TITLE
QoL - No longer require isready before go

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -71,6 +71,7 @@ static void *BeginSearch(void *voidEngine) {
 INLINE void UCIGo(Engine *engine, char *str) {
 
     ABORT_SIGNAL = false;
+    InitTT(engine->threads);
     ParseTimeControl(str, engine->pos.stm);
     pthread_create(&engine->threads->pthreads[0], NULL, &BeginSearch, engine);
     pthread_detach(engine->threads->pthreads[0]);

--- a/src/uci.c
+++ b/src/uci.c
@@ -177,7 +177,7 @@ static int HashInput(char *str) {
     while (*str && *str != ' ')
         hash ^= *(str++) ^ len++;
     return hash;
-};
+}
 
 // Sets up the engine and follows UCI protocol commands
 int main(int argc, char **argv) {


### PR DESCRIPTION
Init TT on receiving go if not already done with isready. GUIs should send isready at least once before go, but for manual use this is a nice QoL upgrade.