### PR TITLE
Count nodes in makemove

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -54,6 +54,8 @@ typedef struct Position {
 
     Key key;
 
+    uint64_t nodes;
+
     History gameHistory[MAXGAMEMOVES];
 
 } Position;

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -266,6 +266,8 @@ bool MakeMove(Position *pos, const Move move) {
     if (KingAttacked(pos, sideToMove^1))
         return TakeMove(pos), false;
 
+    pos->nodes++;
+
     assert(PositionOk(pos));
 
     return true;

--- a/src/search.c
+++ b/src/search.c
@@ -100,8 +100,7 @@ static int Quiescence(Thread *thread, int alpha, const int beta) {
     if (OutOfTime(thread) || ABORT_SIGNAL)
         longjmp(thread->jumpBuffer, true);
 
-    // Update node count and selective depth
-    thread->nodes++;
+    // Update selective depth
     if (pos->ply > thread->seldepth)
         thread->seldepth = pos->ply;
 
@@ -201,10 +200,9 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     if (depth <= 0)
         return Quiescence(thread, alpha, beta);
 
-    // Update node count and selective depth
-    thread->nodes++;
+    // Update selective depth
     if (pos->ply > thread->seldepth)
-        thread->seldepth = pos->ply;    
+        thread->seldepth = pos->ply;
 
     // Probe transposition table
     bool ttHit;

--- a/src/threads.c
+++ b/src/threads.c
@@ -47,7 +47,7 @@ uint64_t TotalNodes(const Thread *threads) {
 
     uint64_t total = 0;
     for (int i = 0; i < threads->count; ++i)
-        total += threads[i].nodes;
+        total += threads[i].pos.nodes;
     return total;
 }
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -24,7 +24,6 @@
 
 typedef struct Thread {
 
-    uint64_t nodes;
     uint64_t tbhits;
 
     int score;

--- a/src/time.c
+++ b/src/time.c
@@ -60,7 +60,7 @@ void InitTimeManagement() {
 // Check time situation
 bool OutOfTime(Thread *thread) {
 
-    return (thread->nodes & 4095) == 4095
+    return (thread->pos.nodes & 4095) == 4095
         && thread->index == 0
         && Limits.timelimit
         && TimeSince(Limits.start) >= Limits.maxUsage;


### PR DESCRIPTION
Changes the node counting to match SF exactly. Node count in bench is ~3% lower than before.

No functional change.