### PR TITLE
Bugfix

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -407,7 +407,7 @@ move_loop:
             // Reduce less when improving
             r -= improving;
             // Reduce less for killers
-            r -= mp.stage == KILLER1 || mp.stage == KILLER2;
+            r -= move == mp.kill1 || move == mp.kill2;
             // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
             // Adjust reduction by move history (-2 to +2)


### PR DESCRIPTION
The movepicker stage has already advanced when the killers are returned - there is no move returned while the stage is KILLER1, and killer 1 is returned while stage is KILLER2. This patch fixes the logic so it does what it always looked like it did.

ELO   | 0.94 +- 2.88 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
Games | N: 23560 W: 5017 L: 4953 D: 13590