### PR TITLE
IIR before forward pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -243,13 +243,13 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Improving if not in check, and current eval is higher than 2 plies ago
     bool improving = !inCheck && eval > (ss-2)->eval;
 
-    // Skip pruning in check, at root, during early iterations, and when proving singularity
-    if (inCheck || pvNode || !thread->doPruning || ss->excluded)
-        goto move_loop;
-
     // Internal iterative reduction based on Rebel's idea
     if (depth >= 4 && !ttMove)
         depth--;
+
+    // Skip pruning in check, at root, during early iterations, and when proving singularity
+    if (inCheck || pvNode || !thread->doPruning || ss->excluded)
+        goto move_loop;
 
     // Razoring
     if (   depth < 2

--- a/src/search.c
+++ b/src/search.c
@@ -247,6 +247,10 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (inCheck || pvNode || !thread->doPruning || ss->excluded)
         goto move_loop;
 
+    // Internal iterative reduction based on Rebel's idea
+    if (depth >= 4 && !ttMove)
+        depth--;
+
     // Razoring
     if (   depth < 2
         && eval + 640 < alpha)
@@ -313,10 +317,6 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     }
 
 move_loop:
-
-    // Internal iterative reduction based on Rebel's idea
-    if (depth >= 4 && !ttMove)
-        depth--;
 
     InitNormalMP(&mp, thread, ttMove, ss->killers[0], ss->killers[1]);
 


### PR DESCRIPTION
Allows more aggressive pruning. May or may not just be making up for pruning being too conservative in general.

ELO   | 2.87 +- 2.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 26168 W: 5865 L: 5649 D: 14654

ELO   | 2.37 +- 2.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 29152 W: 5258 L: 5059 D: 18835