### PR TITLE
Push threat

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -55,6 +55,7 @@ const int PawnDoubled  = S(-14,-37);
 const int PawnIsolated = S(-10,-12);
 const int PawnSupport  = S( 17,  9);
 const int PawnThreat   = S( 41, 70);
+const int PushThreat   = S( 14,  4);
 const int PawnOpen     = S(-14, -9);
 const int BishopPair   = S( 21,108);
 const int KingAtkPawn  = S( 61, 76);
@@ -293,6 +294,8 @@ INLINE int EvalPieces(const Position *pos, EvalInfo *ei) {
 // Evaluates threats
 INLINE int EvalThreats(const Position *pos, const Color color) {
 
+    const Direction up = color == WHITE ? NORTH : SOUTH;
+
     int eval = 0;
 
     Bitboard ourPawns = colorPieceBB(color, PAWN);
@@ -301,6 +304,11 @@ INLINE int EvalThreats(const Position *pos, const Color color) {
     int count = PopCount(PawnBBAttackBB(ourPawns, color) & theirNonPawns);
     eval += PawnThreat * count;
     TraceCount(PawnThreat);
+
+    Bitboard pawnPushes = ShiftBB(ourPawns, up) & ~pieceBB(ALL);
+    count = PopCount(PawnBBAttackBB(pawnPushes, color) & theirNonPawns);
+    eval += PushThreat * count;
+    TraceCount(PushThreat);
 
     return eval;
 }

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -115,7 +115,7 @@ INLINE int EvalPawns(const Position *pos, const Color color) {
 
     const Direction down = color == WHITE ? SOUTH : NORTH;
 
-    int eval = 0, count;
+    int count, eval = 0;
 
     Bitboard pawns = colorPieceBB(color, PAWN);
 
@@ -296,16 +296,17 @@ INLINE int EvalThreats(const Position *pos, const Color color) {
 
     const Direction up = color == WHITE ? NORTH : SOUTH;
 
-    int eval = 0;
+    int count, eval = 0;
 
     Bitboard ourPawns = colorPieceBB(color, PAWN);
     Bitboard theirNonPawns = colorBB(!color) ^ colorPieceBB(!color, PAWN);
 
-    int count = PopCount(PawnBBAttackBB(ourPawns, color) & theirNonPawns);
+    count = PopCount(PawnBBAttackBB(ourPawns, color) & theirNonPawns);
     eval += PawnThreat * count;
     TraceCount(PawnThreat);
 
     Bitboard pawnPushes = ShiftBB(ourPawns, up) & ~pieceBB(ALL);
+
     count = PopCount(PawnBBAttackBB(pawnPushes, color) & theirNonPawns);
     eval += PushThreat * count;
     TraceCount(PushThreat);

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -48,6 +48,7 @@ extern const int PawnDoubled;
 extern const int PawnIsolated;
 extern const int PawnSupport;
 extern const int PawnThreat;
+extern const int PushThreat;
 extern const int PawnOpen;
 extern const int BishopPair;
 extern const int KingAtkPawn;
@@ -202,6 +203,7 @@ void InitBaseParams(TVector tparams) {
     InitBaseSingle(PawnIsolated);
     InitBaseSingle(PawnSupport);
     InitBaseSingle(PawnThreat);
+    InitBaseSingle(PushThreat);
     InitBaseSingle(PawnOpen);
     InitBaseSingle(BishopPair);
     InitBaseSingle(KingAtkPawn);
@@ -253,6 +255,7 @@ void PrintParameters(TVector params, TVector current) {
     PrintSingle("PawnIsolated", tparams, i++, "");
     PrintSingle("PawnSupport", tparams, i++, " ");
     PrintSingle("PawnThreat", tparams, i++, "  ");
+    PrintSingle("PushThreat", tparams, i++, "  ");
     PrintSingle("PawnOpen", tparams, i++, "    ");
     PrintSingle("BishopPair", tparams, i++, "  ");
     PrintSingle("KingAtkPawn", tparams, i++, " ");
@@ -309,6 +312,7 @@ void InitCoefficients(TCoeffs coeffs) {
     InitCoeffSingle(PawnIsolated);
     InitCoeffSingle(PawnSupport);
     InitCoeffSingle(PawnThreat);
+    InitCoeffSingle(PushThreat);
     InitCoeffSingle(PawnOpen);
     InitCoeffSingle(BishopPair);
     InitCoeffSingle(KingAtkPawn);

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -40,7 +40,7 @@
 #define DATASET      "../../Datasets/Andrew/BIG.book"
 #define NPOSITIONS   (42484641) // Total FENS in the book
 
-#define NTERMS       (     509) // Number of terms being tuned
+#define NTERMS       (     510) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -65,6 +65,7 @@ typedef struct EvalTrace {
     int PawnIsolated[COLOR_NB];
     int PawnSupport[COLOR_NB];
     int PawnThreat[COLOR_NB];
+    int PushThreat[COLOR_NB];
     int PawnOpen[COLOR_NB];
     int BishopPair[COLOR_NB];
     int KingAtkPawn[COLOR_NB];


### PR DESCRIPTION
Give a bonus for pawns that can attack non-pawn pieces by moving forward.

ELO   | 6.18 +- 4.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 8880 W: 2029 L: 1871 D: 4980

ELO   | 3.02 +- 2.82 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 19896 W: 3501 L: 3328 D: 13067