### PR TITLE
Begin LMR 1 move later in root

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -408,7 +408,7 @@ move_loop:
 
         // Reduced depth zero-window search
         if (   depth > 2
-            && moveCount > 1 + pvNode + !ttMove
+            && moveCount > 1 + pvNode + !ttMove + root
             && thread->doPruning) {
 
             // Base reduction


### PR DESCRIPTION
ELO   | 3.88 +- 3.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 15680 W: 3325 L: 3150 D: 9205

ELO   | 3.31 +- 2.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 17112 W: 2836 L: 2673 D: 11603