### PR TITLE
ProbCut only try good noisy moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -275,6 +275,8 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         Move move;
         while ((move = NextMove(&mp))) {
 
+            if (mp.stage > NOISY_GOOD) break;
+
             if (!MakeMove(pos, move)) continue;
 
             // See if a quiescence search beats pbBeta


### PR DESCRIPTION
ELO   | 3.28 +- 2.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 16864 W: 2673 L: 2514 D: 11677

ELO   | 5.25 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 10392 W: 2154 L: 1997 D: 6241