### PR TITLE
Lower base LMR of captures

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -52,7 +52,7 @@ CONSTR InitReductions() {
 
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.75 + log(depth) * log(moves) / 3.0, // capture
+            Reductions[0][depth][moves] = 0.60 + log(depth) * log(moves) / 3.0, // capture
             Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 2.25; // quiet
 }
 


### PR DESCRIPTION
Quiets are already reduced by a full 1 ply more base, and with a steeper curve, but captures are apparently still reduced too much.

ELO   | 7.07 +- 5.28 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 7712 W: 1869 L: 1712 D: 4131
http://openbench.sassytheo.com/test/7693/

ELO   | 7.92 +- 5.28 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 6272 W: 1255 L: 1112 D: 3905
http://openbench.sassytheo.com/test/7695/