### PR TITLE
Pawn Threats

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -289,7 +289,7 @@ INLINE int EvalThreats(const Position *pos, const Color color) {
 
     int count = PopCount(PawnBBAttackBB(ourPawns, color) & (colorBB(!color) ^ theirPawns));
     eval += PawnThreat * count;
-    // TraceCount(PawnThreat);
+    TraceCount(PawnThreat);
 
     return eval;
 }

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -54,6 +54,7 @@ const int Tempo = 15;
 const int PawnDoubled    = S(-13,-25);
 const int PawnIsolated   = S(-14,-18);
 const int PawnSupport    = S( 13,  5);
+const int PawnThreat     = S( 50, 30);
 const int BishopPair     = S( 25,100);
 
 // Passed pawn [rank]
@@ -278,6 +279,21 @@ INLINE int EvalKings(const Position *pos, EvalInfo *ei, const Color color) {
     return eval;
 }
 
+// Evaluates threads
+INLINE int EvalThreats(const Position *pos, const Color color) {
+
+    int eval = 0;
+
+    Bitboard ourPawns = colorPieceBB(color, PAWN);
+    Bitboard theirPawns = colorPieceBB(!color, PAWN);
+
+    int count = PopCount(PawnBBAttackBB(ourPawns, color) & (colorBB(!color) ^ theirPawns));
+    eval += PawnThreat * count;
+    // TraceCount(PawnThreat);
+
+    return eval;
+}
+
 INLINE int EvalPieces(const Position *pos, EvalInfo *ei) {
     return  EvalPiece(pos, ei, WHITE, KNIGHT)
           - EvalPiece(pos, ei, BLACK, KNIGHT)
@@ -341,6 +357,10 @@ int EvalPosition(const Position *pos, PawnCache pc) {
     // Evaluate king safety
     eval +=  EvalSafety(WHITE, &ei)
            - EvalSafety(BLACK, &ei);
+
+    // Evaluate threats
+    eval +=  EvalThreats(pos, WHITE)
+           - EvalThreats(pos, BLACK);
 
     TraceEval(eval);
 

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -47,6 +47,7 @@ extern const int PieceSqValue[7][64];
 extern const int PawnDoubled;
 extern const int PawnIsolated;
 extern const int PawnSupport;
+extern const int PawnThreat;
 extern const int BishopPair;
 
 // Passed pawn [rank]
@@ -202,6 +203,10 @@ void InitBaseParams(TVector tparams) {
     tparams[i][EG] = EgScore(PawnSupport);
     i++;
 
+    tparams[i][MG] = MgScore(PawnThreat);
+    tparams[i][EG] = EgScore(PawnThreat);
+    i++;
+
     tparams[i][MG] = MgScore(BishopPair);
     tparams[i][EG] = EgScore(BishopPair);
     i++;
@@ -226,6 +231,7 @@ void InitBaseParams(TVector tparams) {
         i++;
     }
 
+    // KingLineDanger
     for (int j = 0; j < 28; ++j) {
         tparams[i][MG] = MgScore(KingLineDanger[j]);
         tparams[i][EG] = EgScore(KingLineDanger[j]);
@@ -266,6 +272,7 @@ void PrintParameters(TVector params, TVector current) {
     PrintSingle("PawnDoubled", tparams, i++, "   ");
     PrintSingle("PawnIsolated", tparams, i++, "  ");
     PrintSingle("PawnSupport", tparams, i++, "   ");
+    PrintSingle("PawnThreat", tparams, i++, "    ");
     PrintSingle("BishopPair", tparams, i++, "    ");
 
     puts("\n// Passed pawn [rank]");
@@ -311,6 +318,7 @@ void InitCoefficients(TCoeffs coeffs) {
     coeffs[i++] = T.PawnDoubled[WHITE]    - T.PawnDoubled[BLACK];
     coeffs[i++] = T.PawnIsolated[WHITE]   - T.PawnIsolated[BLACK];
     coeffs[i++] = T.PawnSupport[WHITE]    - T.PawnSupport[BLACK];
+    coeffs[i++] = T.PawnThreat[WHITE]     - T.PawnThreat[BLACK];
     coeffs[i++] = T.BishopPair[WHITE]     - T.BishopPair[BLACK];
 
     for (int j = 0; j < 8; ++j)

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -39,7 +39,7 @@
 #define DATASET      "../../Datasets/Andrew/BIG.book"
 #define NPOSITIONS   (42484641) // Total FENS in the book
 
-#define NTERMS       (     499) // Number of terms being tuned
+#define NTERMS       (     500) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -61,6 +61,7 @@ typedef struct EvalTrace {
     int PawnDoubled[COLOR_NB];
     int PawnIsolated[COLOR_NB];
     int PawnSupport[COLOR_NB];
+    int PawnThreat[COLOR_NB];
     int BishopPair[COLOR_NB];
 
     int PawnPassed[RANK_NB][COLOR_NB];


### PR DESCRIPTION
Give a bonus for pawns attacking non-pawns.

ELO   | 13.13 +- 7.40 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 3840 W: 945 L: 800 D: 2095

ELO   | 8.19 +- 5.26 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5984 W: 1140 L: 999 D: 3845