### PR TITLE
Quiet LMP sooner

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -325,7 +325,7 @@ move_loop:
                 break;
 
             // Quiet late move pruning
-            if (quiet && moveCount > (3 + depth * depth) / (2 - improving)) {
+            if (quiet && moveCount > (1 + depth * depth) / (2 - improving)) {
                 mp.onlyNoisy = true;
                 continue;
             }


### PR DESCRIPTION
Try fewer moves before giving up on quiet moves.

ELO   | 4.21 +- 3.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 13944 W: 2977 L: 2808 D: 8159

ELO   | 4.16 +- 3.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 12848 W: 2155 L: 2001 D: 8692