### PR TITLE
Lower curve LMR of Captures

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -52,7 +52,7 @@ CONSTR InitReductions() {
 
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.60 + log(depth) * log(moves) / 3.0, // capture
+            Reductions[0][depth][moves] = 0.60 + log(depth) * log(moves) / 3.5, // capture
             Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 2.25; // quiet
 }
 


### PR DESCRIPTION
Lower the curve yet again.

ELO   | 5.77 +- 4.67 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10048 W: 2460 L: 2293 D: 5295
http://chess.grantnet.us/test/7697/

ELO   | 3.43 +- 3.16 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 17536 W: 3415 L: 3242 D: 10879
http://chess.grantnet.us/test/7698/