### PR TITLE
Tweak pawn support term

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -124,7 +124,7 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
     TraceCount(PawnDoubled);
 
     // Supported pawns
-    count = PopCount(pawns & PawnBBAttackBB(pawns, color));
+    count = PopCount(pawns & PawnBBAttackBB(pawns, !color));
     eval += PawnSupport * count;
     TraceCount(PawnSupport);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -123,7 +123,7 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
     eval += PawnDoubled * count;
     TraceCount(PawnDoubled);
 
-    // Supported pawns
+    // Pawns defending pawns
     count = PopCount(pawns & PawnBBAttackBB(pawns, !color));
     eval += PawnSupport * count;
     TraceCount(PawnSupport);


### PR DESCRIPTION
Give bonus for number of pawns defending pawns rather than number of defended pawns.

ELO   | 3.12 +- 3.00 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [-1.00, 4.00]
Games | N: 22280 W: 4916 L: 4716 D: 12648