### PR TITLE
Allow helper threads to search past the depth limit

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -564,9 +564,10 @@ static void *IterativeDeepening(void *voidThread) {
     Position *pos = &thread->pos;
     Stack *ss = thread->ss+SS_OFFSET;
     bool mainThread = thread->index == 0;
+    int maxDepth = mainThread ? Limits.depth : MAX_PLY;
 
     // Iterative deepening
-    for (thread->depth = 1; thread->depth <= Limits.depth; ++thread->depth) {
+    for (thread->depth = 1; thread->depth <= maxDepth; ++thread->depth) {
 
         // Jump here and return if we run out of allocated time mid-search
         if (setjmp(thread->jumpBuffer)) break;

--- a/src/tests.c
+++ b/src/tests.c
@@ -97,7 +97,7 @@ void Benchmark(int argc, char **argv) {
 
     // Default depth 15, 1 thread, and 32MB hash
     Limits.timelimit = false;
-    Limits.depth     = argc > 2 ? atoi(argv[2]) : 15;
+    Limits.depth     = argc > 2 ? atoi(argv[2]) : 14;
     int threadCount  = argc > 3 ? atoi(argv[3]) : 1;
     TT.requestedMB   = argc > 4 ? atoi(argv[4]) : DEFAULTHASH;
 


### PR DESCRIPTION
Mainly to avoid low nps in fixed depth searches.