### PR TITLE
Get seldepth from history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -507,6 +507,7 @@ static int AspirationWindow(Thread *thread) {
 static void *IterativeDeepening(void *voidThread) {
 
     Thread *thread = voidThread;
+    Position *pos = &thread->pos;
     bool mainThread = thread->index == 0;
 
     // Iterative deepening
@@ -531,7 +532,9 @@ static void *IterativeDeepening(void *voidThread) {
             && TimeSince(Limits.start) > Limits.optimalUsage * (1 + uncertain))
             break;
 
-        // thread->seldepth = 0;
+        // Clear key history for seldepth calculation
+        for (int i = 1; i < MAXDEPTH; ++i)
+            history(i).posKey = 0;
     }
 
     return NULL;

--- a/src/search.c
+++ b/src/search.c
@@ -100,10 +100,6 @@ static int Quiescence(Thread *thread, int alpha, const int beta) {
     if (OutOfTime(thread) || ABORT_SIGNAL)
         longjmp(thread->jumpBuffer, true);
 
-    // Update selective depth
-    if (pos->ply > thread->seldepth)
-        thread->seldepth = pos->ply;
-
     // If we are at max depth, return static eval
     if (pos->ply >= MAXDEPTH)
         return EvalPosition(pos);
@@ -199,10 +195,6 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     // Quiescence at the end of search
     if (depth <= 0)
         return Quiescence(thread, alpha, beta);
-
-    // Update selective depth
-    if (pos->ply > thread->seldepth)
-        thread->seldepth = pos->ply;
 
     // Probe transposition table
     bool ttHit;
@@ -539,7 +531,7 @@ static void *IterativeDeepening(void *voidThread) {
             && TimeSince(Limits.start) > Limits.optimalUsage * (1 + uncertain))
             break;
 
-        thread->seldepth = 0;
+        // thread->seldepth = 0;
     }
 
     return NULL;

--- a/src/threads.h
+++ b/src/threads.h
@@ -30,7 +30,6 @@ typedef struct Thread {
     Depth depth;
     Move bestMove;
     Move ponderMove;
-    Depth seldepth;
 
     PV pv;
 

--- a/src/uci.c
+++ b/src/uci.c
@@ -232,6 +232,8 @@ INLINE int MateScore(const int score) {
 // Print thinking
 void PrintThinking(const Thread *thread, int score, int alpha, int beta) {
 
+    const Position *pos = &thread->pos;
+
     // Determine whether we have a centipawn or mate score
     char *type = abs(score) >= MATE_IN_MAX ? "mate" : "cp";
 
@@ -246,11 +248,14 @@ void PrintThinking(const Thread *thread, int score, int alpha, int beta) {
                                        : score * 100 / P_MG;
 
     TimePoint elapsed = TimeSince(Limits.start);
-    Depth seldepth    = thread->seldepth;
     uint64_t nodes    = TotalNodes(thread);
     uint64_t tbhits   = TotalTBHits(thread);
     int hashFull      = HashFull();
     int nps           = (int)(1000 * nodes / (elapsed + 1));
+
+    Depth seldepth = MAXDEPTH-1;
+    for (; seldepth > 0; --seldepth)
+        if (history(seldepth).posKey != 0) break;
 
     // Basic info
     printf("info depth %d seldepth %d score %s %d%s time %" PRId64

--- a/src/uci.c
+++ b/src/uci.c
@@ -253,9 +253,9 @@ void PrintThinking(const Thread *thread, int score, int alpha, int beta) {
     int hashFull      = HashFull();
     int nps           = (int)(1000 * nodes / (elapsed + 1));
 
-    Depth seldepth = MAXDEPTH-1;
+    Depth seldepth = MAXDEPTH;
     for (; seldepth > 0; --seldepth)
-        if (history(seldepth).posKey != 0) break;
+        if (history(seldepth-1).posKey != 0) break;
 
     // Basic info
     printf("info depth %d seldepth %d score %s %d%s time %" PRId64


### PR DESCRIPTION
Get seldepth by checking history instead of incrementally updating it during search. Moves some code out of AB/QS which are huge and spreads it over other smaller functions. Maybe slightly faster.

ELO   | 1.60 +- 3.06 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 25468 W: 6632 L: 6515 D: 12321
http://chess.grantnet.us/test/7438/