### PR TITLE
Full AB first few iterations of search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -375,7 +375,7 @@ move_loop:
 
         const Depth newDepth = depth - 1;
 
-        bool doLMR = depth > 2 && moveCount > (2 + pvNode);
+        bool doLMR = depth > 2 && moveCount > (2 + pvNode) && thread->depth > 6;
 
         // Reduced depth zero-window search
         if (doLMR) {

--- a/src/search.c
+++ b/src/search.c
@@ -253,7 +253,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     bool improving = !inCheck && pos->ply >= 2 && eval > history(-2).eval;
 
     // Skip pruning while in check and at the root
-    if (inCheck || root)
+    if (inCheck || root || thread->depth < 6)
         goto move_loop;
 
     // Razoring
@@ -342,7 +342,7 @@ move_loop:
         bool quiet = moveIsQuiet(move);
 
         // Late move pruning
-        if (  !pvNode
+        if (  !pvNode && thread->depth > 6
             && bestScore > -TBWIN_IN_MAX
             && quietCount > (3 + 2 * depth * depth) / (2 - improving)) {
             mp.onlyNoisy = true;


### PR DESCRIPTION
No pruning nor reductions for the first few iterations of search. Widens the search and finds short tricks, improving puzzle solving a bit. Regresses at short time controls, will look into making the limit dynamic based on available time.

ELO   | -5.83 +- 4.43 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | -3.01 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 12048 W: 2981 L: 3183 D: 5884
http://chess.grantnet.us/test/7499/

ELO   | 4.04 +- 4.00 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 12224 W: 2659 L: 2517 D: 7048
http://chess.grantnet.us/test/7500/