### PR TITLE
Fix go mate

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -561,14 +561,14 @@ static void *IterativeDeepening(void *voidThread) {
         // Only the main thread concerns itself with the rest
         if (!mainThread) continue;
 
-        // Stop searching after finding a short enough mate
-        if (MATE - abs(thread->score) <= 2 * abs(Limits.mate)) break;
-
         bool uncertain = ss->pv.line[0] != thread->bestMove;
 
         // Save bestMove and ponderMove before overwriting the pv next iteration
         thread->bestMove   = ss->pv.line[0];
         thread->ponderMove = ss->pv.length > 1 ? ss->pv.line[1] : NOMOVE;
+
+        // Stop searching after finding a short enough mate
+        if (MATE - abs(thread->score) <= 2 * abs(Limits.mate)) break;
 
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -16,6 +16,14 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+
+/*
+  Gradient Decent Tuning for Chess Engines as described by Andrew Grant
+  in his paper: Evaluation & Tuning in Chess Engines:
+
+  https://github.com/AndyGrant/Ethereal/blob/master/Tuning.pdf
+*/
+
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -16,6 +16,14 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
+
+/*
+  Gradient Decent Tuning for Chess Engines as described by Andrew Grant
+  in his paper: Evaluation & Tuning in Chess Engines:
+
+  https://github.com/AndyGrant/Ethereal/blob/master/Tuning.pdf
+*/
+
 #pragma once
 
 #include "../types.h"


### PR DESCRIPTION
Update bestmove before aborting search in go mate. Often the mate found starts with the best move of the previous iteration, but not always. Also for mate in 1 it would print a1a1 as bestmove would be 0.

Also added a link to @AndyGrant 's paper on eval tuning.