### PR TITLE
Keep searching when uncertain

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -577,7 +577,8 @@ static void *IterativeDeepening(void *voidThread) {
 
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit
-            && TimeSince(Limits.start) > Limits.optimalUsage * (1 + thread->uncertain))
+            && !thread->uncertain
+            && TimeSince(Limits.start) > Limits.optimalUsage)
             break;
 
         // Clear key history for seldepth calculation


### PR DESCRIPTION
Instead of temporarily doubling the time before not attempting to start the next depth, just keep starting the next depth as long as we are uncertain.

ELO   | 3.48 +- 2.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 15568 W: 2360 L: 2204 D: 11004