### PR TITLE
Checkers2

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -206,3 +206,9 @@ INLINE Bitboard PawnBBAttackBB(Bitboard pawns, Color color) {
 Bitboard Attackers(const Position *pos, const Square sq, const Bitboard occ);
 bool SqAttacked(const Position *pos, Square sq, Color color);
 bool KingAttacked(const Position *pos, Color color);
+
+INLINE Bitboard Checkers(const Position *pos) {
+
+    return colorBB(!sideToMove)
+         & Attackers(pos, Lsb(colorPieceBB(sideToMove, KING)), pieceBB(ALL));
+}

--- a/src/board.c
+++ b/src/board.c
@@ -168,6 +168,7 @@ static void UpdatePosition(Position *pos) {
         }
     }
 
+    pos->checkers = Checkers(pos);
     pos->phase = UpdatePhase(pos->phaseValue);
 }
 

--- a/src/board.h
+++ b/src/board.h
@@ -23,6 +23,7 @@
 
 typedef struct {
     Key posKey;
+    Bitboard checkers;
     Move move;
     uint8_t epSquare;
     uint8_t rule50;
@@ -36,6 +37,7 @@ typedef struct Position {
     uint8_t board[64];
     Bitboard pieceBB[TYPE_NB];
     Bitboard colorBB[2];
+    Bitboard checkers;
 
     int nonPawnCount[2];
 

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -178,6 +178,7 @@ void TakeMove(Position *pos) {
 
     // Get various info from history
     pos->key            = history(0).posKey;
+    pos->checkers       = history(0).checkers;
     pos->epSquare       = history(0).epSquare;
     pos->rule50         = history(0).rule50;
     pos->castlingRights = history(0).castlingRights;
@@ -190,6 +191,7 @@ bool MakeMove(Position *pos, const Move move) {
 
     // Save position
     history(0).posKey         = pos->key;
+    history(0).checkers       = pos->checkers;
     history(0).move           = move;
     history(0).epSquare       = pos->epSquare;
     history(0).rule50         = pos->rule50;
@@ -266,6 +268,7 @@ bool MakeMove(Position *pos, const Move move) {
     if (KingAttacked(pos, sideToMove^1))
         return TakeMove(pos), false;
 
+    pos->checkers = Checkers(pos);
     pos->nodes++;
 
     assert(PositionOk(pos));

--- a/src/move.h
+++ b/src/move.h
@@ -83,7 +83,7 @@ INLINE bool CastlePseudoLegal(const Position *pos, Color color, int side) {
 
     return (pos->castlingRights & castle)
         && !(pieceBB(ALL) & blocking)
-        && !pos->checkers
+        && !SqAttacked(pos, kingSq, !color)
         && !SqAttacked(pos, midway, !color);
 }
 

--- a/src/move.h
+++ b/src/move.h
@@ -83,7 +83,7 @@ INLINE bool CastlePseudoLegal(const Position *pos, Color color, int side) {
 
     return (pos->castlingRights & castle)
         && !(pieceBB(ALL) & blocking)
-        && !SqAttacked(pos, kingSq, !color)
+        && !pos->checkers
         && !SqAttacked(pos, midway, !color);
 }
 

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -68,10 +68,8 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const Color color, cons
     const Direction left  = color == WHITE ? WEST  : EAST;
     const Direction right = color == WHITE ? EAST  : WEST;
 
-    const Bitboard empty   = pos->checkers ? BetweenBB[Lsb(colorPieceBB(color, KING))][Lsb(pos->checkers)]
-                                           : ~pieceBB(ALL);
-    const Bitboard enemies = pos->checkers ? pos->checkers
-                                           : colorBB(!color);
+    const Bitboard empty   = ~pieceBB(ALL);
+    const Bitboard enemies = pos->checkers ? pos->checkers : colorBB(!color);
     const Bitboard pawns   = colorPieceBB(color, PAWN);
 
     const Bitboard on7th  = pawns & RankBB[RelativeRank(color, RANK_7)];
@@ -83,6 +81,10 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const Color color, cons
         Bitboard pawnMoves  = empty & ShiftBB(up, not7th);
         Bitboard pawnStarts = empty & ShiftBB(up, pawnMoves)
                                     & RankBB[RelativeRank(color, RANK_4)];
+
+        if (pos->checkers)
+            pawnMoves  &= BetweenBB[Lsb(colorPieceBB(color, KING))][Lsb(pos->checkers)],
+            pawnStarts &= BetweenBB[Lsb(colorPieceBB(color, KING))][Lsb(pos->checkers)];
 
         // Normal pawn moves
         while (pawnMoves) {

--- a/src/search.c
+++ b/src/search.c
@@ -191,7 +191,7 @@ static int AlphaBeta(Thread *thread, int alpha, int beta, Depth depth, PV *pv, M
     }
 
     // Extend search if in check
-    const bool inCheck = KingAttacked(pos, sideToMove);
+    const bool inCheck = pos->checkers;
     if (inCheck && depth + 1 < MAXDEPTH) depth++;
 
     // Quiescence at the end of search


### PR DESCRIPTION
Keep a bitboard of checking pieces in the position, and use it to avoid generating a lot of illegal moves when in check.

ELO   | 3.25 +- 3.18 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 21360 W: 5088 L: 4888 D: 11384
http://chess.grantnet.us/test/7802/

ELO   | 7.11 +- 4.89 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.03 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 7280 W: 1447 L: 1298 D: 4535
http://chess.grantnet.us/test/7806/