### PR TITLE
Minor behind pawn

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -60,6 +60,7 @@ const int BishopPair   = S( 24,103);
 const int KingAtkPawn  = S( 53, 80);
 const int OpenFile     = S( 27, 12);
 const int SemiOpenFile = S(  7, 18);
+const int NBBehindPawn = S( 14, 25);
 
 // Passed pawn [rank]
 const int PawnPassed[8] = {
@@ -178,6 +179,12 @@ INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const
     if (pt == BISHOP && Multiple(pieces)) {
         eval += BishopPair;
         TraceIncr(BishopPair);
+    }
+
+    if (pt == KNIGHT || pt == BISHOP) {
+        int count = PopCount(pieces & ShiftBB(pieceBB(PAWN), color == WHITE ? SOUTH : NORTH));
+        eval += count * NBBehindPawn;
+        TraceCount(NBBehindPawn);
     }
 
     // Evaluate each individual piece

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -53,6 +53,7 @@ extern const int BishopPair;
 extern const int KingAtkPawn;
 extern const int OpenFile;
 extern const int SemiOpenFile;
+extern const int NBBehindPawn;
 
 // Passed pawn [rank]
 extern const int PawnPassed[RANK_NB];
@@ -193,6 +194,7 @@ void InitBaseParams(TVector tparams) {
     InitBaseSingle(KingAtkPawn);
     InitBaseSingle(OpenFile);
     InitBaseSingle(SemiOpenFile);
+    InitBaseSingle(NBBehindPawn);
 
     // Passed pawns
     InitBaseArray(PawnPassed, RANK_NB);
@@ -240,6 +242,7 @@ void PrintParameters(TVector params, TVector current) {
     PrintSingle("KingAtkPawn", tparams, i++, " ");
     PrintSingle("OpenFile", tparams, i++, "    ");
     PrintSingle("SemiOpenFile", tparams, i++, "");
+    PrintSingle("NBBehindPawn", tparams, i++, "");
 
     puts("\n// Passed pawn [rank]");
     PrintArray("PawnPassed", tparams, i, 8, "[8]");
@@ -291,6 +294,7 @@ void InitCoefficients(TCoeffs coeffs) {
     InitCoeffSingle(KingAtkPawn);
     InitCoeffSingle(OpenFile);
     InitCoeffSingle(SemiOpenFile);
+    InitCoeffSingle(NBBehindPawn);
 
     // Passed pawns
     InitCoeffArray(PawnPassed, RANK_NB);

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -39,7 +39,7 @@
 #define DATASET      "../../Datasets/Andrew/BIG.book"
 #define NPOSITIONS   (42484641) // Total FENS in the book
 
-#define NTERMS       (     500) // Number of terms being tuned
+#define NTERMS       (     501) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -68,6 +68,7 @@ typedef struct EvalTrace {
     int KingAtkPawn[COLOR_NB];
     int OpenFile[COLOR_NB];
     int SemiOpenFile[COLOR_NB];
+    int NBBehindPawn[COLOR_NB];
 
     int PawnPassed[RANK_NB][COLOR_NB];
     int KingLineDanger[28][COLOR_NB];


### PR DESCRIPTION
Bonus for having pawns shielded by our pawns or blocking enemy pawns.

ELO   | 12.19 +- 7.14 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4136 W: 1013 L: 868 D: 2255

ELO   | 8.79 +- 5.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5616 W: 1125 L: 983 D: 3508