### PR TITLE
Tweak king safety count modifier

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -99,7 +99,7 @@ const int Mobility[4][28] = {
 // KingSafety [pt-2]
 const uint16_t AttackPower[4] = {  35, 20, 40, 80 };
 const uint16_t CheckPower[4]  = { 100, 35, 65, 65 };
-const uint16_t CountModifier[8] = { 0, 0, 50, 75, 80, 88, 95, 100 };
+const uint16_t CountModifier[8] = { 0, 0, 64, 96, 113, 120, 124, 128 };
 
 
 // Evaluates pawns
@@ -280,7 +280,7 @@ INLINE int EvalThreats(const Position *pos, const Color color) {
 INLINE int EvalSafety(const Color color ,const EvalInfo *ei) {
     int16_t safetyScore =  ei->attackPower[color]
                          * CountModifier[MIN(7, ei->attackCount[color])]
-                         / 100;
+                         / 128;
 
     return S(safetyScore, 0);
 }


### PR DESCRIPTION
Increases relative value of 4-6 attackers.

Also, dividing by power of 2 is faster.

ELO   | 6.73 +- 5.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 5940 W: 1419 L: 1304 D: 3217