### PR TITLE
Passed king distance tweak

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -320,18 +320,18 @@ INLINE int EvalPassedPawns(const Position *pos, const EvalInfo *ei, const Color 
     while (passers) {
 
         Square sq = PopLsb(&passers);
+        Square forward = sq + up;
         int rank = RelativeRank(color, RankOf(sq));
         if (rank < RANK_5) continue;
 
-        count = Distance(sq, kingSq( color));
+        count = Distance(forward, kingSq( color));
         eval += count * PassedDistUs[rank];
         TraceCount(PassedDistUs[rank]);
 
-        count = Distance(sq, kingSq(!color));
+        count = Distance(forward, kingSq(!color));
         eval += count * PassedDistThem[rank];
         TraceCount(PassedDistThem[rank]);
 
-        Square forward = sq + up;
         if (pieceOn(forward)) {
             eval += PassedBlocked[rank];
             TraceIncr(PassedBlocked[rank]);


### PR DESCRIPTION
Use distance to the square in front of the passer, as supporting or preventing the pawn's advance is important.

ELO   | 2.24 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 36792 W: 7981 L: 7744 D: 21067