### PR TITLE
Global threads

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -46,8 +46,7 @@ static Move PickNextMove(MoveList *list, const Move ttMove, const Move kill1, co
 
     for (int i = list->next + 1; i < list->count; ++i)
         if (list->moves[i].score > bestScore)
-            bestScore = list->moves[i].score,
-            bestIdx = i;
+            bestScore = list->moves[bestIdx = i].score;
 
     Move bestMove = list->moves[bestIdx].move;
     list->moves[bestIdx] = list->moves[list->next++];

--- a/src/noobprobe/noobprobe.c
+++ b/src/noobprobe/noobprobe.c
@@ -43,6 +43,7 @@
 #include "noobprobe.h"
 #include "../board.h"
 #include "../move.h"
+#include "../threads.h"
 
 
 bool noobbook;
@@ -53,7 +54,7 @@ int noobLimit;
 void error(const char *msg) { perror(msg); exit(0); }
 
 // Probes noobpwnftw's Chess Cloud Database
-bool ProbeNoob(Position *pos, Thread *threads) {
+bool ProbeNoob(Position *pos) {
 
     // Stop querying after 3 failures or at the specified depth
     if (  !noobbook

--- a/src/noobprobe/noobprobe.h
+++ b/src/noobprobe/noobprobe.h
@@ -16,7 +16,7 @@
   along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-#include "../threads.h"
+#include "../board.h"
 #include "../types.h"
 
 
@@ -25,4 +25,4 @@ extern int failedQueries;
 extern int noobLimit;
 
 
-bool ProbeNoob(Position *pos, Thread *threads);
+bool ProbeNoob(Position *pos);

--- a/src/search.c
+++ b/src/search.c
@@ -600,7 +600,7 @@ static void *IterativeDeepening(void *voidThread) {
 }
 
 // Root of search
-void SearchPosition(Position *pos) {
+void *SearchPosition(void *pos) {
 
     InitTimeManagement();
     PrepareSearch(pos);
@@ -630,4 +630,6 @@ conclusion:
 
     // Print conclusion
     PrintConclusion(threads);
+
+    return NULL;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -27,11 +27,11 @@
 #include "makemove.h"
 #include "move.h"
 #include "movepicker.h"
+#include "search.h"
+#include "syzygy.h"
 #include "time.h"
 #include "threads.h"
 #include "transposition.h"
-#include "search.h"
-#include "syzygy.h"
 #include "uci.h"
 
 
@@ -600,18 +600,18 @@ static void *IterativeDeepening(void *voidThread) {
 }
 
 // Root of search
-void SearchPosition(Position *pos, Thread *threads) {
+void SearchPosition(Position *pos) {
 
     InitTimeManagement();
-    PrepareSearch(threads, pos);
+    PrepareSearch(pos);
     bool threadsSpawned = false;
 
     // Probe TBs for a move if already in a TB position
-    if (RootProbe(pos, threads)) goto conclusion;
+    if (RootProbe(pos)) goto conclusion;
 
     // Probe noobpwnftw's Chess Cloud Database
     if (   (!Limits.timelimit || Limits.maxUsage > 2000)
-        && ProbeNoob(pos, threads)) goto conclusion;
+        && ProbeNoob(pos)) goto conclusion;
 
     // Make extra threads and begin searching
     threadsSpawned = true;

--- a/src/search.c
+++ b/src/search.c
@@ -613,10 +613,9 @@ void SearchPosition(Position *pos) {
     if (   (!Limits.timelimit || Limits.maxUsage > 2000)
         && ProbeNoob(pos)) goto conclusion;
 
-    // Make extra threads and begin searching
+    // Start helper threads and begin searching
     threadsSpawned = true;
-    for (int i = 1; i < threads->count; ++i)
-        pthread_create(&threads->pthreads[i], NULL, &IterativeDeepening, &threads[i]);
+    StartHelpers(IterativeDeepening);
     IterativeDeepening(&threads[0]);
 
 conclusion:
@@ -627,8 +626,7 @@ conclusion:
     // Signal any extra threads to stop and wait for them
     ABORT_SIGNAL = true;
     if (threadsSpawned)
-        for (int i = 1; i < threads->count; ++i)
-            pthread_join(threads->pthreads[i], NULL);
+        WaitForHelpers();
 
     // Print conclusion
     PrintConclusion(threads);

--- a/src/search.c
+++ b/src/search.c
@@ -621,9 +621,9 @@ void *SearchPosition(void *pos) {
 conclusion:
 
     // Wait for 'stop' in infinite search
-    if (Limits.infinite) Wait(threads, &ABORT_SIGNAL);
+    if (Limits.infinite) Wait(&ABORT_SIGNAL);
 
-    // Signal any extra threads to stop and wait for them
+    // Signal helper threads to stop and wait for them to finish
     ABORT_SIGNAL = true;
     if (threadsSpawned)
         WaitForHelpers();

--- a/src/search.h
+++ b/src/search.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "board.h"
-#include "threads.h"
 #include "types.h"
 
 
@@ -36,4 +35,4 @@ extern SearchLimits Limits;
 extern volatile bool ABORT_SIGNAL;
 
 
-void SearchPosition(Position *pos, Thread *threads);
+void SearchPosition(Position *pos);

--- a/src/search.h
+++ b/src/search.h
@@ -35,4 +35,4 @@ extern SearchLimits Limits;
 extern volatile bool ABORT_SIGNAL;
 
 
-void SearchPosition(Position *pos);
+void *SearchPosition(void *pos);

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -23,6 +23,7 @@
 #include "pyrrhic/tbprobe.h"
 #include "bitboard.h"
 #include "move.h"
+#include "transposition.h"
 #include "types.h"
 
 
@@ -67,7 +68,7 @@ bool ProbeWDL(const Position *pos, int *score, int *bound, int ply) {
 }
 
 // Calls pyrrhic to get optimal moves in tablebase positions in root
-bool RootProbe(Position *pos, Thread *thread) {
+bool RootProbe(Position *pos) {
 
     // Tablebases contain no positions with castling legal,
     // and if there are too many pieces a probe will fail
@@ -112,7 +113,7 @@ bool RootProbe(Position *pos, Thread *thread) {
     fflush(stdout);
 
     // Set move to be printed as conclusion
-    thread->bestMove = move;
+    threads->bestMove = move;
 
     return true;
 }

--- a/src/tests.c
+++ b/src/tests.c
@@ -102,7 +102,7 @@ void Benchmark(int argc, char **argv) {
     TT.requestedMB   = argc > 4 ? atoi(argv[4]) : DEFAULTHASH;
 
     Position pos;
-    threads = InitThreads(threadCount);
+    InitThreads(threadCount);
     InitTT(threads);
 
     int FENCount = sizeof(BenchmarkFENs) / sizeof(char *);
@@ -175,20 +175,19 @@ static uint64_t RecursivePerft(Thread *thread, const Depth depth) {
 void Perft(char *str) {
 
     char *default_fen = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1";
-    Thread *thread = InitThreads(1);
 
     strtok(str, " ");
     char *d = strtok(NULL, " ");
     char *fen = strtok(NULL, "\0") ?: default_fen;
 
     Depth depth = d ? atoi(d) : 5;
-    ParseFen(fen, &thread->pos);
+    ParseFen(fen, &threads->pos);
 
     printf("\nPerft starting:\nDepth : %d\nFEN   : %s\n", depth, fen);
     fflush(stdout);
 
     const TimePoint start = Now();
-    uint64_t leafNodes = RecursivePerft(thread, depth);
+    uint64_t leafNodes = RecursivePerft(threads, depth);
     const TimePoint elapsed = TimeSince(start) + 1;
 
     printf("\nPerft complete:"
@@ -197,7 +196,6 @@ void Perft(char *str) {
            "\nNodes: %" PRIu64 "\n",
            elapsed, leafNodes * 1000 / elapsed, leafNodes);
     fflush(stdout);
-    free(thread);
 }
 
 void PrintEval(Position *pos) {

--- a/src/tests.c
+++ b/src/tests.c
@@ -102,7 +102,7 @@ void Benchmark(int argc, char **argv) {
     TT.requestedMB   = argc > 4 ? atoi(argv[4]) : DEFAULTHASH;
 
     Position pos;
-    Thread *threads = InitThreads(threadCount);
+    threads = InitThreads(threadCount);
     InitTT(threads);
 
     int FENCount = sizeof(BenchmarkFENs) / sizeof(char *);
@@ -118,7 +118,7 @@ void Benchmark(int argc, char **argv) {
         ParseFen(BenchmarkFENs[i], &pos);
         ABORT_SIGNAL = false;
         Limits.start = Now();
-        SearchPosition(&pos, threads);
+        SearchPosition(&pos);
 
         // Collect results
         BenchResult *r = &results[i];

--- a/src/threads.c
+++ b/src/threads.c
@@ -23,28 +23,31 @@
 #include "threads.h"
 
 
+Thread *threads;
+
+
 // Allocates memory for thread structs
 Thread *InitThreads(int count) {
 
-    Thread *threads = calloc(count, sizeof(Thread));
+    Thread *t = calloc(count, sizeof(Thread));
 
     // Each thread knows its own index and total thread count
     for (int i = 0; i < count; ++i)
-        threads[i].index = i,
-        threads[i].count = count;
+        t[i].index = i,
+        t[i].count = count;
 
     // Used for letting the main thread sleep
-    pthread_mutex_init(&threads->mutex, NULL);
-    pthread_cond_init(&threads->sleepCondition, NULL);
+    pthread_mutex_init(&t->mutex, NULL);
+    pthread_cond_init(&t->sleepCondition, NULL);
 
     // Array of pthreads
-    threads->pthreads = calloc(count, sizeof(pthread_t));
+    t->pthreads = calloc(count, sizeof(pthread_t));
 
-    return threads;
+    return t;
 }
 
 // Tallies the nodes searched by all threads
-uint64_t TotalNodes(const Thread *threads) {
+uint64_t TotalNodes() {
     uint64_t total = 0;
     for (int i = 0; i < threads->count; ++i)
         total += threads[i].pos.nodes;
@@ -52,7 +55,7 @@ uint64_t TotalNodes(const Thread *threads) {
 }
 
 // Tallies the tbhits of all threads
-uint64_t TotalTBHits(const Thread *threads) {
+uint64_t TotalTBHits() {
     uint64_t total = 0;
     for (int i = 0; i < threads->count; ++i)
         total += threads[i].tbhits;
@@ -60,7 +63,7 @@ uint64_t TotalTBHits(const Thread *threads) {
 }
 
 // Setup threads for a new search
-void PrepareSearch(Thread *threads, Position *pos) {
+void PrepareSearch(Position *pos) {
     for (Thread *t = threads; t < threads + threads->count; ++t) {
         memset(t, 0, offsetof(Thread, pos));
         memcpy(&t->pos, pos, sizeof(Position));
@@ -70,7 +73,7 @@ void PrepareSearch(Thread *threads, Position *pos) {
 }
 
 // Resets all data that isn't reset each turn
-void ResetThreads(Thread *threads) {
+void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)
         memset(threads[i].pawnCache, 0, sizeof(PawnCache));
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -28,27 +28,23 @@ Thread *threads;
 static pthread_t *pthreads;
 
 // Used for letting the main thread sleep without using cpu
-pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-pthread_cond_t sleepCondition = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t sleepCondition = PTHREAD_COND_INITIALIZER;
 
 
 // Allocates memory for thread structs
-Thread *InitThreads(int count) {
+void InitThreads(int count) {
 
-    if (threads) free(threads);
+    if (threads)  free(threads);
     if (pthreads) free(pthreads);
 
-    Thread *t = calloc(count, sizeof(Thread));
+    threads  = calloc(count, sizeof(Thread));
+    pthreads = calloc(count, sizeof(pthread_t));
 
     // Each thread knows its own index and total thread count
     for (int i = 0; i < count; ++i)
-        t[i].index = i,
-        t[i].count = count;
-
-    // Array of pthreads
-    pthreads = calloc(count, sizeof(pthread_t));
-
-    return t;
+        threads[i].index = i,
+        threads[i].count = count;
 }
 
 // Tallies the nodes searched by all threads

--- a/src/threads.c
+++ b/src/threads.c
@@ -85,18 +85,19 @@ void StartHelpers(void *(*func)(void *)) {
         pthread_create(&pthreads[i], NULL, func, &threads[i]);
 }
 
+// Wait for helper threads to finish
 void WaitForHelpers() {
     for (int i = 1; i < threads->count; ++i)
         pthread_join(pthreads[i], NULL);
 }
 
-// Resets all data that isn't reset each turn
+// Reset all data that isn't reset each turn
 void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)
         memset(threads[i].pawnCache, 0, sizeof(PawnCache));
 }
 
-// Runs the given function once in each thread
+// Run the given function once in each thread
 void RunWithAllThreads(void *(*func)(void *)) {
     for (int i = 0; i < threads->count; ++i)
         pthread_create(&pthreads[i], NULL, func, &threads[i]);

--- a/src/threads.c
+++ b/src/threads.c
@@ -96,16 +96,16 @@ void ResetThreads() {
 }
 
 // Thread sleeps until it is woken up
-void Wait(Thread *thread, volatile bool *condition) {
-    pthread_mutex_lock(&thread->mutex);
+void Wait(volatile bool *condition) {
+    pthread_mutex_lock(&threads->mutex);
     while (!*condition)
-        pthread_cond_wait(&thread->sleepCondition, &thread->mutex);
-    pthread_mutex_unlock(&thread->mutex);
+        pthread_cond_wait(&threads->sleepCondition, &threads->mutex);
+    pthread_mutex_unlock(&threads->mutex);
 }
 
 // Wakes up a sleeping thread
-void Wake(Thread *thread) {
-    pthread_mutex_lock(&thread->mutex);
-    pthread_cond_signal(&thread->sleepCondition);
-    pthread_mutex_unlock(&thread->mutex);
+void Wake() {
+    pthread_mutex_lock(&threads->mutex);
+    pthread_cond_signal(&threads->sleepCondition);
+    pthread_mutex_unlock(&threads->mutex);
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -72,6 +72,17 @@ void PrepareSearch(Position *pos) {
     }
 }
 
+// Starts helper threads running the provided function
+void StartHelpers(void *(*func)(void *)) {
+    for (int i = 1; i < threads->count; ++i)
+        pthread_create(&threads->pthreads[i], NULL, func, &threads[i]);
+}
+
+void WaitForHelpers() {
+    for (int i = 1; i < threads->count; ++i)
+        pthread_join(threads->pthreads[i], NULL);
+}
+
 // Resets all data that isn't reset each turn
 void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)

--- a/src/threads.c
+++ b/src/threads.c
@@ -72,7 +72,13 @@ void PrepareSearch(Position *pos) {
     }
 }
 
-// Starts helper threads running the provided function
+// Start the main thread running the provided function
+void StartMainThread(void *(*func)(void *), Position *pos) {
+    pthread_create(&threads->pthreads[0], NULL, func, pos);
+    pthread_detach(threads->pthreads[0]);
+}
+
+// Start helper threads running the provided function
 void StartHelpers(void *(*func)(void *)) {
     for (int i = 1; i < threads->count; ++i)
         pthread_create(&threads->pthreads[i], NULL, func, &threads[i]);

--- a/src/threads.h
+++ b/src/threads.h
@@ -74,6 +74,7 @@ Thread *InitThreads(int threadCount);
 uint64_t TotalNodes();
 uint64_t TotalTBHits();
 void PrepareSearch(Position *pos);
+void StartMainThread(void *(*func)(void *), Position *pos);
 void StartHelpers(void *(*func)(void *));
 void WaitForHelpers();
 void ResetThreads();

--- a/src/threads.h
+++ b/src/threads.h
@@ -60,7 +60,7 @@ typedef struct Thread {
 extern Thread *threads;
 
 
-Thread *InitThreads(int threadCount);
+void InitThreads(int threadCount);
 uint64_t TotalNodes();
 uint64_t TotalTBHits();
 void PrepareSearch(Position *pos);

--- a/src/threads.h
+++ b/src/threads.h
@@ -60,8 +60,6 @@ typedef struct Thread {
     int index;
     int count;
 
-    pthread_mutex_t mutex;
-    pthread_cond_t sleepCondition;
     pthread_t *pthreads;
 
 } Thread;

--- a/src/threads.h
+++ b/src/threads.h
@@ -39,19 +39,14 @@ typedef struct {
 
 typedef struct Thread {
 
+    int16_t history[COLOR_NB][64][64];
+    Stack ss[128];
+    jmp_buf jumpBuffer;
     uint64_t tbhits;
-
+    Move bestMove;
     int score;
     Depth depth;
     bool doPruning;
-
-    Move bestMove;
-
-    jmp_buf jumpBuffer;
-
-    Stack ss[128];
-
-    int16_t history[COLOR_NB][64][64];
 
     // Anything below here is not zeroed out between searches
     Position pos;

--- a/src/threads.h
+++ b/src/threads.h
@@ -74,6 +74,8 @@ Thread *InitThreads(int threadCount);
 uint64_t TotalNodes();
 uint64_t TotalTBHits();
 void PrepareSearch(Position *pos);
+void StartHelpers(void *(*func)(void *));
+void WaitForHelpers();
 void ResetThreads();
 void Wait(Thread *thread, volatile bool *condition);
 void Wake(Thread *thread);

--- a/src/threads.h
+++ b/src/threads.h
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include <pthread.h>
 #include <setjmp.h>
 
 #include "board.h"
@@ -55,8 +54,6 @@ typedef struct Thread {
     int index;
     int count;
 
-    pthread_t *pthreads;
-
 } Thread;
 
 
@@ -71,5 +68,6 @@ void StartMainThread(void *(*func)(void *), Position *pos);
 void StartHelpers(void *(*func)(void *));
 void WaitForHelpers();
 void ResetThreads();
+void RunWithAllThreads(void *(*func)(void *));
 void Wait(volatile bool *condition);
 void Wake();

--- a/src/threads.h
+++ b/src/threads.h
@@ -67,10 +67,13 @@ typedef struct Thread {
 } Thread;
 
 
+extern Thread *threads;
+
+
 Thread *InitThreads(int threadCount);
-uint64_t TotalNodes(const Thread *threads);
-uint64_t TotalTBHits(const Thread *threads);
-void PrepareSearch(Thread *threads, Position *pos);
-void ResetThreads(Thread *threads);
+uint64_t TotalNodes();
+uint64_t TotalTBHits();
+void PrepareSearch(Position *pos);
+void ResetThreads();
 void Wait(Thread *thread, volatile bool *condition);
 void Wake(Thread *thread);

--- a/src/threads.h
+++ b/src/threads.h
@@ -78,5 +78,5 @@ void StartMainThread(void *(*func)(void *), Position *pos);
 void StartHelpers(void *(*func)(void *));
 void WaitForHelpers();
 void ResetThreads();
-void Wait(Thread *thread, volatile bool *condition);
-void Wake(Thread *thread);
+void Wait(volatile bool *condition);
+void Wake();

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -98,17 +98,8 @@ static void *ThreadClearTT(void *voidThread) {
 
 // Clears the transposition table
 void ClearTT() {
-
     if (!TT.dirty) return;
-
-    // Spawn each thread to clear a part of the TT each
-    for (int i = 0; i < threads->count; ++i)
-        pthread_create(&threads->pthreads[i], NULL, &ThreadClearTT, &threads[i]);
-
-    // Wait for them to finish
-    for (int i = 0; i < threads->count; ++i)
-        pthread_join(threads->pthreads[i], NULL);
-
+    RunWithAllThreads(ThreadClearTT);
     TT.dirty = false;
 }
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -97,7 +97,7 @@ static void *ThreadClearTT(void *voidThread) {
 }
 
 // Clears the transposition table
-void ClearTT(Thread *threads) {
+void ClearTT() {
 
     if (!TT.dirty) return;
 
@@ -113,7 +113,7 @@ void ClearTT(Thread *threads) {
 }
 
 // Allocates memory for the transposition table
-void InitTT(Thread *threads) {
+void InitTT() {
 
     // Skip if already correct size
     if (TT.currentMB == TT.requestedMB)
@@ -147,5 +147,5 @@ void InitTT(Thread *threads) {
 
     // Zero out the memory
     TT.dirty = true;
-    ClearTT(threads);
+    ClearTT();
 }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -80,5 +80,5 @@ INLINE TTEntry *GetEntry(Key key) {
 TTEntry* ProbeTT(Key key, bool *ttHit);
 void StoreTTEntry(TTEntry *tte, Key key, Move move, int score, Depth depth, int bound);
 int HashFull();
-void ClearTT(Thread *threads);
-void InitTT(Thread *threads);
+void ClearTT();
+void InitTT();

--- a/src/uci.c
+++ b/src/uci.c
@@ -142,7 +142,7 @@ static void Info() {
 // Stops searching
 static void Stop() {
     ABORT_SIGNAL = true;
-    Wake(threads);
+    Wake();
 }
 
 // Signals the engine is ready

--- a/src/uci.c
+++ b/src/uci.c
@@ -56,20 +56,13 @@ static void ParseTimeControl(char *str, Color color) {
     Limits.depth = !Limits.depth ? MAX_PLY : MIN(Limits.depth, MAX_PLY);
 }
 
-// Begins a search with the given setup
-static void *BeginSearch(void *pos) {
-    SearchPosition((Position *)pos);
-    return NULL;
-}
-
 // Parses the given limits and creates a new thread to start the search
 INLINE void Go(Position *pos, char *str) {
     ABORT_SIGNAL = false;
     InitTT();
     TT.dirty = true;
     ParseTimeControl(str, pos->stm);
-    pthread_create(&threads->pthreads[0], NULL, &BeginSearch, pos);
-    pthread_detach(threads->pthreads[0]);
+    StartMainThread(SearchPosition, pos);
 }
 
 // Parses a 'position' and sets up the board

--- a/src/uci.c
+++ b/src/uci.c
@@ -104,8 +104,6 @@ static void SetOption(char *str) {
 
     // Sets number of threads to use for searching
     } else if (OptionName(str, "Threads")) {
-        free(threads->pthreads);
-        free(threads);
         threads = InitThreads(atoi(OptionValue(str)));
 
     // Sets the syzygy tablebase path

--- a/src/uci.c
+++ b/src/uci.c
@@ -104,7 +104,7 @@ static void SetOption(char *str) {
 
     // Sets number of threads to use for searching
     } else if (OptionName(str, "Threads")) {
-        threads = InitThreads(atoi(OptionValue(str)));
+        InitThreads(atoi(OptionValue(str)));
 
     // Sets the syzygy tablebase path
     } else if (OptionName(str, "SyzygyPath")) {
@@ -180,7 +180,7 @@ int main(int argc, char **argv) {
 #endif
 
     // Init engine
-    threads = InitThreads(1);
+    InitThreads(1);
     Position pos;
     ParseFen(START_FEN, &pos);
 

--- a/src/uci.h
+++ b/src/uci.h
@@ -21,7 +21,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "board.h"
 #include "threads.h"
 
 
@@ -30,10 +29,6 @@
 #define START_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 #define INPUT_SIZE 4096
 
-
-typedef struct {
-    Position pos;
-} Engine;
 
 enum InputCommands {
     // UCI

--- a/src/uci.h
+++ b/src/uci.h
@@ -33,7 +33,6 @@
 
 typedef struct {
     Position pos;
-    Thread *threads;
 } Engine;
 
 enum InputCommands {


### PR DESCRIPTION
There's no reason to have more than one set of threads so they are now global, avoiding sending them around everywhere. Also moved all implementation specific code (usage of pthread library) to threads.c.

No functional change.