### PR TITLE
Null mover LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -295,9 +295,14 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
         int R = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
 
+        Color nullMoverTemp = thread->nullMover;
+        thread->nullMover = sideToMove;
+
         MakeNullMove(pos);
         int score = -AlphaBeta(thread, ss+1, -beta, -beta+1, depth-R);
         TakeNullMove(pos);
+
+        thread->nullMover = nullMoverTemp;
 
         // Cutoff
         if (score >= beta)
@@ -436,6 +441,8 @@ move_loop:
             r -= improving;
             // Reduce less for killers
             r -= mp.stage == KILLER1 || mp.stage == KILLER2;
+
+            r += sideToMove == thread->nullMover;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);

--- a/src/search.c
+++ b/src/search.c
@@ -441,7 +441,7 @@ move_loop:
             r -= improving;
             // Reduce less for killers
             r -= mp.stage == KILLER1 || mp.stage == KILLER2;
-
+            // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
 
             // Depth after reductions, avoiding going straight to quiescence

--- a/src/threads.c
+++ b/src/threads.c
@@ -68,6 +68,7 @@ void PrepareSearch(Position *pos) {
     for (Thread *t = threads; t < threads + threads->count; ++t) {
         memset(t, 0, offsetof(Thread, pos));
         memcpy(&t->pos, pos, sizeof(Position));
+        t->nullMover = -1;
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
     }

--- a/src/threads.h
+++ b/src/threads.h
@@ -44,6 +44,7 @@ typedef struct Thread {
     Move bestMove;
     int score;
     Depth depth;
+    Color nullMover;
     bool doPruning;
 
     // Anything below here is not zeroed out between searches


### PR DESCRIPTION
Reduce an extra ply for the side that last null moved. This side is trying to claim that it is much better, yet the non-lmr'd moves have already failed. Likely it will keep failing, so spend less time on it.

Idea from Koivisto.

ELO   | 1.57 +- 2.14 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 1.53 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 45360 W: 10282 L: 10077 D: 25001

ELO   | 5.29 +- 4.06 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9856 W: 1809 L: 1659 D: 6388