### PR TITLE
Counter move history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -55,7 +55,7 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
     // Bonus to the move that caused the beta cutoff
     if (depth > 1) {
         HistoryBonus(moveIsQuiet(bestMove) ? QuietEntry(bestMove) : NoisyEntry(bestMove), bonus);
-        if (prevMove)
+        if (prevMove && moveIsQuiet(bestMove))
             HistoryBonus(ContEntry(bestMove), bonus);
     }
 

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -66,11 +66,9 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage) {
 
         Move move = list->moves[i].move;
 
-        list->moves[i].score = stage == GEN_QUIET ? *QuietEntry(move)
+        list->moves[i].score = stage == GEN_QUIET ? *QuietEntry(move) + *ContEntry(move)
                                                   : *NoisyEntry(move)
                                                    + PieceValue[MG][pieceOn(toSq(move))];
-
-        list->moves[i].score += *ContEntry(move);
     }
 
     SortMoves(list);

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -58,6 +58,10 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage) {
 
     const Position *pos = &thread->pos;
 
+    Move prevMove = pos->histPly > 0 ? history(-1).move : NOMOVE;
+    Square prevTo = toSq(prevMove);
+    Piece prevPiece = pieceOn(prevTo);
+
     for (int i = list->next; i < list->count; ++i) {
 
         Move move = list->moves[i].move;
@@ -65,6 +69,8 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage) {
         list->moves[i].score = stage == GEN_QUIET ? *QuietEntry(move)
                                                   : *NoisyEntry(move)
                                                    + PieceValue[MG][pieceOn(toSq(move))];
+
+        list->moves[i].score += *ContEntry(move);
     }
 
     SortMoves(list);

--- a/src/threads.c
+++ b/src/threads.c
@@ -97,7 +97,8 @@ void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)
         memset(threads[i].pawnCache,      0, sizeof(PawnCache)),
         memset(threads[i].history,        0, sizeof(threads[i].history)),
-        memset(threads[i].captureHistory, 0, sizeof(threads[i].captureHistory));
+        memset(threads[i].captureHistory, 0, sizeof(threads[i].captureHistory)),
+        memset(threads[i].continuation,   0, sizeof(threads[i].continuation));
 }
 
 // Run the given function once in each thread

--- a/src/threads.h
+++ b/src/threads.h
@@ -52,6 +52,7 @@ typedef struct Thread {
     PawnCache pawnCache;
     int16_t history[COLOR_NB][64][64];
     int16_t captureHistory[PIECE_NB][64][TYPE_NB];
+    int16_t continuation[PIECE_NB][64][PIECE_NB][64];
 
     int index;
     int count;


### PR DESCRIPTION
Give a history score based on how well a move does given the opponents previous move.

ELO   | 44.68 +- 14.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 1040 W: 295 L: 162 D: 583

ELO   | 33.95 +- 10.83 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 1304 W: 280 L: 153 D: 871