### PR TITLE
Singular extension

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -24,7 +24,6 @@
 typedef struct {
     Key posKey;
     Move move;
-    Move excludedMove;
     uint8_t epSquare;
     uint8_t rule50;
     uint8_t castlingRights;

--- a/src/board.h
+++ b/src/board.h
@@ -24,6 +24,7 @@
 typedef struct {
     Key posKey;
     Move move;
+    Move excludedMove;
     uint8_t epSquare;
     uint8_t rule50;
     uint8_t castlingRights;

--- a/src/search.c
+++ b/src/search.c
@@ -154,7 +154,7 @@ static int Quiescence(Thread *thread, int alpha, const int beta) {
 }
 
 // Alpha Beta
-static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
+static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv, Move excluded) {
 
     Position *pos = &thread->pos;
     MovePicker mp;
@@ -198,7 +198,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
 
     // Probe transposition table
     bool ttHit;
-    Key posKey = pos->key ^ ((Key)history(0).excludedMove << 32);
+    Key posKey = pos->key ^ (((Key)excluded) << 32);
     TTEntry *tte = ProbeTT(posKey, &ttHit);
 
     Move ttMove = ttHit ? tte->move : NOMOVE;
@@ -252,8 +252,8 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
     // Improving if not in check, and current eval is higher than 2 plies ago
     bool improving = !inCheck && pos->ply >= 2 && eval > history(-2).eval;
 
-    // Skip pruning in check, at root and during early iterations
-    if (inCheck || root || !thread->doPruning || history(0).excludedMove)
+    // Skip pruning in check, at root, during early iterations, and when proving singularity
+    if (inCheck || root || !thread->doPruning || excluded)
         goto move_loop;
 
     // Razoring
@@ -279,7 +279,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 
         MakeNullMove(pos);
-        score = -AlphaBeta(thread, -beta, -beta + 1, depth - R, &pvFromHere);
+        score = -AlphaBeta(thread, -beta, -beta + 1, depth - R, &pvFromHere, 0);
         TakeNullMove(pos);
 
         // Cutoff
@@ -313,7 +313,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv) {
 
             // If it did do a proper search with reduced depth
             if (pbScore >= pbBeta)
-                pbScore = -AlphaBeta(thread, -pbBeta, -pbBeta+1, depth-4, &pvFromHere);
+                pbScore = -AlphaBeta(thread, -pbBeta, -pbBeta+1, depth-4, &pvFromHere, 0);
 
             TakeMove(pos);
 
@@ -342,6 +342,8 @@ move_loop:
     Move move;
     while ((move = NextMove(&mp))) {
 
+        if (move == excluded) continue;
+
         bool quiet = moveIsQuiet(move);
 
         // Late move pruning
@@ -363,7 +365,7 @@ move_loop:
         // Singular extension
         if (   depth > 8
             && move == ttMove
-            && !history(0).excludedMove
+            && !excluded
             && tte->depth > depth - 3
             && tte->bound != BOUND_UPPER
             && abs(ttScore) < TBWIN_IN_MAX / 4
@@ -376,9 +378,7 @@ move_loop:
             int singBeta = ttScore - depth * 2;
             int singDepth = depth / 2;
 
-            history(0).excludedMove = move;
-            score = AlphaBeta(thread, singBeta-1, singBeta, singDepth, &pvFromHere);
-            history(0).excludedMove = NOMOVE;
+            score = AlphaBeta(thread, singBeta-1, singBeta, singDepth, &pvFromHere, move);
 
             // Extend as this move seems forced
             if (score < singBeta)
@@ -426,15 +426,15 @@ move_loop:
             // Depth after reductions, avoiding going straight to quiescence
             Depth RDepth = CLAMP(newDepth - R, 1, newDepth - 1);
 
-            score = -AlphaBeta(thread, -alpha - 1, -alpha, RDepth, &pvFromHere);
+            score = -AlphaBeta(thread, -alpha - 1, -alpha, RDepth, &pvFromHere, 0);
         }
         // Full depth zero-window search
         if (doLMR ? score > alpha : !pvNode || moveCount > 1)
-            score = -AlphaBeta(thread, -alpha - 1, -alpha, newDepth, &pvFromHere);
+            score = -AlphaBeta(thread, -alpha - 1, -alpha, newDepth, &pvFromHere, 0);
 
         // Full depth alpha-beta window search
         if (pvNode && ((score > alpha && score < beta) || moveCount == 1))
-            score = -AlphaBeta(thread, -beta, -alpha, newDepth, &pvFromHere);
+            score = -AlphaBeta(thread, -beta, -alpha, newDepth, &pvFromHere, 0);
 
 skip_search:
 
@@ -488,14 +488,17 @@ skip_search:
 
     // Checkmate or stalemate
     if (!moveCount)
-        return inCheck ? -MATE + pos->ply : 0;
+        return excluded ? alpha
+             : inCheck  ? -MATE + pos->ply
+                        : 0;
 
     // Store in TT
     const int flag = bestScore >= beta ? BOUND_LOWER
                    : alpha != oldAlpha ? BOUND_EXACT
                                        : BOUND_UPPER;
 
-    StoreTTEntry(tte, posKey, bestMove, ScoreToTT(bestScore, pos->ply), depth, flag);
+    if (!excluded)
+        StoreTTEntry(tte, posKey, bestMove, ScoreToTT(bestScore, pos->ply), depth, flag);
 
     assert(alpha >= oldAlpha);
     assert(ValidScore(alpha));
@@ -531,7 +534,7 @@ static int AspirationWindow(Thread *thread) {
         if (alpha < -3500) alpha = -INFINITE;
         if (beta  >  3500) beta  =  INFINITE;
 
-        score = AlphaBeta(thread, alpha, beta, depth, &thread->pv);
+        score = AlphaBeta(thread, alpha, beta, depth, &thread->pv, 0);
 
         // Give an update when done, or after each iteration in long searches
         if (mainThread && (   (score > alpha && score < beta)


### PR DESCRIPTION
Extend moves that seem to be forced. Helps discover the result of long forced lines earlier. Code inspired by SF, Eth and many other engines, they all seem to have a fairly similar implementations.

I tried adding this concept before, but it didn't work out, possibly due to poor eval.

ELO   | 11.52 +- 6.84 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5040 W: 1367 L: 1200 D: 2473
http://chess.grantnet.us/test/7577/

ELO   | 24.21 +- 9.83 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1984 W: 479 L: 341 D: 1164
http://chess.grantnet.us/test/7579/