### PR TITLE
TT cut history bonus tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -230,7 +230,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (   !pvNode && ttHit && tte->depth >= depth
         && (tte->bound & (ttScore >= beta ? BOUND_LOWER : BOUND_UPPER))) {
 
-        if (moveIsQuiet(ttMove))
+        if (ttScore >= beta && moveIsQuiet(ttMove))
             HistoryBonus(&thread->history[sideToMove][fromSq(ttMove)][toSq(ttMove)], depth*depth);
 
         return ttScore;


### PR DESCRIPTION
Only give a history bonus to the tt move if we are failing high with it.

ELO   | 2.45 +- 2.52 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 34440 W: 8280 L: 8037 D: 18123

ELO   | 3.29 +- 3.07 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.94 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 18376 W: 3520 L: 3346 D: 11510