### PR TITLE
Avoid returning winning score by pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -234,7 +234,8 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Reverse Futility Pruning
     if (   depth < 7
-        && eval - 225 * depth + 100 * improving >= beta)
+        && eval - 225 * depth + 100 * improving >= beta
+        && abs(beta) < TBWIN_IN_MAX)
         return eval;
 
     // Null Move Pruning


### PR DESCRIPTION
Always prove terminal win scores.