### PR TITLE
Pawn cache

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -149,6 +149,9 @@ static void AddPiece(Position *pos, const Square sq, const Piece piece) {
     pos->phaseValue += PhaseValue[piece];
     pos->nonPawnCount[color] += NonPawn[piece];
 
+    if (PieceTypeOf(piece) == PAWN)
+        pos->pawnKey ^= PieceKeys[piece][sq];
+
     // Update bitboards
     pieceBB(ALL)   |= BB(sq);
     pieceBB(pt)    |= BB(sq);

--- a/src/board.c
+++ b/src/board.c
@@ -357,6 +357,20 @@ void PrintBoard(const Position *pos) {
 #endif
 
 #ifndef NDEBUG
+// Generates the pawn key from scratch
+static Key GenPawnKey(const Position *pos) {
+
+    Key key = 0;
+
+    for (Color c = BLACK; c <= WHITE; c++) {
+        Bitboard pawns = colorPieceBB(c, PAWN);
+        while (pawns)
+            key ^= PieceKeys[MakePiece(c, PAWN)][PopLsb(&pawns)];
+    }
+
+    return key;
+}
+
 // Check board state makes sense
 bool PositionOk(const Position *pos) {
 
@@ -397,6 +411,7 @@ bool PositionOk(const Position *pos) {
         && pos->castlingRights <= 15);
 
     assert(GeneratePosKey(pos) == pos->key);
+    assert(GenPawnKey(pos) == pos->pawnKey);
 
     assert(!KingAttacked(pos, !sideToMove));
 

--- a/src/board.h
+++ b/src/board.h
@@ -52,6 +52,7 @@ typedef struct Position {
     uint16_t gameMoves;
 
     Key key;
+    Key pawnKey;
 
     uint64_t nodes;
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -181,21 +181,6 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
     return eval;
 }
 
-static Key GenPawnKey(const Position *pos) {
-
-    Key key = 0;
-
-    Bitboard whitePawns = colorPieceBB(WHITE, PAWN);
-    while (whitePawns)
-        key ^= PieceKeys[wP][PopLsb(&whitePawns)];
-
-    Bitboard blackPawns = colorPieceBB(BLACK, PAWN);
-    while (blackPawns)
-        key ^= PieceKeys[bP][PopLsb(&blackPawns)];
-
-    return key;
-}
-
 // Tries to get pawn eval from cache, otherwise evaluates and saves
 int ProbePawnCache(const Position *pos) {
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -199,6 +199,9 @@ static Key GenPawnKey(const Position *pos) {
 // Tries to get pawn eval from cache, otherwise evaluates and saves
 int ProbePawnCache(const Position *pos) {
 
+    // Can't cache when tuning as full trace is needed
+    if (TRACE) return EvalPawns(pos, WHITE) - EvalPawns(pos, BLACK);
+
     Key key = GenPawnKey(pos);
     PawnEntry *pe = &cache[key % PAWN_CACHE_SIZE];
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -202,11 +202,11 @@ int ProbePawnCache(const Position *pos) {
     // Can't cache when tuning as full trace is needed
     if (TRACE) return EvalPawns(pos, WHITE) - EvalPawns(pos, BLACK);
 
-    Key key = GenPawnKey(pos);
+    Key key = pos->pawnKey;
     PawnEntry *pe = &cache[key % PAWN_CACHE_SIZE];
 
     if (pe->key != key)
-        pe->key = key,
+        pe->key  = key,
         pe->eval = EvalPawns(pos, WHITE) - EvalPawns(pos, BLACK);
 
     return pe->eval;

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -22,13 +22,18 @@
 #include "types.h"
 
 
+#define PAWN_CACHE_SIZE 128 * 1024
+
+typedef struct PawnEntry {
+    Key key;
+    int eval;
+} PawnEntry;
+
+typedef PawnEntry PawnCache[PAWN_CACHE_SIZE];
+
+
 extern const int Tempo;
 extern const int PieceValue[2][PIECE_NB];
-
-
-typedef struct EvalInfo {
-    Bitboard mobilityArea[2];
-} EvalInfo;
 
 
 // Tapered Eval
@@ -59,4 +64,4 @@ static inline int UpdatePhase(int value) {
 }
 
 // Returns a static evaluation of the position
-int EvalPosition(const Position *pos);
+int EvalPosition(const Position *pos, PawnCache pc);

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -124,8 +124,7 @@ static void MovePiece(Position *pos, const Square from, const Square to, const b
         HASH_PCE(piece, to);
 
     if (PieceTypeOf(piece) == PAWN)
-        pos->pawnKey ^= PieceKeys[piece][from],
-        pos->pawnKey ^= PieceKeys[piece][to];
+        pos->pawnKey ^= PieceKeys[piece][from] ^ PieceKeys[piece][to];
 
     // Set old square to empty, new to piece
     pieceOn(from) = EMPTY;

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -54,6 +54,9 @@ static void ClearPiece(Position *pos, const Square sq, const bool hash) {
     if (hash)
         HASH_PCE(piece, sq);
 
+    if (PieceTypeOf(piece) == PAWN)
+        pos->pawnKey ^= PieceKeys[piece][sq];
+
     // Set square to empty
     pieceOn(sq) = EMPTY;
 
@@ -82,6 +85,9 @@ static void AddPiece(Position *pos, const Square sq, const Piece piece, const bo
     // Hash in piece at square
     if (hash)
         HASH_PCE(piece, sq);
+
+    if (PieceTypeOf(piece) == PAWN)
+        pos->pawnKey ^= PieceKeys[piece][sq];
 
     // Update square
     pieceOn(sq) = piece;
@@ -116,6 +122,10 @@ static void MovePiece(Position *pos, const Square from, const Square to, const b
     if (hash)
         HASH_PCE(piece, from),
         HASH_PCE(piece, to);
+
+    if (PieceTypeOf(piece) == PAWN)
+        pos->pawnKey ^= PieceKeys[piece][from],
+        pos->pawnKey ^= PieceKeys[piece][to];
 
     // Set old square to empty, new to piece
     pieceOn(from) = EMPTY;

--- a/src/search.c
+++ b/src/search.c
@@ -101,11 +101,11 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
 
     // If we are at max depth, return static eval
     if (ss->ply >= MAXDEPTH)
-        return EvalPosition(pos);
+        return EvalPosition(pos, thread->pawnCache);
 
     // Standing Pat -- If the stand-pat beats beta there is most likely also a move that beats beta
     // so we assume we have a beta cutoff. If the stand-pat beats alpha we use it as alpha.
-    int score = EvalPosition(pos);
+    int score = EvalPosition(pos, thread->pawnCache);
     if (score >= beta)
         return score;
     if (score + QuiescenceDeltaMargin(pos) < alpha)
@@ -200,7 +200,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
         // Max depth reached
         if (ss->ply >= MAXDEPTH)
-            return EvalPosition(pos);
+            return EvalPosition(pos, thread->pawnCache);
 
         // Mate distance pruning
         alpha = MAX(alpha, -MATE + ss->ply);
@@ -251,7 +251,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Do a static evaluation for pruning considerations
     int eval = ss->eval = inCheck          ? NOSCORE
                         : lastMoveNullMove ? -(ss-1)->eval + 2 * Tempo
-                                           : EvalPosition(pos);
+                                           : EvalPosition(pos, thread->pawnCache);
 
     // Use ttScore as eval if it is more informative
     if (   ttScore != NOSCORE

--- a/src/tests.c
+++ b/src/tests.c
@@ -238,7 +238,7 @@ void Perft(char *line) {
 
 void PrintEval(Position *pos) {
 
-    printf("%d\n", sideToMove == WHITE ? EvalPosition(pos) : -EvalPosition(pos));
+    printf("%d\n", sideToMove == WHITE ? EvalPosition(pos, NULL) : -EvalPosition(pos, NULL));
     fflush(stdout);
 }
 
@@ -262,9 +262,9 @@ void MirrorEvalTest(Position *pos) {
 
         ParseFen(lineIn, pos);
         positions++;
-        ev1 = EvalPosition(pos);
+        ev1 = EvalPosition(pos, NULL);
         MirrorBoard(pos);
-        ev2 = EvalPosition(pos);
+        ev2 = EvalPosition(pos, NULL);
 
         if (ev1 != ev2) {
             printf("\n\n\n");

--- a/src/threads.c
+++ b/src/threads.c
@@ -60,6 +60,13 @@ uint64_t TotalTBHits(const Thread *threads) {
     return total;
 }
 
+// Resets all data that isn't reset each turn
+void ResetThreads(Thread *threads) {
+
+    for (int i = 0; i < threads->count; ++i)
+        memset(threads[i].pawnCache, 0, sizeof(PawnCache));
+}
+
 // Thread sleeps until it is woken up
 void Wait(Thread *thread, volatile bool *condition) {
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "board.h"
+#include "evaluate.h"
 #include "types.h"
 
 
@@ -56,6 +57,8 @@ typedef struct Thread {
     pthread_mutex_t mutex;
     pthread_cond_t sleepCondition;
     pthread_t *pthreads;
+
+    PawnCache pawnCache;
 
 } Thread;
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -50,6 +50,7 @@ typedef struct Thread {
 
     // Anything below here is not zeroed out between searches
     Position pos;
+    PawnCache pawnCache;
 
     int index;
     int count;
@@ -58,13 +59,12 @@ typedef struct Thread {
     pthread_cond_t sleepCondition;
     pthread_t *pthreads;
 
-    PawnCache pawnCache;
-
 } Thread;
 
 
 Thread *InitThreads(int threadCount);
 uint64_t TotalNodes(const Thread *threads);
 uint64_t TotalTBHits(const Thread *threads);
+void ResetThreads(Thread *threads);
 void Wait(Thread *thread, volatile bool *condition);
 void Wake(Thread *thread);

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -354,8 +354,8 @@ void InitTunerEntry(TEntry *entry, Position *pos) {
 
     // Save a white POV static evaluation
     TCoeffs coeffs; T = EmptyTrace;
-    entry->seval = pos->stm == WHITE ?  EvalPosition(pos)
-                                     : -EvalPosition(pos);
+    entry->seval = pos->stm == WHITE ?  EvalPosition(pos, NULL)
+                                     : -EvalPosition(pos, NULL);
 
     // evaluate() -> [[NTERMS][COLOUR_NB]]
     InitCoefficients(coeffs);

--- a/src/uci.c
+++ b/src/uci.c
@@ -172,6 +172,7 @@ static void UCIIsReady(Engine *engine) {
 // Reset for a new game
 static void UCINewGame(Engine *engine) {
     ClearTT(engine->threads);
+    ResetThreads(engine->threads);
     failedQueries = 0;
 }
 


### PR DESCRIPTION
Pawn evaluation doesn't depend on any other pieces, and doesn't change too often so caching it and reusing it later is a nice speedup. Gets about 80-90% hitrate depending on position.

ELO   | 10.11 +- 6.10 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5776 W: 1427 L: 1259 D: 3090