### PR TITLE
No pruning iteration 7

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -518,8 +518,8 @@ static int AspirationWindow(Thread *thread, Stack *ss) {
     int beta  =  INFINITE;
 
     // Decide how deep to go before starting to prune
-    int pruningLimit = Limits.timelimit ? (Limits.optimalUsage + 250) / 250 : 6;
-    thread->doPruning = depth > MIN(6, pruningLimit);
+    int pruningLimit = Limits.timelimit ? (Limits.optimalUsage + 250) / 250 : 7;
+    thread->doPruning = depth > MIN(7, pruningLimit);
 
     // Shrink the window at higher depths
     if (depth > 6)


### PR DESCRIPTION
Finished testing slightly negative, but it's a fairly unique feature so I'll take the slight loss in order to increase the effect of it.

ELO   | -0.91 +- 2.64 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | -2.99 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 24464 W: 4469 L: 4533 D: 15462