### PR TITLE
Fix mate x

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -562,7 +562,7 @@ static void *IterativeDeepening(void *voidThread) {
         if (!mainThread) continue;
 
         // Stop searching after finding a short enough mate
-        if (MATE - abs(thread->score) <= 2 * Limits.mate) break;
+        if (MATE - abs(thread->score) <= 2 * abs(Limits.mate)) break;
 
         bool uncertain = ss->pv.line[0] != thread->bestMove;
 


### PR DESCRIPTION
When getting mated the given value is supposed to be negative. This solution still allows finding a mate for the wrong side, but I still think that's unlikely enough, if not impossible, that it's not worth worrying about.