### PR TITLE
LMR history adjustment tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -331,7 +331,7 @@ move_loop:
             }
 
             // History pruning
-            if (lmrDepth < 3 && histScore < -2024 * depth)
+            if (lmrDepth < 3 && histScore < -2048 * depth)
                 continue;
 
             // SEE pruning
@@ -408,7 +408,7 @@ move_loop:
             // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
             // Adjust reduction by move history
-            r -= histScore / 6000;
+            r -= histScore / 8192;
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);


### PR DESCRIPTION
ELO   | 2.62 +- 2.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 27288 W: 5556 L: 5350 D: 16382

ELO   | 4.79 +- 3.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 10528 W: 1691 L: 1546 D: 7291