### PR TITLE
Followup move history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -40,7 +40,8 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
 
     const Position *pos = &thread->pos;
 
-    Move prevMove = pos->histPly > 0 ? history(-1).move : NOMOVE;
+    Move prevMove = pos->histPly >= 1 ? history(-1).move : NOMOVE;
+    Move prevMove2 = pos->histPly >= 2 ? history(-2).move : NOMOVE;
 
     // Update killers
     if (ss->killers[0] != bestMove) {
@@ -55,6 +56,8 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
         HistoryBonus(QuietEntry(bestMove), bonus);
         if (prevMove)
             HistoryBonus(ContEntry(prevMove, bestMove), bonus);
+        if (prevMove2)
+            HistoryBonus(ContEntry(prevMove2, bestMove), bonus);
     }
 
     // If bestMove is quiet, penalize quiet moves that failed to produce a cut
@@ -64,6 +67,8 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
         HistoryBonus(QuietEntry(move), -bonus);
         if (prevMove)
             HistoryBonus(ContEntry(prevMove, move), -bonus);
+        if (prevMove2)
+            HistoryBonus(ContEntry(prevMove2, move), -bonus);
     }
 }
 

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -58,13 +58,14 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage) {
 
     const Position *pos = &thread->pos;
 
-    Move prevMove = pos->histPly > 0 ? history(-1).move : NOMOVE;
+    Move prevMove = pos->histPly >= 1 ? history(-1).move : NOMOVE;
+    Move prevMove2 = pos->histPly >= 2 ? history(-2).move : NOMOVE;
 
     for (int i = list->next; i < list->count; ++i) {
 
         Move move = list->moves[i].move;
 
-        list->moves[i].score = stage == GEN_QUIET ? *QuietEntry(move) + *ContEntry(prevMove, move)
+        list->moves[i].score = stage == GEN_QUIET ? *QuietEntry(move) + *ContEntry(prevMove, move) + *ContEntry(prevMove2, move)
                                                   : *NoisyEntry(move)
                                                    + PieceValue[MG][pieceOn(toSq(move))];
     }


### PR DESCRIPTION
Give a history score based on how well a move does given our own previous move.

ELO   | 14.31 +- 7.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 3400 W: 790 L: 650 D: 1960

ELO   | 4.14 +- 3.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 12760 W: 2084 L: 1932 D: 8744