### PR TITLE
Disable nullmove at high depth with 1 piece left

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -291,7 +291,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         && eval >= beta
         && ss->eval >= beta
         && history(-1).move != NOMOVE
-        && pos->nonPawnCount[sideToMove] > 1) {
+        && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 

--- a/src/search.c
+++ b/src/search.c
@@ -291,7 +291,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         && eval >= beta
         && ss->eval >= beta
         && history(-1).move != NOMOVE
-        && pos->nonPawnCount[sideToMove] > 0) {
+        && pos->nonPawnCount[sideToMove] > 1) {
 
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 


### PR DESCRIPTION
Change caused by a silly loss to Halogen at TCEC due to null move pruning in zugzwang, immediately losing a dead drawn position.

ELO   | -0.22 +- 2.98 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 1.17 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 22544 W: 4871 L: 4885 D: 12788

ELO   | 2.11 +- 3.29 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 14688 W: 2563 L: 2474 D: 9651