### PR TITLE
Use approximate LMR depth for pruning margins

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -318,6 +318,8 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
+            Depth lmrDepth = MAX(0, depth - Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)]);
+
             // Late move pruning
             if (moveCount > (3 + 2 * depth * depth) / (2 - improving))
                 break;
@@ -329,11 +331,11 @@ move_loop:
             }
 
             // History pruning
-            if (depth < 3 && histScore < -2024 * depth)
+            if (lmrDepth < 3 && histScore < -2024 * depth)
                 continue;
 
             // SEE pruning
-            if (depth < 7 && !SEE(pos, move, -50 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, -50 * depth))
                 continue;
         }
 


### PR DESCRIPTION
Allows pruning at high depths if LMR would reduce the searched depth enough.

ELO   | 4.01 +- 3.40 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 13680 W: 2412 L: 2254 D: 9014