### PR TITLE
Reverse futility pruning tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -234,7 +234,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Reverse Futility Pruning
     if (   depth < 7
-        && eval - 175 * depth + 100 * improving >= beta
+        && eval - 175 * depth / (1 + improving) >= beta
         && abs(beta) < TBWIN_IN_MAX)
         return eval;
 


### PR DESCRIPTION
As seen in Bit Genie.

ELO   | 1.82 +- 1.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 50328 W: 9876 L: 9612 D: 30840

ELO   | 2.21 +- 2.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 29072 W: 4408 L: 4223 D: 20441