### PR TITLE
Quiescence Futility

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -126,6 +126,12 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
                  && RelativeRank(sideToMove, RankOf(toSq(move))) > 5))
             continue;
 
+        if (   futility <= alpha
+            && !SEE(pos, move, 1)) {
+            bestScore = MAX(bestScore, futility);
+            continue;
+        }
+
         // Recursively search the positions after making the moves, skipping illegal ones
         if (!MakeMove(pos, move)) continue;
         score = -Quiescence(thread, ss+1, -beta, -alpha);


### PR DESCRIPTION
All moves in QSearch have to have a static exchange evaluation greater than or equal to 0. Now requires it to be greater than 0 if static eval is significantly below alpha.

ELO   | 5.74 +- 4.64 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 10172 W: 2490 L: 2322 D: 5360

ELO   | 1.50 +- 2.12 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 1.53 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 38848 W: 7403 L: 7235 D: 24210