### PR TITLE
Fix TB scoring

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -231,6 +231,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         return ttScore;
 
     int bestScore = -INFINITE;
+    int maxScore  =  INFINITE;
 
     // Probe syzygy TBs
     int tbScore, bound;
@@ -243,9 +244,13 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
             return tbScore;
         }
 
-        if (pvNode && bound == BOUND_LOWER)
-            bestScore = tbScore,
-            alpha = MAX(alpha, tbScore);
+        if (pvNode) {
+            if (bound == BOUND_LOWER)
+                bestScore = tbScore,
+                alpha = MAX(alpha, tbScore);
+            else
+                maxScore = tbScore;
+        }
     }
 
     // Do a static evaluation for pruning considerations
@@ -477,6 +482,8 @@ skip_search:
         return ss->excluded ? alpha
              : inCheck      ? -MATE + ss->ply
                             : 0;
+
+    bestScore = MIN(bestScore, maxScore);
 
     // Store in TT
     const int flag = bestScore >= beta ? BOUND_LOWER


### PR DESCRIPTION
In positions the TB says are losing weiss keeps searching to see if it's even worse (getting mated), but can also fail to see that it's losing at all. This avoids returning a score that's better than TB loss in such a situation.