### PR TITLE
Bad history -> bad noisy

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -92,7 +92,7 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(&mp->list, mp->ttMove, NOMOVE, NOMOVE)))
-                if (mp->list.moves[mp->list.next-1].score > 16000 || SEE(pos, move, 0))
+                if (mp->list.moves[mp->list.next-1].score > 16000 || (mp->list.moves[mp->list.next-1].score > -8000 && SEE(pos, move, 0)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -92,7 +92,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(&mp->list, mp->ttMove, NOMOVE, NOMOVE)))
-                if (mp->list.moves[mp->list.next-1].score > 16000 || (mp->list.moves[mp->list.next-1].score > -8000 && SEE(pos, move, 0)))
+                if (    mp->list.moves[mp->list.next-1].score > 16000
+                    || (mp->list.moves[mp->list.next-1].score > -8000 && SEE(pos, move, 0)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;


### PR DESCRIPTION
Classify noisy moves as bad if they have bad history, regardless of SEE.

ELO   | 3.51 +- 3.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 17904 W: 3856 L: 3675 D: 10373

ELO   | 5.68 +- 4.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 8864 W: 1578 L: 1433 D: 5853