### PR TITLE
Count root moves before search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -483,9 +483,6 @@ skip_search:
              : inCheck      ? -MATE + ss->ply
                             : 0;
 
-    // Limit time spent on forced moves
-    if (root) thread->rootMoveCount = moveCount;
-
     // Make sure score isn't above the max score given by TBs
     bestScore = MIN(bestScore, maxScore);
 


### PR DESCRIPTION
It seems the time limit for only-moves was sometimes applied even when there were multiple root moves at TCEC. As seen in SuFi testing games for season 21. I have no idea how that could happen, and I was unable to reproduce the behavior.

To avoid this just count root moves before starting the search instead of relying on number of moves searched in root.