### PR TITLE
Quiet LMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -387,9 +387,16 @@ move_loop:
         // Late move pruning
         if (  !pvNode
             && thread->doPruning
-            && bestScore > -TBWIN_IN_MAX
-            && moveCount > (3 + 2 * depth * depth) / (2 - improving))
-            break;
+            && bestScore > -TBWIN_IN_MAX) {
+
+            if (moveCount > (3 + 2 * depth * depth) / (2 - improving))
+                break;
+
+            if (quiet && moveCount > (3 + depth * depth) / (2 - improving)) {
+                mp.onlyNoisy = true;
+                continue;
+            }
+        }
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));
 


### PR DESCRIPTION
Found out I made a mistake with my LMP, allowing it to prune non-quiets too. No wonder I couldn't make the formula more aggressive. This adds a quiet-only LMP which prunes much earlier, but only quiets.

ELO   | 8.89 +- 6.08 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 6096 W: 1562 L: 1406 D: 3128

ELO   | 22.78 +- 9.37 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 2016 W: 451 L: 319 D: 1246