### PR TITLE
Fix killer history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -90,3 +90,24 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
     for (int i = 0; i < nCount; ++i)
         HistoryBonus(NoisyEntry(noisys[i]), -bonus);
 }
+
+INLINE int GetQuietHistory(const Thread *thread, Move move) {
+
+    const Position *pos = &thread->pos;
+
+    Move prevMove  = pos->histPly >= 1 ? history(-1).move : NOMOVE;
+    Move prevMove2 = pos->histPly >= 2 ? history(-2).move : NOMOVE;
+
+    return *QuietEntry(move)+ *ContEntry(prevMove, move)+ *ContEntry(prevMove2, move);
+}
+
+INLINE int GetCaptureHistory(const Thread *thread, Move move) {
+
+    const Position *pos = &thread->pos;
+
+    return *NoisyEntry(move);
+}
+
+INLINE int GetHistory(const Thread *thread, Move move) {
+    return moveIsQuiet(move) ? GetQuietHistory(thread, move) : GetCaptureHistory(thread, move);
+}

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -60,18 +60,11 @@ static void ScoreMoves(MoveList *list, const Thread *thread, const int stage, De
 
     const Position *pos = &thread->pos;
 
-    Move prevMove  = pos->histPly >= 1 ? history(-1).move : NOMOVE;
-    Move prevMove2 = pos->histPly >= 2 ? history(-2).move : NOMOVE;
-
     for (int i = list->next; i < list->count; ++i) {
-
         Move move = list->moves[i].move;
-
-        list->moves[i].score = stage == GEN_QUIET ?  *QuietEntry(move)
-                                                   + *ContEntry(prevMove, move)
-                                                   + *ContEntry(prevMove2, move)
-                                                  :  *NoisyEntry(move)
-                                                   + PieceValue[MG][pieceOn(toSq(move))];
+        list->moves[i].score =
+            stage == GEN_QUIET ? GetQuietHistory(thread, move)
+                               : GetCaptureHistory(thread, move) + PieceValue[MG][pieceOn(toSq(move))];
     }
 
     SortMoves(list, -1000 * depth);

--- a/src/search.c
+++ b/src/search.c
@@ -313,7 +313,7 @@ move_loop:
 
         bool quiet = moveIsQuiet(move);
 
-        int histScore = mp.list.moves[mp.list.next-1].score;
+        int histScore = GetHistory(thread, move);
 
         // Misc pruning
         if (  !root


### PR DESCRIPTION
Killers were using the history of the last good noisy move instead of their own. Also removes the value of the captured piece for capture history in search.

ELO   | 3.16 +- 3.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 20432 W: 4223 L: 4037 D: 12172

ELO   | 6.91 +- 4.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6792 W: 1066 L: 931 D: 4795