### PR TITLE
Lower the history pruning margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -331,7 +331,7 @@ move_loop:
             }
 
             // History pruning
-            if (lmrDepth < 3 && histScore < -2048 * depth)
+            if (lmrDepth < 3 && histScore < -1024 * depth)
                 continue;
 
             // SEE pruning


### PR DESCRIPTION
ELO   | 6.33 +- 4.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 8448 W: 1756 L: 1602 D: 5090

ELO   | 3.48 +- 3.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 15584 W: 2438 L: 2282 D: 10864