### PR TITLE
Penalize undefended, unopposed pawns

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -132,6 +132,15 @@ INLINE Bitboard ShiftBB(Bitboard bb, const Direction dir) {
                    : bb >> -dir;
 }
 
+// Fills a bitboard in either vertical direction
+INLINE Bitboard Fill(Bitboard bb, const Direction dir) {
+    assert(dir & 7 == 0);
+    bb |= ShiftBB(bb, dir);
+    bb |= ShiftBB(bb, 2*dir);
+    bb |= ShiftBB(bb, 4*dir);
+    return bb;
+}
+
 INLINE Bitboard AdjacentFilesBB(const Square sq) {
     return ShiftBB(FileBB[FileOf(sq)], WEST)
          | ShiftBB(FileBB[FileOf(sq)], EAST);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -55,6 +55,7 @@ const int PawnDoubled  = S(-13,-25);
 const int PawnIsolated = S(-14,-18);
 const int PawnSupport  = S( 13,  5);
 const int PawnThreat   = S( 50, 30);
+const int PawnOpen     = S(-12, -7);
 const int BishopPair   = S( 25,100);
 const int KingAtkPawn  = S( 23, 71);
 
@@ -106,6 +107,8 @@ const uint16_t CountModifier[8] = { 0, 0, 50, 75, 80, 88, 95, 100 };
 // Evaluates pawns
 INLINE int EvalPawns(const Position *pos, const Color color) {
 
+    const Direction down = color == WHITE ? SOUTH : NORTH;
+
     int eval = 0, count;
 
     Bitboard pawns = colorPieceBB(color, PAWN);
@@ -119,6 +122,12 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
     count = PopCount(pawns & PawnBBAttackBB(pawns, color));
     eval += PawnSupport * count;
     TraceCount(PawnSupport);
+
+    // Open pawns
+    Bitboard open = ~Fill(colorPieceBB(!color, PAWN), down);
+    count = PopCount(pawns & open & ~PawnBBAttackBB(pawns, color));
+    eval += PawnOpen * count;
+    TraceCount(PawnOpen);
 
     // Evaluate each individual pawn
     while (pawns) {

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -48,6 +48,7 @@ extern const int PawnDoubled;
 extern const int PawnIsolated;
 extern const int PawnSupport;
 extern const int PawnThreat;
+extern const int PawnOpen;
 extern const int BishopPair;
 extern const int KingAtkPawn;
 
@@ -188,6 +189,7 @@ void InitBaseParams(TVector tparams) {
     InitBaseSingle(PawnIsolated);
     InitBaseSingle(PawnSupport);
     InitBaseSingle(PawnThreat);
+    InitBaseSingle(PawnOpen);
     InitBaseSingle(BishopPair);
     InitBaseSingle(KingAtkPawn);
 
@@ -236,6 +238,7 @@ void PrintParameters(TVector params, TVector current) {
     PrintSingle("PawnIsolated", tparams, i++, "");
     PrintSingle("PawnSupport", tparams, i++, " ");
     PrintSingle("PawnThreat", tparams, i++, "  ");
+    PrintSingle("PawnOpen", tparams, i++, "    ");
     PrintSingle("BishopPair", tparams, i++, "  ");
     PrintSingle("KingAtkPawn", tparams, i++, " ");
 
@@ -290,6 +293,7 @@ void InitCoefficients(TCoeffs coeffs) {
     InitCoeffSingle(PawnIsolated);
     InitCoeffSingle(PawnSupport);
     InitCoeffSingle(PawnThreat);
+    InitCoeffSingle(PawnOpen);
     InitCoeffSingle(BishopPair);
     InitCoeffSingle(KingAtkPawn);
 
@@ -495,7 +499,7 @@ void Tune() {
     TEntry *entries = calloc(NPOSITIONS, sizeof(TEntry));
     TupleStack      = calloc(STACKSIZE,  sizeof(TTuple));
 
-    printf("Tuning %d terms using %s\n", NTERMS, DATASET);
+    printf("Tuning %d terms using %d positions from %s\n", NTERMS, NPOSITIONS, DATASET);
     InitTunerEntries(entries);
     printf("Allocated:\n");
     printf("Optimal K...\r");

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -39,7 +39,7 @@
 #define DATASET      "../../Datasets/Andrew/BIG.book"
 #define NPOSITIONS   (42484641) // Total FENS in the book
 
-#define NTERMS       (     501) // Number of terms being tuned
+#define NTERMS       (     502) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -61,6 +61,7 @@ typedef struct EvalTrace {
     int PawnIsolated[COLOR_NB];
     int PawnSupport[COLOR_NB];
     int PawnThreat[COLOR_NB];
+    int PawnOpen[COLOR_NB];
     int BishopPair[COLOR_NB];
     int KingAtkPawn[COLOR_NB];
 


### PR DESCRIPTION
Undefended, unopposed pawns are targets for constant pressure by rooks and queens.

ELO   | 10.39 +- 6.58 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5116 W: 1300 L: 1147 D: 2669

ELO   | 5.81 +- 4.40 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 9036 W: 1788 L: 1637 D: 5611