### PR TITLE
Aspiration tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -482,6 +482,9 @@ static int AspirationWindow(Thread *thread) {
     // Search with aspiration window until the result is inside the window
     while (true) {
 
+        if (alpha < -2000) alpha = -INFINITE;
+        if (beta  >  2000) beta  =  INFINITE;
+
         score = AlphaBeta(thread, alpha, beta, depth, &thread->pv);
 
         // Give an update when done, or after each iteration in long searches

--- a/src/search.c
+++ b/src/search.c
@@ -482,8 +482,8 @@ static int AspirationWindow(Thread *thread) {
     // Search with aspiration window until the result is inside the window
     while (true) {
 
-        if (alpha < -2000) alpha = -INFINITE;
-        if (beta  >  2000) beta  =  INFINITE;
+        if (alpha < -3500) alpha = -INFINITE;
+        if (beta  >  3500) beta  =  INFINITE;
 
         score = AlphaBeta(thread, alpha, beta, depth, &thread->pv);
 


### PR DESCRIPTION
Once scores get very high or low just open the aspiration window completely in that direction for slightly improved mate detection.

No signifant change in playing strength.

ELO   | 1.85 +- 3.23 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 22916 W: 5991 L: 5869 D: 11056
http://chess.grantnet.us/test/7412/

ELO   | -1.00 +- 3.69 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 0.01 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 14588 W: 3116 L: 3158 D: 8314
http://chess.grantnet.us/test/7420/