### PR TITLE
More careful with time

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -59,7 +59,7 @@ void InitTimeManagement() {
 
 // Check time situation
 bool OutOfTime(Thread *thread) {
-    return (thread->pos.nodes & 4095) == 4095
+    return (thread->pos.nodes & 2047) == 2047
         && thread->index == 0
         && Limits.timelimit
         && TimeSince(Limits.start) >= Limits.maxUsage;

--- a/src/time.c
+++ b/src/time.c
@@ -24,7 +24,7 @@
 // Decide how much time to spend this turn
 void InitTimeManagement() {
 
-    const int overhead = 5;
+    const int overhead = 6;
 
     // No time to manage
     if (!Limits.timelimit)


### PR DESCRIPTION
Openbench now supports Syzygy TBs for tests, but most workers have them on HDDs which is very slow and rare time outs have happened. To combat this I'm doubling the frequency at which time is checked, and increasing overhead by 1 ms. The increased overhead might gain a couple elo at very fast time controls.

ELO   | 1.33 +- 3.39 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 19328 W: 4682 L: 4608 D: 10038

