### PR TITLE
Static exchange evaluation pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -384,19 +384,22 @@ move_loop:
 
         bool quiet = moveIsQuiet(move);
 
-        // Late move pruning
+        // Misc pruning
         if (  !pvNode
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
+            // Late move pruning
             if (moveCount > (3 + 2 * depth * depth) / (2 - improving))
                 break;
 
+            // Quiet late move pruning
             if (quiet && moveCount > (3 + depth * depth) / (2 - improving)) {
                 mp.onlyNoisy = true;
                 continue;
             }
 
+            // SEE pruning
             if (depth < 7 && !SEE(pos, move, -300 * depth))
                 continue;
         }

--- a/src/search.c
+++ b/src/search.c
@@ -396,6 +396,9 @@ move_loop:
                 mp.onlyNoisy = true;
                 continue;
             }
+
+            if (depth < 7 && !SEE(pos, move, -300 * depth))
+                continue;
         }
 
         __builtin_prefetch(GetEntry(KeyAfter(pos, move)));


### PR DESCRIPTION
Prune moves with bad SEE.

ELO   | 8.69 +- 5.97 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 6120 W: 1517 L: 1364 D: 3239

ELO   | 6.08 +- 4.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 8568 W: 1694 L: 1544 D: 5330