### PR TITLE
Multi-PV aspiration window improvement

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -492,7 +492,7 @@ skip_search:
 static void AspirationWindow(Thread *thread, Stack *ss) {
 
     bool mainThread = thread->index == 0;
-    int score = thread->score[0];
+    int score = thread->score[thread->multiPV];
     int depth = thread->depth;
 
     const int initialWindow = 12;


### PR DESCRIPTION
Center the aspiration window of each multipv search around the previous score of that pv index, instead of centering all of them around the best move.

ELO   | 13.16 +- 7.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 3936 W: 1045 L: 896 D: 1995