### PR TITLE
History bonus only on beta cut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -167,6 +167,10 @@ INLINE void UpdateHistory(Thread *thread, Move quiets[], Move move, Depth depth,
         killer1 = move;
     }
 
+    // Bonus to the move that caused the beta cutoff
+    if (depth > 1)
+        thread->history[sideToMove][fromSq(move)][toSq(move)] += depth * depth;
+
     // Lower history scores of moves that failed to produce a cut
     for (int i = 0; i < count; ++i) {
         Move m = quiets[i];
@@ -473,10 +477,6 @@ skip_search:
 
                 alpha = score;
 
-                // Update search history
-                if (quiet && depth > 1)
-                    thread->history[sideToMove][fromSq(move)][toSq(move)] += depth * depth;
-
                 // If score beats beta we have a cutoff
                 if (score >= beta)
                     break;
@@ -484,7 +484,7 @@ skip_search:
         }
     }
 
-    // Lower history scores of moves that failed to produce a cut
+    // Update history if a quiet move causes a beta cutoff
     if (bestScore >= beta && moveIsQuiet(bestMove))
         UpdateHistory(thread, quiets, bestMove, depth, quietCount);
 


### PR DESCRIPTION
No bonus for moves that beat alpha.

ELO   | 3.12 +- 3.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 23248 W: 5496 L: 5287 D: 12465
http://chess.grantnet.us/test/7810/

ELO   | 4.61 +- 3.79 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 12144 W: 2365 L: 2204 D: 7575
http://chess.grantnet.us/test/7815/