### PR TITLE
History tt cut bonus

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -233,8 +233,13 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Trust TT if not a pvnode and the entry depth is sufficiently high
     if (   !pvNode && ttHit && tte->depth >= depth
-        && (ttScore >= beta ? tte->bound & BOUND_LOWER : tte->bound & BOUND_UPPER))
-        return HistoryBonus(&thread->history[sideToMove][fromSq(ttMove)][toSq(ttMove)], depth*depth), ttScore;
+        && (ttScore >= beta ? tte->bound & BOUND_LOWER : tte->bound & BOUND_UPPER)) {
+
+        if (moveIsQuiet(ttMove))
+            HistoryBonus(&thread->history[sideToMove][fromSq(ttMove)][toSq(ttMove)], depth*depth);
+
+        return ttScore;
+    }
 
     int bestScore = -INFINITE;
     int maxScore  =  INFINITE;

--- a/src/search.c
+++ b/src/search.c
@@ -234,7 +234,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Trust TT if not a pvnode and the entry depth is sufficiently high
     if (   !pvNode && ttHit && tte->depth >= depth
         && (ttScore >= beta ? tte->bound & BOUND_LOWER : tte->bound & BOUND_UPPER))
-        return ttScore;
+        return HistoryBonus(&thread->history[sideToMove][fromSq(ttMove)][toSq(ttMove)], depth*depth), ttScore;
 
     int bestScore = -INFINITE;
     int maxScore  =  INFINITE;


### PR DESCRIPTION
Give a history bonus to the TT move when cutting with TT info.

ELO   | 4.58 +- 3.61 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17312 W: 4344 L: 4116 D: 8852
http://chess.grantnet.us/test/9422/

ELO   | 1.55 +- 1.57 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 70944 W: 13657 L: 13340 D: 43947
http://chess.grantnet.us/test/9424/