### PR TITLE
Fix going past max ply

### DIFF
--- a/src/threads.c
+++ b/src/threads.c
@@ -68,7 +68,7 @@ void PrepareSearch(Position *pos) {
     for (Thread *t = threads; t < threads + threads->count; ++t) {
         memset(t, 0, offsetof(Thread, pos));
         memcpy(&t->pos, pos, sizeof(Position));
-        for (Depth d = 0; d < MAX_PLY; ++d)
+        for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
     }
 }

--- a/src/uci.c
+++ b/src/uci.c
@@ -236,7 +236,7 @@ void PrintThinking(const Thread *thread, const Stack *ss, int score, int alpha, 
     int hashFull      = HashFull();
     int nps           = (int)(1000 * nodes / (elapsed + 1));
 
-    Depth seldepth = MAX_PLY;
+    Depth seldepth = 128;
     for (; seldepth > 0; --seldepth)
         if (history(seldepth-1).key != 0) break;
 


### PR DESCRIPTION
At ply 100, ss->ply was left at 0 making search miss the fact that it was at max ply. PrintThinking assumed max ply was 100 and didn't bother checking for higher, hiding the fact that search went out of bounds.

Fixed the bug and prints will now indicate if search goes beyond 100.