### PR TITLE
Butterfly history

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -73,7 +73,7 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage) {
                                  : MvvLvaScores[pieceOn(toSq(move))][pieceOn(fromSq(move))];
 
         if (stage == GEN_QUIET)
-            list->moves[i].score = thread->history[pieceOn(fromSq(move))][toSq(move)];
+            list->moves[i].score = thread->history[sideToMove][fromSq(move)][toSq(move)];
     }
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -456,7 +456,7 @@ skip_search:
 
                 // Update search history
                 if (quiet && depth > 1)
-                    thread->history[pieceOn(fromSq(bestMove))][toSq(bestMove)] += depth * depth;
+                    thread->history[sideToMove][fromSq(move)][toSq(move)] += depth * depth;
 
                 // If score beats beta we have a cutoff
                 if (score >= beta) {
@@ -478,7 +478,7 @@ skip_search:
         for (int i = 0; i < quietCount; ++i) {
             Move m = quiets[i];
             if (m == bestMove) continue;
-            thread->history[pieceOn(fromSq(m))][toSq(m)] -= depth * depth;
+            thread->history[sideToMove][fromSq(m)][toSq(m)] -= depth * depth;
         }
 
     // Checkmate or stalemate

--- a/src/threads.h
+++ b/src/threads.h
@@ -36,7 +36,7 @@ typedef struct Thread {
 
     jmp_buf jumpBuffer;
 
-    int history[PIECE_NB][64];
+    int history[2][64][64];
     Move killers[MAXDEPTH][2];
 
     // Anything below here is not zeroed out between searches


### PR DESCRIPTION
Switch from piece-to history to butterfly history.

ELO   | 4.69 +- 4.09 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 13040 W: 3170 L: 2994 D: 6876
http://openbench.sassytheo.com/test/7680/

ELO   | 12.81 +- 6.93 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 3744 W: 796 L: 658 D: 2290
http://openbench.sassytheo.com/test/7691/