### PR TITLE
History score decay

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -154,7 +154,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     return bestScore;
 }
 
-INLINE void HistoryBonus(int *cur, int bonus) {
+INLINE void HistoryBonus(int16_t *cur, int bonus) {
     *cur += bonus - *cur * abs(bonus) / 29952;
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -154,6 +154,10 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     return bestScore;
 }
 
+INLINE void HistoryBonus(int *cur, int bonus) {
+    *cur += bonus - *cur * abs(bonus) / 29952;
+}
+
 // Updates various history heuristics when a quiet move causes a cutoff
 INLINE void UpdateHistory(Thread *thread, Stack *ss, Move quiets[], Move move, Depth depth, int count) {
 
@@ -165,15 +169,17 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move quiets[], Move move, D
         ss->killers[0] = move;
     }
 
+    int bonus = depth * depth;
+
     // Bonus to the move that caused the beta cutoff
     if (depth > 1)
-        thread->history[sideToMove][fromSq(move)][toSq(move)] += depth * depth;
+        HistoryBonus(&thread->history[sideToMove][fromSq(move)][toSq(move)], bonus);
 
     // Lower history scores of moves that failed to produce a cut
     for (int i = 0; i < count; ++i) {
         Move m = quiets[i];
         if (m == move) continue;
-        thread->history[sideToMove][fromSq(m)][toSq(m)] -= depth * depth;
+        HistoryBonus(&thread->history[sideToMove][fromSq(m)][toSq(m)], -bonus);
     }
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -155,7 +155,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
 }
 
 INLINE void HistoryBonus(int16_t *cur, int bonus) {
-    *cur += bonus - *cur * abs(bonus) / 29952;
+    *cur += 32 * bonus - *cur * abs(bonus) / 512;
 }
 
 // Updates various history heuristics when a quiet move causes a cutoff

--- a/src/threads.h
+++ b/src/threads.h
@@ -49,7 +49,7 @@ typedef struct Thread {
 
     Stack ss[128];
 
-    int history[2][64][64];
+    int16_t history[2][64][64];
 
     // Anything below here is not zeroed out between searches
     Position pos;


### PR DESCRIPTION
Fix history scores overflowing. Formula from Ethereal.

Testing with [-5, 0]:

ELO   | 11.05 +- 7.87 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3648 W: 947 L: 831 D: 1870
http://chess.grantnet.us/test/9366/

ELO   | 10.39 +- 6.89 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 3680 W: 750 L: 640 D: 2290
http://chess.grantnet.us/test/9367/