### PR TITLE
Separate LMR for captures

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -40,7 +40,7 @@
 #include "uci.h"
 
 
-int Reductions[32][32];
+int Reductions[2][32][32];
 
 SearchLimits Limits;
 volatile bool ABORT_SIGNAL = false;
@@ -52,7 +52,8 @@ CONSTR InitReductions() {
 
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[depth][moves] = 0.75 + log(depth) * log(moves) / 2.25;
+            Reductions[0][depth][moves] = 0.75 + log(depth) * log(moves) / 3.0, // capture
+            Reductions[1][depth][moves] = 0.75 + log(depth) * log(moves) / 2.25; // quiet
 }
 
 // Check if current position is a repetition
@@ -411,7 +412,7 @@ move_loop:
         // Reduced depth zero-window search
         if (doLMR) {
             // Base reduction
-            int R = Reductions[MIN(31, depth)][MIN(31, moveCount)];
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Reduce less in pv nodes
             R -= pvNode;
             // Reduce less when improving

--- a/src/search.c
+++ b/src/search.c
@@ -53,7 +53,7 @@ CONSTR InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
             Reductions[0][depth][moves] = 0.75 + log(depth) * log(moves) / 3.0, // capture
-            Reductions[1][depth][moves] = 0.75 + log(depth) * log(moves) / 2.25; // quiet
+            Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 2.25; // quiet
 }
 
 // Check if current position is a repetition
@@ -417,8 +417,6 @@ move_loop:
             R -= pvNode;
             // Reduce less when improving
             R -= improving;
-            // Reduce more for quiets
-            R += quiet;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth RDepth = CLAMP(newDepth - R, 1, newDepth - 1);


### PR DESCRIPTION
Add a separate table for LMR reductions of captures, and reduce them less than before.

ELO   | 11.55 +- 7.02 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4512 W: 1158 L: 1008 D: 2346
http://chess.grantnet.us/test/7672/

ELO   | 5.07 +- 4.06 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10688 W: 2117 L: 1961 D: 6610
http://chess.grantnet.us/test/7673/
