### PR TITLE
Lower razor margin

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -229,7 +229,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Razoring
     if (   depth < 2
-        && eval + 640 < alpha)
+        && eval + 500 < alpha)
         return Quiescence(thread, ss, alpha, beta);
 
     // Reverse Futility Pruning

--- a/src/search.c
+++ b/src/search.c
@@ -229,7 +229,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Razoring
     if (   depth < 2
-        && eval + 500 < alpha)
+        && eval + 350 < alpha)
         return Quiescence(thread, ss, alpha, beta);
 
     // Reverse Futility Pruning


### PR DESCRIPTION
ELO   | 3.30 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 18832 W: 3791 L: 3612 D: 11429

ELO   | 0.97 +- 1.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.69 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 47408 W: 7223 L: 7090 D: 33095