### PR TITLE
Limit time spent on forced moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -473,8 +473,7 @@ skip_search:
                             : 0;
 
     // Limit time spent on forced moves
-    if (root && moveCount == 1 && Limits.timelimit)
-        Limits.optimalUsage = MIN(500, Limits.optimalUsage);
+    if (root) thread->rootMoveCount = moveCount;
 
     bestScore = MIN(bestScore, maxScore);
 
@@ -569,6 +568,10 @@ static void *IterativeDeepening(void *voidThread) {
 
         // Stop searching after finding a short enough mate
         if (MATE - abs(thread->score) <= 2 * abs(Limits.mate)) break;
+
+        // Limit time spent on forced moves
+        if (thread->rootMoveCount == 1 && Limits.timelimit && !Limits.movetime)
+            Limits.optimalUsage = MIN(500, Limits.optimalUsage);
 
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit

--- a/src/search.c
+++ b/src/search.c
@@ -472,6 +472,10 @@ skip_search:
              : inCheck      ? -MATE + ss->ply
                             : 0;
 
+    // Limit time spent on forced moves
+    if (root && moveCount == 1 && Limits.timelimit)
+        Limits.optimalUsage = MIN(500, Limits.optimalUsage);
+
     bestScore = MIN(bestScore, maxScore);
 
     // Store in TT

--- a/src/threads.h
+++ b/src/threads.h
@@ -45,6 +45,7 @@ typedef struct Thread {
     int score;
     Depth depth;
     Color nullMover;
+    int rootMoveCount;
     bool doPruning;
 
     // Anything below here is not zeroed out between searches


### PR DESCRIPTION
Spend at most half a second on forced moves.

Closes #500 

ELO   | 1.43 +- 2.68 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 19192 W: 2893 L: 2814 D: 13485