### PR TITLE
History pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -350,6 +350,12 @@ move_loop:
                 continue;
             }
 
+            int histScore = mp.list.moves[mp.list.next-1].score;
+
+            // History pruning
+            if (depth < 3 && histScore < -2024 * depth)
+                continue;
+
             // SEE pruning
             if (depth < 7 && !SEE(pos, move, -50 * depth))
                 continue;


### PR DESCRIPTION
Skip moves with bad history at low depths.

ELO   | 9.05 +- 5.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5680 W: 1325 L: 1177 D: 3178

ELO   | 10.50 +- 6.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4568 W: 905 L: 767 D: 2896