### PR TITLE
Change perft print to be more similar to others

### DIFF
--- a/src/tests.c
+++ b/src/tests.c
@@ -192,10 +192,10 @@ void Perft(char *str) {
     const TimePoint elapsed = TimeSince(start) + 1;
 
     printf("\nPerft complete:"
-           "\nTime  : %" PRId64 "ms"
-           "\nLeaves: %" PRIu64
-           "\nLPS   : %" PRId64 "\n",
-           elapsed, leafNodes, leafNodes * 1000 / elapsed);
+           "\nTime : %" PRId64 "ms"
+           "\nNPS  : %" PRId64
+           "\nNodes: %" PRIu64 "\n",
+           elapsed, leafNodes * 1000 / elapsed, leafNodes);
     fflush(stdout);
     free(thread);
 }


### PR DESCRIPTION
Made a python script to test perft on fens from a file, seems most others print either just the nodecount alone, or following a token like "Nodes:" so to make it easy to use the script with other engines I'll make the prints of Weiss more standard, and let the script expect that.

No functional change