### PR TITLE
X-ray enemy queens for mobility

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -191,9 +191,9 @@ INLINE Bitboard AttackBB(PieceType pt, Square sq, Bitboard occupied) {
 INLINE Bitboard XRayAttackBB(const Position *pos, const Color color, const PieceType pt, const Square sq) {
     Bitboard occ = pieceBB(ALL);
     switch (pt) {
-        case BISHOP: occ ^= colorPieceBB(color, QUEEN) ^ colorPieceBB(color, BISHOP); break;
-        case ROOK  : occ ^= colorPieceBB(color, QUEEN) ^ colorPieceBB(color, ROOK); break;
-        case QUEEN : occ ^= colorPieceBB(color, QUEEN) ^ colorPieceBB(color, ROOK) ^ colorPieceBB(color, BISHOP); break;
+        case BISHOP: occ ^= pieceBB(QUEEN) ^ colorPieceBB(color, BISHOP); break;
+        case ROOK  : occ ^= pieceBB(QUEEN) ^ colorPieceBB(color, ROOK); break;
+        case QUEEN : occ ^= pieceBB(QUEEN) ^ colorPieceBB(color, ROOK) ^ colorPieceBB(color, BISHOP); break;
     }
     return AttackBB(pt, sq, occ);
 }


### PR DESCRIPTION
Queens are terrible blockers, so ignore them for slider mobility.

ELO   | 3.28 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 18848 W: 3772 L: 3594 D: 11482

ELO   | 6.90 +- 4.51 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6952 W: 1134 L: 996 D: 4822