### PR TITLE
Fail-low beta reduction tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -521,7 +521,7 @@ static int AspirationWindow(Thread *thread, Stack *ss) {
         // Failed low, relax lower bound and search again
         if (score <= alpha) {
             alpha = MAX(alpha - delta, -INFINITE);
-            beta  = (alpha + beta) / 2;
+            beta  = (alpha + 2 * beta) / 3;
             depth = thread->depth;
 
         // Failed high, relax upper bound and search again

--- a/src/search.c
+++ b/src/search.c
@@ -521,7 +521,7 @@ static int AspirationWindow(Thread *thread, Stack *ss) {
         // Failed low, relax lower bound and search again
         if (score <= alpha) {
             alpha = MAX(alpha - delta, -INFINITE);
-            beta  = (alpha + 2 * beta) / 3;
+            beta  = (alpha + 3 * beta) / 4;
             depth = thread->depth;
 
         // Failed high, relax upper bound and search again


### PR DESCRIPTION
Smaller reduction of beta after a fail-low.

ELO   | 3.34 +- 2.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 17048 W: 2839 L: 2675 D: 11534