### PR TITLE
Upcoming repetition detection

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -339,14 +339,6 @@ move_loop:
     Move move;
     while ((move = NextMove(&mp))) {
 
-        if (  !inCheck
-            && eval > 500
-            && pos->histPly >= 2
-            && pos->rule50 != 0
-            && fromSq(move) == toSq(history(-2).move)
-            && toSq(move) == fromSq(history(-2).move))
-            continue;
-
         bool quiet = moveIsQuiet(move);
 
         // Late move pruning
@@ -366,6 +358,20 @@ move_loop:
         moveCount++;
         if (quiet && quietCount < 32)
             quiets[quietCount++] = move;
+
+        // If alpha <= 0 and we take back our last move, opponent can do the same
+        // and get a fail high by repetition
+        if (   pos->rule50 >= 3
+            && pos->histPly >= 2
+            && alpha > 0
+            // The current move has been made and is -1, 2 back is then -3
+            && fromSq(move) == toSq(history(-3).move)
+            && toSq(move) == fromSq(history(-3).move)) {
+
+            score = 0;
+            pvFromHere.length = 0;
+            goto skip_search;
+        }
 
         const Depth newDepth = depth - 1;
 
@@ -394,6 +400,8 @@ move_loop:
         // Full depth alpha-beta window search
         if (pvNode && ((score > alpha && score < beta) || moveCount == 1))
             score = -AlphaBeta(thread, -beta, -alpha, newDepth, &pvFromHere);
+
+skip_search:
 
         // Undo the move
         TakeMove(pos);

--- a/src/search.c
+++ b/src/search.c
@@ -339,6 +339,14 @@ move_loop:
     Move move;
     while ((move = NextMove(&mp))) {
 
+        if (  !inCheck
+            && eval > 500
+            && pos->histPly >= 2
+            && pos->rule50 != 0
+            && fromSq(move) == toSq(history(-2).move)
+            && toSq(move) == fromSq(history(-2).move))
+            continue;
+
         bool quiet = moveIsQuiet(move);
 
         // Late move pruning

--- a/src/search.c
+++ b/src/search.c
@@ -359,7 +359,7 @@ move_loop:
         if (quiet && quietCount < 32)
             quiets[quietCount++] = move;
 
-        // If alpha <= 0 and we take back our last move, opponent can do the same
+        // If alpha > 0 and we take back our last move, opponent can do the same
         // and get a fail high by repetition
         if (   pos->rule50 >= 3
             && pos->histPly >= 2


### PR DESCRIPTION
If we are pressing for a win, and we make a move, they make a move, and we move back, unless one of these moves reset the 50 move rule (capture, pawn move), then they can repeat and get a fail high with score 0. So we give the takeback a score of 0 immediately.

There is a slight exception where a move can change castling rights without resetting the 50 move rule, but it does reset the 3-fold rule, but it seems that should be fine to ignore.

ELO   | 3.63 +- 3.52 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 19520 W: 5205 L: 5001 D: 9314
http://chess.grantnet.us/test/7480/

ELO   | 5.43 +- 4.40 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10246 W: 2275 L: 2115 D: 5856
http://chess.grantnet.us/test/7482/