### PR TITLE
Draw Contempt

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -197,7 +197,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
         // Position is drawn
         if (IsRepetition(pos) || pos->rule50 >= 100)
-            return 0;
+            return 8 - (pos->nodes & 0x7);
 
         // Max depth reached
         if (ss->ply >= MAX_PLY)


### PR DESCRIPTION
Give most draws a small positive random score to make the side playing into the draw explore more alternatives, hopefully finding a way to avoid it when better, or being more certain of the draw when behind.

ELO   | 3.12 +- 2.95 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 19840 W: 3802 L: 3624 D: 12414

ELO   | 5.27 +- 4.36 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 11264 W: 2698 L: 2527 D: 6039