### PR TITLE
Adjust LMR by move history more aggressively

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -435,7 +435,7 @@ move_loop:
             // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
 
-            r -= histScore / 7000;
+            r -= histScore / 6000;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);

--- a/src/search.c
+++ b/src/search.c
@@ -435,7 +435,7 @@ move_loop:
             // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
 
-            r -= histScore / 8000;
+            r -= histScore / 7000;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);


### PR DESCRIPTION
ELO   | 4.94 +- 4.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 11600 W: 2610 L: 2445 D: 6545

ELO   | 3.92 +- 3.37 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 14176 W: 2553 L: 2393 D: 9230