### PR TITLE
Do per-move pruning in PV nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -338,7 +338,7 @@ move_loop:
         int histScore = mp.list.moves[mp.list.next-1].score;
 
         // Misc pruning
-        if (  !pvNode
+        if (  !root
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 


### PR DESCRIPTION
ELO   | 2.77 +- 2.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 22416 W: 3958 L: 3779 D: 14679

ELO   | 6.31 +- 4.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 8648 W: 1966 L: 1809 D: 4873