### PR TITLE
LMP based on total move count

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -371,7 +371,7 @@ move_loop:
         if (  !pvNode
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX
-            && quietCount > (3 + 2 * depth * depth) / (2 - improving)) {
+            && moveCount > (3 + 2 * depth * depth) / (2 - improving)) {
             mp.onlyNoisy = true;
             continue;
         }


### PR DESCRIPTION
Count all moves instead of only quiets for LMP.

ELO   | 4.19 +- 3.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 15168 W: 3702 L: 3519 D: 7947

ELO   | 4.50 +- 3.76 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 12280 W: 2380 L: 2221 D: 7679