### PR TITLE
LMR tweak

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -408,7 +408,7 @@ move_loop:
 
         // Reduced depth zero-window search
         if (   depth > 2
-            && moveCount > (2 + pvNode - (ttMove != NOMOVE))
+            && moveCount > 1 + pvNode + !ttMove
             && thread->doPruning) {
 
             // Base reduction

--- a/src/search.c
+++ b/src/search.c
@@ -408,7 +408,7 @@ move_loop:
 
         // Reduced depth zero-window search
         if (   depth > 2
-            && moveCount > (2 + pvNode)
+            && moveCount > (2 + pvNode - (ttMove != NOMOVE))
             && thread->doPruning) {
 
             // Base reduction


### PR DESCRIPTION
Start LMR 1 move sooner when there's a tt move as the chance the best move was already searched is higher.

ELO   | 2.11 +- 2.19 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 39600 W: 8287 L: 8046 D: 23267

ELO   | 1.57 +- 1.63 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 56168 W: 9200 L: 8946 D: 38022