### PR TITLE
Tweak TT replacement scheme

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -56,7 +56,7 @@ void StoreTTEntry(TTEntry *tte, const Key key,
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (key != tte->key || depth >= tte->depth || bound == BOUND_EXACT)
+    if (key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT)
         tte->key   = key,
         tte->move  = move,
         tte->score = score,

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -56,7 +56,7 @@ void StoreTTEntry(TTEntry *tte, const Key key,
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (key != tte->key || depth + 3 >= tte->depth || bound == BOUND_EXACT)
+    if (key != tte->key || depth * 2 >= tte->depth || bound == BOUND_EXACT)
         tte->key   = key,
         tte->move  = move,
         tte->score = score,

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -56,7 +56,7 @@ void StoreTTEntry(TTEntry *tte, const Key key,
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT)
+    if (key != tte->key || depth + 3 >= tte->depth || bound == BOUND_EXACT)
         tte->key   = key,
         tte->move  = move,
         tte->score = score,


### PR DESCRIPTION
Most engines use something like depth + 4 > tte->depth, this failed in weiss a long time ago. Now it seems to work, but this is even better.

Idea from Berserk author.

ELO   | 9.46 +- 5.82 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5144 W: 1040 L: 900 D: 3204