### PR TITLE
Lower reverse futility pruning margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -234,7 +234,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Reverse Futility Pruning
     if (   depth < 7
-        && eval - 225 * depth + 100 * improving >= beta
+        && eval - 175 * depth + 100 * improving >= beta
         && abs(beta) < TBWIN_IN_MAX)
         return eval;
 


### PR DESCRIPTION
ELO   | 8.39 +- 5.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6008 W: 1262 L: 1117 D: 3629

ELO   | 5.10 +- 3.75 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9880 W: 1557 L: 1412 D: 6911