### PR TITLE
Fix bug with MultiPV

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -588,7 +588,7 @@ static void *IterativeDeepening(void *voidThread) {
             AspirationWindow(thread, ss);
 
         // Sort root moves so they are printed in the right order in multi-pv mode
-        SortRootMoves(thread, Limits.multiPV);
+        SortRootMoves(thread, MIN(Limits.multiPV, thread->rootMoveCount));
 
         // Only the main thread concerns itself with the rest
         if (!mainThread) continue;
@@ -621,7 +621,7 @@ static void *IterativeDeepening(void *voidThread) {
 void *SearchPosition(void *pos) {
 
     InitTimeManagement();
-    PrepareSearch(pos);
+    PrepareSearch(pos, Limits.searchmoves);
     bool threadsSpawned = false;
 
     // Probe TBs for a move if already in a TB position

--- a/src/search.c
+++ b/src/search.c
@@ -576,6 +576,7 @@ static void *IterativeDeepening(void *voidThread) {
     Position *pos = &thread->pos;
     Stack *ss = thread->ss+SS_OFFSET;
     bool mainThread = thread->index == 0;
+    int multiPV = MIN(Limits.multiPV, thread->rootMoveCount);
 
     // Iterative deepening
     while (++thread->depth <= (mainThread ? Limits.depth : MAX_PLY)) {
@@ -584,11 +585,11 @@ static void *IterativeDeepening(void *voidThread) {
         if (setjmp(thread->jumpBuffer)) break;
 
         // Search position, using aspiration windows for higher depths
-        for (thread->multiPV = 0; thread->multiPV < Limits.multiPV; ++thread->multiPV)
+        for (thread->multiPV = 0; thread->multiPV < multiPV; ++thread->multiPV)
             AspirationWindow(thread, ss);
 
         // Sort root moves so they are printed in the right order in multi-pv mode
-        SortRootMoves(thread, MIN(Limits.multiPV, thread->rootMoveCount));
+        SortRootMoves(thread, multiPV);
 
         // Only the main thread concerns itself with the rest
         if (!mainThread) continue;

--- a/src/threads.c
+++ b/src/threads.c
@@ -90,14 +90,25 @@ uint64_t TotalTBHits() {
     return total;
 }
 
+// Checks if the move is in the list of searchmoves if any were given
+static bool NotInSearchMoves(Move searchmoves[], Move move) {
+    if (searchmoves[0] == 0) return false;
+    for (Move *m = searchmoves; *m != 0; ++m)
+        if (*m == move)
+            return false;
+    return true;
+}
+
 // Setup threads for a new search
-void PrepareSearch(Position *pos) {
+void PrepareSearch(Position *pos, Move searchmoves[]) {
     int rootMoveCount = 0;
     MoveList list = { 0 };
     GenNoisyMoves(pos, &list);
     GenQuietMoves(pos, &list);
     for (int i = 0; i < list.count; ++i) {
-        if (!MakeMove(pos, list.moves[list.next++].move)) continue;
+        Move move = list.moves[list.next++].move;
+        if (NotInSearchMoves(searchmoves, move)) continue;
+        if (!MakeMove(pos, move)) continue;
         ++rootMoveCount;
         TakeMove(pos);
     }

--- a/src/threads.h
+++ b/src/threads.h
@@ -77,7 +77,7 @@ bool AlreadySearchedMultiPV(Thread *thread, Move move);
 void SortRootMoves(Thread *thread, int multiPV);
 uint64_t TotalNodes();
 uint64_t TotalTBHits();
-void PrepareSearch(Position *pos);
+void PrepareSearch(Position *pos, Move searchmoves[]);
 void StartMainThread(void *(*func)(void *), Position *pos);
 void StartHelpers(void *(*func)(void *));
 void WaitForHelpers();

--- a/src/uci.c
+++ b/src/uci.c
@@ -235,7 +235,6 @@ INLINE int MateScore(const int score) {
 void PrintThinking(const Thread *thread, int alpha, int beta) {
 
     const Position *pos = &thread->pos;
-    const int multiPV = Limits.multiPV;
 
     TimePoint elapsed = TimeSince(Limits.start);
     uint64_t nodes    = TotalNodes(thread);
@@ -247,7 +246,7 @@ void PrintThinking(const Thread *thread, int alpha, int beta) {
     for (; seldepth > 0; --seldepth)
         if (history(seldepth-1).key != 0) break;
 
-    for (int i = 0; i < multiPV; ++i) {
+    for (int i = 0; i < Limits.multiPV; ++i) {
 
         const PV *pv = &thread->rootMoves[i].pv;
         int score = thread->rootMoves[i].score;
@@ -261,7 +260,7 @@ void PrintThinking(const Thread *thread, int alpha, int beta) {
         // Determine if score is an upper or lower bound
         char *bound = score >= beta  ? " lowerbound"
                     : score <= alpha ? " upperbound"
-                                    : "";
+                                     : "";
 
         // Translate internal score into printed score
         score = abs(score) >=  MATE_IN_MAX ? MateScore(score)
@@ -271,7 +270,7 @@ void PrintThinking(const Thread *thread, int alpha, int beta) {
 
         // Basic info
         printf("info depth %d seldepth %d multipv %d score %s %d%s time %" PRId64
-            " nodes %" PRIu64 " nps %d tbhits %" PRIu64 " hashfull %d pv",
+               " nodes %" PRIu64 " nps %d tbhits %" PRIu64 " hashfull %d pv",
                 thread->depth, seldepth, i+1, type, score, bound, elapsed,
                 nodes, nps, tbhits, hashFull);
 


### PR DESCRIPTION
When there were fewer legal (or restricted by searchmoves) moves than MultiPV and the scores of the searched moves were negative they would be sorted behind empty moves, and skipped in printing. This patch includes the searchmoves restriction when counting rootmoves, and sorts at most as many PVs as there are rootmoves.