### PR TITLE
Lower base LMR of captures again

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -52,7 +52,7 @@ CONSTR InitReductions() {
 
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.60 + log(depth) * log(moves) / 3.5, // capture
+            Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.25, // capture
             Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 2.25; // quiet
 }
 


### PR DESCRIPTION
Start the LMR of captures at zero, but increase the curve slightly.

ELO   | 4.00 +- 3.68 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 16144 W: 3916 L: 3730 D: 8498
http://chess.grantnet.us/test/7831/

ELO   | 2.59 +- 2.57 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 26384 W: 5053 L: 4856 D: 16475
http://chess.grantnet.us/test/7832/