### PR TITLE
Trend

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -55,6 +55,7 @@ typedef struct Position {
     Key pawnKey;
 
     uint64_t nodes;
+    int trend;
 
     History gameHistory[256];
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -358,7 +358,7 @@ int EvalPosition(const Position *pos, PawnCache pc) {
     InitEvalInfo(pos, &ei, BLACK);
 
     // Material (includes PSQT)
-    int eval = pos->material;
+    int eval = pos->material + pos->trend;
 
     // Evaluate pawns
     eval += ProbePawnCache(pos, pc);

--- a/src/search.c
+++ b/src/search.c
@@ -491,6 +491,8 @@ skip_search:
 // Aspiration window
 static void AspirationWindow(Thread *thread, Stack *ss) {
 
+    Position *pos = &thread->pos;
+
     bool mainThread = thread->index == 0;
     int score = thread->score[thread->multiPV];
     int depth = thread->depth;
@@ -502,9 +504,13 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
     int beta  =  INFINITE;
 
     // Shrink the window at higher depths
-    if (depth > 6)
-        alpha = MAX(score - initialWindow, -INFINITE),
+    if (depth > 6) {
+        alpha = MAX(score - initialWindow, -INFINITE);
         beta  = MIN(score + initialWindow,  INFINITE);
+
+        int x = CLAMP(score / 2, -50, +50);
+        pos->trend = sideToMove == WHITE ? S(x, x/2) : -S(x, x/2);
+    }
 
     // Search with aspiration window until the result is inside the window
     while (true) {

--- a/src/search.c
+++ b/src/search.c
@@ -508,7 +508,7 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
         alpha = MAX(score - initialWindow, -INFINITE);
         beta  = MIN(score + initialWindow,  INFINITE);
 
-        int x = CLAMP(score / 2, -50, +50);
+        int x = CLAMP(score / 2, -35, 35);
         pos->trend = sideToMove == WHITE ? S(x, x/2) : -S(x, x/2);
     }
 


### PR DESCRIPTION
Trend, also known previously as dynamic contempt, biases evaluations in the direction the previous search depth indicated the position is going, increasing all evaluations when search says we are winning, and reducing them when losing.

Inspired by SF.

ELO   | 10.99 +- 5.77 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 4144 W: 683 L: 552 D: 2909