### PR TITLE
Start king attack power at a value of -30

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -319,7 +319,7 @@ INLINE void InitEvalInfo(const Position *pos, EvalInfo *ei, const Color color) {
     b = AttackBB(KING, Lsb(colorPieceBB(!color, KING)), 0);
     ei->enemyKingZone[color] = b | ShiftBB(up, b);
 
-    ei->attackPower[color] = 0;
+    ei->attackPower[color] = -30;
     ei->attackCount[color] = 0;
 }
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -25,7 +25,7 @@
 #include "threads.h"
 
 
-#define NAME "Weiss 1.3"
+#define NAME "Weiss 1.3-dev"
 
 #define START_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 #define INPUT_SIZE 4096


### PR DESCRIPTION
STC:
ELO   | 2.33 +- 2.40 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 36814 W: 8535 L: 8288 D: 19991
http://chess.grantnet.us/test/10063/

LTC:
ELO   | 2.67 +- 2.59 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 24444 W: 4439 L: 4251 D: 15754
http://chess.grantnet.us/test/10087/