### PR TITLE
LMR reduce more for late quiet moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -47,7 +47,7 @@ CONSTR InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
             Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.25, // capture
-            Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 2.25; // quiet
+            Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 1.75; // quiet
 }
 
 // Quiescence


### PR DESCRIPTION
With the additional history heuristics, quiet move ordering is much better than before, and late moves are thus less likely to be good.

ELO   | 7.37 +- 5.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 7024 W: 1511 L: 1362 D: 4151

ELO   | 4.88 +- 3.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 10400 W: 1722 L: 1576 D: 7102