### PR TITLE
Don't count nodes while setting up position

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -98,6 +98,8 @@ static void UCIPosition(Position *pos, char *str) {
         if (pos->rule50 == 0)
             pos->histPly = 0;
     }
+
+    pos->nodes = 0;
 }
 
 // Parses a 'setoption' and updates settings


### PR DESCRIPTION
Noticed node count was different when setting up with FEN instead of startpos + moves. Fixed by resetting node count to 0 after parsing moves.