### PR TITLE
LMR quiets more when ttMove is a capture

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -424,7 +424,7 @@ move_loop:
             // Adjust reduction by move history
             r -= histScore / 8192;
 
-            r += moveIsCapture(ttMove);
+            r -= !moveIsCapture(ttMove);
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);

--- a/src/search.c
+++ b/src/search.c
@@ -47,7 +47,7 @@ CONSTR InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
             Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.25, // capture
-            Reductions[1][depth][moves] = 1.75 + log(depth) * log(moves) / 1.75; // quiet
+            Reductions[1][depth][moves] = 1.50 + log(depth) * log(moves) / 1.75; // quiet
 }
 
 // Checks if the move is in the list of searchmoves if any were given

--- a/src/search.c
+++ b/src/search.c
@@ -424,7 +424,7 @@ move_loop:
             // Adjust reduction by move history
             r -= histScore / 8192;
 
-            r -= !moveIsCapture(ttMove);
+            r += quiet && moveIsCapture(ttMove);
 
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);

--- a/src/search.c
+++ b/src/search.c
@@ -424,6 +424,8 @@ move_loop:
             // Adjust reduction by move history
             r -= histScore / 8192;
 
+            r += moveIsCapture(ttMove);
+
             // Depth after reductions, avoiding going straight to quiescence
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);
 

--- a/src/search.c
+++ b/src/search.c
@@ -423,7 +423,7 @@ move_loop:
             r += sideToMove == thread->nullMover;
             // Adjust reduction by move history
             r -= histScore / 8192;
-
+            // Reduce quiets more if ttMove is a capture
             r += quiet && moveIsCapture(ttMove);
 
             // Depth after reductions, avoiding going straight to quiescence


### PR DESCRIPTION
ELO   | 3.33 +- 2.96 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 16672 W: 2720 L: 2560 D: 11392