### PR TITLE
No early pruning tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -253,7 +253,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     bool improving = !inCheck && pos->ply >= 2 && eval > history(-2).eval;
 
     // Skip pruning while in check and at the root
-    if (inCheck || root || thread->depth < 6)
+    if (inCheck || root || !thread->doEarlyPruning)
         goto move_loop;
 
     // Razoring
@@ -342,7 +342,8 @@ move_loop:
         bool quiet = moveIsQuiet(move);
 
         // Late move pruning
-        if (  !pvNode && thread->depth > 6
+        if (  !pvNode
+            && thread->doEarlyPruning
             && bestScore > -TBWIN_IN_MAX
             && quietCount > (3 + 2 * depth * depth) / (2 - improving)) {
             mp.onlyNoisy = true;
@@ -375,7 +376,7 @@ move_loop:
 
         const Depth newDepth = depth - 1;
 
-        bool doLMR = depth > 2 && moveCount > (2 + pvNode) && thread->depth > 6;
+        bool doLMR = depth > 2 && moveCount > (2 + pvNode) && thread->doEarlyPruning;
 
         // Reduced depth zero-window search
         if (doLMR) {
@@ -481,6 +482,8 @@ static int AspirationWindow(Thread *thread) {
 
     int alpha = -INFINITE;
     int beta  =  INFINITE;
+
+    thread->doEarlyPruning = depth > 5;
 
     // Shrink the window at higher depths
     if (depth > 6)

--- a/src/search.c
+++ b/src/search.c
@@ -483,7 +483,8 @@ static int AspirationWindow(Thread *thread) {
     int alpha = -INFINITE;
     int beta  =  INFINITE;
 
-    thread->doEarlyPruning = depth > 5;
+    int earlyPruningLimit = Limits.timelimit ? (Limits.optimalUsage + 250) / 250 : 6;
+    thread->doEarlyPruning = depth > MIN(6, earlyPruningLimit);
 
     // Shrink the window at higher depths
     if (depth > 6)

--- a/src/threads.h
+++ b/src/threads.h
@@ -28,9 +28,10 @@ typedef struct Thread {
 
     int score;
     Depth depth;
+    bool doEarlyPruning;
+
     Move bestMove;
     Move ponderMove;
-
     PV pv;
 
     jmp_buf jumpBuffer;


### PR DESCRIPTION
Refactor to use a flag in thread to turn off pruning/reductions, and add a scaling based on time to fix the regression at short time controls the original version introduced. The linear scaling is unlikely to be optimal as nodes per depth doesn't scale linearly, so a better formula is probably possible, as is including nps and/or thread count in the calculation.

ELO   | 8.22 +- 5.96 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 6891 W: 1906 L: 1743 D: 3242
http://chess.grantnet.us/test/7506/

ELO   | 1.11 +- 3.25 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 0.12 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 19021 W: 4160 L: 4099 D: 10762
http://chess.grantnet.us/test/7510/