### PR TITLE
Increase KingAttackPower each possible check

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -77,6 +77,7 @@ const int SemiOpenFile[2] = { S(  8, 15), S(  2,  2) };
 
 // KingSafety [pt-2]
 const uint16_t PieceAttackPower[4] = {35, 20, 40, 80};
+const uint16_t PieceCheckPower[4]  = {75, 25, 50, 50};
 const uint16_t PieceCountModifier[8] = {0, 0, 50, 75, 80, 88, 95, 100};
 
 // KingLineDanger
@@ -240,11 +241,12 @@ INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const
         // Attacks for king safety calculations
         int kingAttack = PopCount(mobilityBB & ei->enemyKingZone[color]);
 
-        Bitboard checks = AttackBB(pt,  Lsb(colorPieceBB(!color, KING)), pieceBB(ALL)) & mobilityBB;
+        int checks = PopCount(AttackBB(pt,  Lsb(colorPieceBB(!color, KING)), pieceBB(ALL)) & mobilityBB);
 
-        if (kingAttack > 0 || checks != 0) {
+        if (kingAttack > 0 || checks > 0) {
             ei->KingAttackCount[color]++;
             ei->KingAttackPower[color] += kingAttack * PieceAttackPower[pt - 2];
+            ei->KingAttackPower[color] += checks * PieceCheckPower[pt - 2];
         }
 
         if (pt == ROOK || pt == QUEEN) {

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -77,7 +77,7 @@ const int SemiOpenFile[2] = { S(  8, 15), S(  2,  2) };
 
 // KingSafety [pt-2]
 const uint16_t PieceAttackPower[4] = {35, 20, 40, 80};
-const uint16_t PieceCheckPower[4]  = {75, 25, 50, 50};
+const uint16_t PieceCheckPower[4]  = {100, 35, 65, 65};
 const uint16_t PieceCountModifier[8] = {0, 0, 50, 75, 80, 88, 95, 100};
 
 // KingLineDanger

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -241,12 +241,12 @@ INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const
         // Attacks for king safety calculations
         int kingAttack = PopCount(mobilityBB & ei->enemyKingZone[color]);
 
-        int checks = PopCount(AttackBB(pt,  Lsb(colorPieceBB(!color, KING)), pieceBB(ALL)) & mobilityBB);
+        int checks = PopCount(AttackBB(pt, Lsb(colorPieceBB(!color, KING)), pieceBB(ALL)) & mobilityBB);
 
         if (kingAttack > 0 || checks > 0) {
             ei->KingAttackCount[color]++;
-            ei->KingAttackPower[color] += kingAttack * PieceAttackPower[pt - 2];
-            ei->KingAttackPower[color] += checks * PieceCheckPower[pt - 2];
+            ei->KingAttackPower[color] += kingAttack * PieceAttackPower[pt - 2]
+                                        + checks * PieceCheckPower[pt - 2];
         }
 
         if (pt == ROOK || pt == QUEEN) {


### PR DESCRIPTION
STC:
ELO   | 4.83 +- 3.79 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16833 W: 4509 L: 4275 D: 8049
http://chess.grantnet.us/test/10000/

LTC:
ELO   | 11.66 +- 6.53 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4592 W: 1048 L: 894 D: 2650
http://chess.grantnet.us/test/10002/