### PR TITLE
Keep history from previous turn

### DIFF
--- a/src/threads.c
+++ b/src/threads.c
@@ -94,7 +94,8 @@ void WaitForHelpers() {
 // Reset all data that isn't reset each turn
 void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)
-        memset(threads[i].pawnCache, 0, sizeof(PawnCache));
+        memset(threads[i].pawnCache, 0, sizeof(PawnCache)),
+        memset(threads[i].history, 0, sizeof(threads[i].history));
 }
 
 // Run the given function once in each thread

--- a/src/threads.h
+++ b/src/threads.h
@@ -38,7 +38,6 @@ typedef struct {
 
 typedef struct Thread {
 
-    int16_t history[COLOR_NB][64][64];
     Stack ss[128];
     jmp_buf jumpBuffer;
     uint64_t tbhits;
@@ -50,6 +49,7 @@ typedef struct Thread {
     // Anything below here is not zeroed out between searches
     Position pos;
     PawnCache pawnCache;
+    int16_t history[COLOR_NB][64][64];
 
     int index;
     int count;


### PR DESCRIPTION
Since the change to history updates, the history won't overflow anymore and is quicker to adapt to changes in the search tree so keeping it from turn to turn finally works out.

ELO   | 11.45 +- 6.81 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4464 W: 1072 L: 925 D: 2467

ELO   | 7.54 +- 4.95 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 6448 W: 1172 L: 1032 D: 4244