### PR TITLE
Adjust LMR by move history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -335,6 +335,8 @@ move_loop:
 
         bool quiet = moveIsQuiet(move);
 
+        int histScore = mp.list.moves[mp.list.next-1].score;
+
         // Misc pruning
         if (  !pvNode
             && thread->doPruning
@@ -349,8 +351,6 @@ move_loop:
                 mp.onlyNoisy = true;
                 continue;
             }
-
-            int histScore = mp.list.moves[mp.list.next-1].score;
 
             // History pruning
             if (depth < 3 && histScore < -2024 * depth)
@@ -434,6 +434,8 @@ move_loop:
             r -= mp.stage == KILLER1 || mp.stage == KILLER2;
             // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
+
+            r -= histScore / 8000;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);


### PR DESCRIPTION
Adjust LMR reduction by between +2 and -2 based on move history.

ELO   | 14.11 +- 7.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 3448 W: 805 L: 665 D: 1978

ELO   | 13.90 +- 7.06 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 3352 W: 672 L: 538 D: 2142