### PR TITLE
LMR tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -426,6 +426,7 @@ move_loop:
 
         const Depth newDepth = depth - 1 + extension;
 
+        bool doFullDepthSearch;
         bool doLMR =   depth > 2
                     && moveCount > (2 + pvNode)
                     && thread->doPruning;
@@ -445,9 +446,13 @@ move_loop:
             Depth RDepth = CLAMP(newDepth - R, 1, newDepth);
 
             score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, RDepth);
-        }
+
+            doFullDepthSearch = score > alpha && RDepth < newDepth;
+        } else
+            doFullDepthSearch = !pvNode || moveCount > 1;
+
         // Full depth zero-window search
-        if (doLMR ? score > alpha : !pvNode || moveCount > 1)
+        if (doFullDepthSearch)
             score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, newDepth);
 
         // Full depth alpha-beta window search

--- a/src/search.c
+++ b/src/search.c
@@ -442,7 +442,7 @@ move_loop:
             R -= mp.stage == KILLER1 || mp.stage == KILLER2;
 
             // Depth after reductions, avoiding going straight to quiescence
-            Depth RDepth = CLAMP(newDepth - R, 1, newDepth - 1);
+            Depth RDepth = CLAMP(newDepth - R, 1, newDepth);
 
             score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, RDepth);
         }

--- a/src/search.c
+++ b/src/search.c
@@ -427,12 +427,12 @@ move_loop:
         const Depth newDepth = depth - 1 + extension;
 
         bool doFullDepthSearch;
-        bool doLMR =   depth > 2
-                    && moveCount > (2 + pvNode)
-                    && thread->doPruning;
 
         // Reduced depth zero-window search
-        if (doLMR) {
+        if (   depth > 2
+            && moveCount > (2 + pvNode)
+            && thread->doPruning) {
+
             // Base reduction
             int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Reduce less in pv nodes


### PR DESCRIPTION
Allow LMR reduction to be 0, effectively skipping the LMR and doing a full depth zero-window search instead.

ELO   | 2.62 +- 2.68 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 30248 W: 7208 L: 6980 D: 16060

ELO   | 5.06 +- 4.03 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10576 W: 2036 L: 1882 D: 6658