### PR TITLE
Sort bad noisy moves last

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -162,6 +162,20 @@ CONSTR InitBitMasks() {
                     BetweenBB[sq1][sq2] = AttackBB(pt, sq1, SquareBB[sq2]) & AttackBB(pt, sq2, SquareBB[sq1]);
 }
 
+// Returns a bitboard with all attackers of a square
+Bitboard Attackers(const Position *pos, const Square sq, const Bitboard occ) {
+
+    const Bitboard bishops = pieceBB(BISHOP) | pieceBB(QUEEN);
+    const Bitboard rooks   = pieceBB(ROOK)   | pieceBB(QUEEN);
+
+    return (PawnAttackBB(WHITE, sq) & colorPieceBB(BLACK, PAWN))
+         | (PawnAttackBB(BLACK, sq) & colorPieceBB(WHITE, PAWN))
+         | (AttackBB(KNIGHT, sq, occ) & pieceBB(KNIGHT))
+         | (AttackBB(KING,   sq, occ) & pieceBB(KING))
+         | (AttackBB(BISHOP, sq, occ) & bishops)
+         | (AttackBB(ROOK,   sq, occ) & rooks);
+}
+
 // Checks whether a square is attacked by the given color
 bool SqAttacked(const Position *pos, const Square sq, const Color color) {
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -203,5 +203,6 @@ INLINE Bitboard PawnBBAttackBB(Bitboard pawns, Color color) {
     return ShiftBB(up+WEST, pawns) | ShiftBB(up+EAST, pawns);
 }
 
+Bitboard Attackers(const Position *pos, const Square sq, const Bitboard occ);
 bool SqAttacked(const Position *pos, Square sq, Color color);
 bool KingAttacked(const Position *pos, Color color);

--- a/src/board.h
+++ b/src/board.h
@@ -72,6 +72,7 @@ extern uint64_t SideKey;
 void InitDistance();
 void ParseFen(const char *fen, Position *pos);
 Key KeyAfter(const Position *pos, Move move);
+bool SEE(const Position *pos, const Move move, const int threshold);
 char *BoardToFen(const Position *pos);
 #ifndef NDEBUG
 void PrintBoard(const Position *pos);

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -22,7 +22,7 @@
 
 
 typedef enum MPStage {
-    TTMOVE, GEN_NOISY, NOISY, KILLER1, KILLER2, GEN_QUIET, QUIET
+    TTMOVE, GEN_NOISY, NOISY_GOOD, KILLER1, KILLER2, GEN_QUIET, QUIET, NOISY_BAD
 } MPStage;
 
 typedef struct MovePicker {
@@ -30,6 +30,7 @@ typedef struct MovePicker {
     MoveList *list;
     MPStage stage;
     Move ttMove, kill1, kill2;
+    int bads;
     bool onlyNoisy;
 } MovePicker;
 

--- a/src/search.c
+++ b/src/search.c
@@ -358,8 +358,10 @@ move_loop:
         // Late move pruning
         if (  !pvNode
             && bestScore > -TBWIN_IN_MAX
-            && quietCount > (3 + 2 * depth * depth) / (2 - improving))
-            break;
+            && quietCount > (3 + 2 * depth * depth) / (2 - improving)) {
+            mp.onlyNoisy = true;
+            continue;
+        }
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -18,8 +18,11 @@
 
 #pragma once
 
-#include "types.h"
+#include <stdio.h>
 #include <string.h>
+
+#include "board.h"
+#include "threads.h"
 
 
 #define NAME "Weiss 1.1-dev"


### PR DESCRIPTION
Order seemingly bad noisy moves last using static exchange evaluation. SEE code inspired by Eth.

ELO   | 18.11 +- 9.13 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3034 W: 906 L: 748 D: 1380
http://chess.grantnet.us/test/7383/

ELO   | 22.39 +- 9.56 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2300 W: 595 L: 447 D: 1258
http://chess.grantnet.us/test/7384/