### PR TITLE
Avoid printing empty PVs

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -254,6 +254,9 @@ void PrintThinking(const Thread *thread, int alpha, int beta) {
         const PV *pv = &thread->rootMoves[i].pv;
         int score = thread->rootMoves[i].score;
 
+        // Skip empty pvs that occur when MultiPV > legal moves in root
+        if (pv->length == 0) break;
+
         // Determine whether we have a centipawn or mate score
         char *type = abs(score) >= MATE_IN_MAX ? "mate" : "cp";
 


### PR DESCRIPTION
When MultiPV is set higher than the number of legal moves in root (or the number of searchmoves) some pvs will be empty as nothing was searched. This avoids printing those as they are pointless.