### PR TITLE
Support 'go mate x'

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -567,6 +567,12 @@ static void *IterativeDeepening(void *voidThread) {
         // Only the main thread concerns itself with the rest
         if (!mainThread) continue;
 
+        // Stop searching after finding a short enough mate
+        if (   Limits.mate
+            && thread->score >= MATE_IN_MAX
+            && MATE - thread->score <= 2 * Limits.mate)
+            break;
+
         bool uncertain = ss->pv.line[0] != thread->bestMove;
 
         // Save bestMove and ponderMove before overwriting the pv next iteration

--- a/src/search.c
+++ b/src/search.c
@@ -568,10 +568,7 @@ static void *IterativeDeepening(void *voidThread) {
         if (!mainThread) continue;
 
         // Stop searching after finding a short enough mate
-        if (   Limits.mate
-            && thread->score >= MATE_IN_MAX
-            && MATE - thread->score <= 2 * Limits.mate)
-            break;
+        if (MATE - abs(thread->score) <= 2 * Limits.mate) break;
 
         bool uncertain = ss->pv.line[0] != thread->bestMove;
 

--- a/src/search.h
+++ b/src/search.h
@@ -28,6 +28,7 @@ typedef struct {
     TimePoint start;
     int time, inc, movestogo, movetime, depth;
     int optimalUsage, maxUsage;
+    int mate;
     bool timelimit, infinite;
 
 } SearchLimits;

--- a/src/uci.c
+++ b/src/uci.c
@@ -52,6 +52,7 @@ static void ParseTimeControl(char *str, Color color) {
     SetLimit(str, "movestogo", &Limits.movestogo);
     SetLimit(str, "movetime",  &Limits.movetime);
     SetLimit(str, "depth",     &Limits.depth);
+    SetLimit(str, "mate",      &Limits.mate);
 
     Limits.timelimit = Limits.time || Limits.movetime;
 


### PR DESCRIPTION
Also works for getting mated in x. Can fail if Weiss thinks it's getting mated in x or fewer moves, when it should be a mating in x, but this should be extremely rare, if at all possible.

No impact on playing strength.