### PR TITLE
Phalanx

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -68,6 +68,12 @@ const int PawnPassed[8] = {
     S( 23, 90), S( 46,158), S(154,212), S(  0,  0),
 };
 
+// Pawn phalanx [rank]
+const int PawnPhalanx[8] = {
+    S(  0,  0), S(  7, -2), S( 17,  8), S( 23, 28),
+    S( 53, 96), S( 71,161), S(162,237), S(  0,  0),
+};
+
 // KingLineDanger
 const int KingLineDanger[28] = {
     S(  0,  0), S(  0,  0), S( -2,  0), S(-13, 45),
@@ -127,6 +133,14 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
     count = PopCount(pawns & open & ~PawnBBAttackBB(pawns, color));
     eval += PawnOpen * count;
     TraceCount(PawnOpen);
+
+    // Phalanx
+    Bitboard phalanx = pawns & ShiftBB(pawns, WEST);
+    while (phalanx) {
+        Square rank = RelativeRank(color, RankOf(PopLsb(&phalanx)));
+        eval += PawnPhalanx[rank];
+        TraceIncr(PawnPhalanx[rank]);
+    }
 
     // Evaluate each individual pawn
     while (pawns) {


### PR DESCRIPTION
Pawns next to eachother support either pawn pushing forward, and are extremely dangerous when nearing promotion.

ELO   | 12.54 +- 7.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 4076 W: 992 L: 845 D: 2239

ELO   | 9.11 +- 5.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 5264 W: 977 L: 839 D: 3448