### PR TITLE
Reduce less for killers

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -443,7 +443,7 @@ move_loop:
             // Reduce less when improving
             R -= improving;
             // Reduce less for killers
-            R -= (mp.stage == KILLER1 || mp.stage == KILLER2);
+            R -= mp.stage == KILLER1 || mp.stage == KILLER2;
 
 
             // Depth after reductions, avoiding going straight to quiescence

--- a/src/search.c
+++ b/src/search.c
@@ -442,6 +442,9 @@ move_loop:
             R -= pvNode;
             // Reduce less when improving
             R -= improving;
+            // Reduce less for killers
+            R -= (mp.stage == KILLER1 || mp.stage == KILLER2);
+
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth RDepth = CLAMP(newDepth - R, 1, newDepth - 1);


### PR DESCRIPTION
Reduce less while trying killers because they are likely to cause a re-search
Passed STC:

ELO   | 3.67 +- 3.46 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.94 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 17596 W: 4105 L: 3919 D: 9572
http://chess.grantnet.us/test/10147/

Passed LTC:
ELO   | 4.74 +- 3.52 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13186 W: 2417 L: 2237 D: 8532
http://chess.grantnet.us/test/10149/