### PR TITLE
Cleanup

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -363,7 +363,7 @@ static Key GenPawnKey(const Position *pos) {
 // Check board state makes sense
 bool PositionOk(const Position *pos) {
 
-    assert(0 <= pos->histPly && pos->histPly < MAXGAMEMOVES);
+    assert(0 <= pos->histPly && pos->histPly < 256);
 
     int counts[PIECE_NB] = { 0 };
     int nonPawnCount[2] = { 0, 0 };

--- a/src/board.h
+++ b/src/board.h
@@ -56,7 +56,7 @@ typedef struct Position {
 
     uint64_t nodes;
 
-    History gameHistory[MAXGAMEMOVES];
+    History gameHistory[256];
 
 } Position;
 
@@ -137,7 +137,7 @@ INLINE Color ColorOf(const Piece piece) {
 }
 
 INLINE PieceType PieceTypeOf(const Piece piece) {
-    return (piece & 7);
+    return piece & 7;
 }
 
 INLINE Piece MakePiece(const Color color, const PieceType pt) {

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -30,7 +30,7 @@ typedef struct {
 typedef struct {
     int count;
     int next;
-    MoveListEntry moves[MAXPOSITIONMOVES];
+    MoveListEntry moves[256];
 } MoveList;
 
 

--- a/src/search.c
+++ b/src/search.c
@@ -94,7 +94,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
         longjmp(thread->jumpBuffer, true);
 
     // If we are at max depth, return static eval
-    if (ss->ply >= MAXDEPTH)
+    if (ss->ply >= MAX_PLY)
         return EvalPosition(pos, thread->pawnCache);
 
     // Do a static evaluation for pruning considerations
@@ -199,7 +199,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
             return 0;
 
         // Max depth reached
-        if (ss->ply >= MAXDEPTH)
+        if (ss->ply >= MAX_PLY)
             return EvalPosition(pos, thread->pawnCache);
 
         // Mate distance pruning
@@ -239,7 +239,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         thread->tbhits++;
 
         if (bound == BOUND_EXACT || (bound == BOUND_LOWER ? tbScore >= beta : tbScore <= alpha)) {
-            StoreTTEntry(tte, key, NOMOVE, ScoreToTT(tbScore, ss->ply), MAXDEPTH, bound);
+            StoreTTEntry(tte, key, NOMOVE, ScoreToTT(tbScore, ss->ply), MAX_PLY, bound);
             return tbScore;
         }
 
@@ -576,7 +576,7 @@ static void *IterativeDeepening(void *voidThread) {
             break;
 
         // Clear key history for seldepth calculation
-        for (int i = 1; i < MAXDEPTH; ++i)
+        for (int i = 1; i < MAX_PLY; ++i)
             history(i).key = 0;
     }
 
@@ -590,7 +590,7 @@ static void PrepareSearch(Position *pos, Thread *threads) {
     for (Thread *t = threads; t < threads + threads->count; ++t) {
         memset(t, 0, offsetof(Thread, pos));
         memcpy(&t->pos, pos, sizeof(Position));
-        for (Depth d = 0; d < MAXDEPTH; ++d)
+        for (Depth d = 0; d < MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
     }
 

--- a/src/search.c
+++ b/src/search.c
@@ -546,7 +546,7 @@ static void *IterativeDeepening(void *voidThread) {
 
     Thread *thread = voidThread;
     Position *pos = &thread->pos;
-    Stack *ss = thread->ss;
+    Stack *ss = thread->ss+SS_OFFSET;
     bool mainThread = thread->index == 0;
 
     // Iterative deepening
@@ -591,7 +591,7 @@ static void PrepareSearch(Position *pos, Thread *threads) {
         memset(t, 0, offsetof(Thread, pos));
         memcpy(&t->pos, pos, sizeof(Position));
         for (Depth d = 0; d < MAXDEPTH; ++d)
-            (t->ss+d)->ply = d;
+            (t->ss+SS_OFFSET+d)->ply = d;
     }
 
     // Mark TT as used

--- a/src/search.c
+++ b/src/search.c
@@ -211,7 +211,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Extend search if in check
     const bool inCheck = pos->checkers;
-    if (inCheck && depth + 1 < MAXDEPTH) depth++;
+    if (inCheck) depth++;
 
     // Quiescence at the end of search
     if (depth <= 0)
@@ -239,7 +239,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         thread->tbhits++;
 
         if (bound == BOUND_EXACT || (bound == BOUND_LOWER ? tbScore >= beta : tbScore <= alpha)) {
-            StoreTTEntry(tte, key, NOMOVE, ScoreToTT(tbScore, ss->ply), MAXDEPTH-1, bound);
+            StoreTTEntry(tte, key, NOMOVE, ScoreToTT(tbScore, ss->ply), MAXDEPTH, bound);
             return tbScore;
         }
 

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -108,7 +108,7 @@ bool RootProbe(Position *pos, Thread *thread) {
     // Print thinking info
     printf("info depth %d seldepth %d score cp %d "
            "time 0 nodes 0 nps 0 tbhits 1 pv %s\n",
-           MAXDEPTH-1, MAXDEPTH-1, score, MoveToStr(move));
+           MAXDEPTH, MAXDEPTH, score, MoveToStr(move));
     fflush(stdout);
 
     // Set move to be printed as conclusion

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -108,7 +108,7 @@ bool RootProbe(Position *pos, Thread *thread) {
     // Print thinking info
     printf("info depth %d seldepth %d score cp %d "
            "time 0 nodes 0 nps 0 tbhits 1 pv %s\n",
-           MAXDEPTH, MAXDEPTH, score, MoveToStr(move));
+           MAX_PLY, MAX_PLY, score, MoveToStr(move));
     fflush(stdout);
 
     // Set move to be printed as conclusion

--- a/src/threads.h
+++ b/src/threads.h
@@ -23,6 +23,9 @@
 #include "types.h"
 
 
+#define SS_OFFSET 10
+
+
 typedef struct {
     int eval;
     Depth ply;
@@ -44,7 +47,7 @@ typedef struct Thread {
 
     jmp_buf jumpBuffer;
 
-    Stack ss[MAXDEPTH];
+    Stack ss[128];
 
     int history[2][64][64];
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -32,7 +32,7 @@
 
 #define ValidBound(bound) (bound >= BOUND_UPPER && bound <= BOUND_EXACT)
 #define ValidScore(score) (score >= -MATE && score <= MATE)
-#define ValidDepth(depth) (depth >= 1 && depth < MAXDEPTH)
+#define ValidDepth(depth) (depth >= 1 && depth <= MAXDEPTH)
 
 
 enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };

--- a/src/types.h
+++ b/src/types.h
@@ -60,7 +60,7 @@ typedef int32_t PieceType;
 
 
 enum {
-    MAXDEPTH = 100
+    MAX_PLY = 100
 };
 
 enum Score {
@@ -137,5 +137,5 @@ enum CastlingRights {
 
 typedef struct PV {
     int length;
-    Move line[MAXDEPTH];
+    Move line[MAX_PLY];
 } PV;

--- a/src/types.h
+++ b/src/types.h
@@ -62,7 +62,7 @@ typedef int32_t PieceType;
 enum Limit {
     MAXGAMEMOVES     = 256,
     MAXPOSITIONMOVES = 256,
-    MAXDEPTH         = 128
+    MAXDEPTH         = 100
 };
 
 enum Score {

--- a/src/types.h
+++ b/src/types.h
@@ -59,10 +59,8 @@ typedef int32_t Piece;
 typedef int32_t PieceType;
 
 
-enum Limit {
-    MAXGAMEMOVES     = 256,
-    MAXPOSITIONMOVES = 256,
-    MAXDEPTH         = 100
+enum {
+    MAXDEPTH = 100
 };
 
 enum Score {

--- a/src/uci.c
+++ b/src/uci.c
@@ -55,8 +55,8 @@ static void ParseTimeControl(char *str, Color color) {
 
     Limits.timelimit = Limits.time || Limits.movetime;
 
-    // If no depth limit is given, use MAXDEPTH - 1
-    Limits.depth = Limits.depth == 0 ? MAXDEPTH - 1 : Limits.depth;
+    // If no depth limit is given, use MAXDEPTH
+    Limits.depth = !Limits.depth ? MAXDEPTH : MIN(Limits.depth, MAXDEPTH);
 }
 
 // Begins a search with the given setup

--- a/src/uci.c
+++ b/src/uci.c
@@ -54,9 +54,7 @@ static void ParseTimeControl(char *str, Color color) {
     SetLimit(str, "mate",      &Limits.mate);
 
     Limits.timelimit = Limits.time || Limits.movetime;
-
-    // If no depth limit is given, use MAXDEPTH
-    Limits.depth = !Limits.depth ? MAXDEPTH : MIN(Limits.depth, MAXDEPTH);
+    Limits.depth = !Limits.depth ? MAX_PLY : MIN(Limits.depth, MAX_PLY);
 }
 
 // Begins a search with the given setup
@@ -244,7 +242,7 @@ void PrintThinking(const Thread *thread, const Stack *ss, int score, int alpha, 
     int hashFull      = HashFull();
     int nps           = (int)(1000 * nodes / (elapsed + 1));
 
-    Depth seldepth = MAXDEPTH;
+    Depth seldepth = MAX_PLY;
     for (; seldepth > 0; --seldepth)
         if (history(seldepth-1).key != 0) break;
 


### PR DESCRIPTION
Set max search depth to 100, and add a buffer at the beginning of the search stack so looking up positions before root is safe. Properly cap 'go depth x' at the normal maximum depth.

No functional change.