### PR TITLE
Capture History

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -74,8 +74,9 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage) {
         Move move = list->moves[i].move;
 
         if (stage == GEN_NOISY)
-            list->moves[i].score = moveIsEnPas(move) ? 105
-                                 : MvvLvaScores[pieceOn(toSq(move))][pieceOn(fromSq(move))];
+            list->moves[i].score = thread->captureHistory[pieceOn(fromSq(move))][toSq(move)][PieceTypeOf(capturing(move))]
+                                  + (moveIsEnPas(move) ? 105
+                                  : MvvLvaScores[pieceOn(toSq(move))][pieceOn(fromSq(move))]);
 
         if (stage == GEN_QUIET)
             list->moves[i].score = thread->history[sideToMove][fromSq(move)][toSq(move)];

--- a/src/threads.c
+++ b/src/threads.c
@@ -95,8 +95,9 @@ void WaitForHelpers() {
 // Reset all data that isn't reset each turn
 void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)
-        memset(threads[i].pawnCache, 0, sizeof(PawnCache)),
-        memset(threads[i].history, 0, sizeof(threads[i].history));
+        memset(threads[i].pawnCache,      0, sizeof(PawnCache)),
+        memset(threads[i].history,        0, sizeof(threads[i].history)),
+        memset(threads[i].captureHistory, 0, sizeof(threads[i].captureHistory));
 }
 
 // Run the given function once in each thread

--- a/src/threads.h
+++ b/src/threads.h
@@ -51,6 +51,7 @@ typedef struct Thread {
     Position pos;
     PawnCache pawnCache;
     int16_t history[COLOR_NB][64][64];
+    int16_t captureHistory[PIECE_NB][64][TYPE_NB];
 
     int index;
     int count;


### PR DESCRIPTION
Order noisy moves by history heuristics much like quiet moves. The slowdown hurts STC, but LTC shows decent gain.

ELO   | -4.17 +- 4.83 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | -3.01 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9088 W: 2028 L: 2137 D: 4923

ELO   | 3.66 +- 3.29 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 15936 W: 3052 L: 2884 D: 10000