### PR TITLE
Encode moving piece in the move

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -27,8 +27,8 @@
 
 
 #define QuietEntry(move) &thread->history[sideToMove][fromSq(move)][toSq(move)]
-#define NoisyEntry(move) &thread->captureHistory[pieceOn(fromSq(move))][toSq(move)][PieceTypeOf(capturing(move))]
-#define ContEntry(prev, move) &thread->continuation[pieceOn(toSq(prev))][toSq(prev)][pieceOn(fromSq(move))][toSq(move)]
+#define NoisyEntry(move) &thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))]
+#define ContEntry(prev, move) &thread->continuation[piece(prev)][toSq(prev)][piece(move)][toSq(move)]
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus) {
@@ -74,8 +74,6 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
 // Updates various history heuristics when a move causes a beta cutoff
 INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth, Move quiets[], int qCount, Move noisys[], int nCount) {
 
-    const Position *pos = &thread->pos;
-
     int bonus = depth * depth;
 
     // Update quiet history if bestMove is quiet
@@ -105,9 +103,6 @@ INLINE int GetQuietHistory(const Thread *thread, Move move) {
 }
 
 INLINE int GetCaptureHistory(const Thread *thread, Move move) {
-
-    const Position *pos = &thread->pos;
-
     return *NoisyEntry(move);
 }
 

--- a/src/move.c
+++ b/src/move.c
@@ -135,5 +135,5 @@ Move ParseMove(const char *str, const Position *pos) {
         flag = FLAG_CASTLE;
     }
 
-    return MOVE(from, to, pieceOn(to), promo, flag);
+    return MOVE(from, to, pieceOn(to), promo, flag, pieceOn(from));
 }

--- a/src/move.c
+++ b/src/move.c
@@ -50,6 +50,7 @@ bool MoveIsPseudoLegal(const Position *pos, const Move move) {
 
     // Must move to a square not occupied by our own pieces, and capture the piece specified
     if (   (colorBB(color) & BB(to))
+        || piece(move) != pieceOn(from)
         || capturing(move) != pieceOn(to))
         return false;
 

--- a/src/move.h
+++ b/src/move.h
@@ -21,24 +21,26 @@
 #include "bitboard.h"
 #include "types.h"
 
-/* Move contents - total 23bits used
-0000 0000 0000 0000 0011 1111 -> From       <<  0
-0000 0000 0000 1111 1100 0000 -> To         <<  6
-0000 0000 1111 0000 0000 0000 -> Captured   << 12
-0000 1111 0000 0000 0000 0000 -> Promotion  << 16
-0001 0000 0000 0000 0000 0000 -> En passant << 20
-0010 0000 0000 0000 0000 0000 -> Pawn Start << 21
-0100 0000 0000 0000 0000 0000 -> Castle     << 22
+/* Move contents - total 27 bits used
+0000 0000 0000 0000 0000 0000 0011 1111 -> From       <<  0
+0000 0000 0000 0000 0000 1111 1100 0000 -> To         <<  6
+0000 0000 0000 0000 1111 0000 0000 0000 -> Captured   << 12
+0000 0000 0000 1111 0000 0000 0000 0000 -> Promotion  << 16
+0000 0000 0001 0000 0000 0000 0000 0000 -> En passant << 20
+0000 0000 0010 0000 0000 0000 0000 0000 -> Pawn Start << 21
+0000 0000 0100 0000 0000 0000 0000 0000 -> Castle     << 22
+0000 1111 0000 0000 0000 0000 0000 0000 -> Piece      << 24
 */
 
 #define NOMOVE 0
 
 // Fields
-#define MOVE_FROM       0x00003F
-#define MOVE_TO         0x000FC0
-#define MOVE_CAPT       0x00F000
-#define MOVE_PROMO      0x0F0000
-#define MOVE_FLAGS      0x700000
+#define MOVE_FROM       0x000003F
+#define MOVE_TO         0x0000FC0
+#define MOVE_CAPT       0x000F000
+#define MOVE_PROMO      0x00F0000
+#define MOVE_FLAGS      0x0700000
+#define MOVE_PIECE      0xF000000
 
 // Special move flags
 #define FLAG_NONE       0
@@ -47,13 +49,14 @@
 #define FLAG_CASTLE     0x400000
 
 // Move constructor
-#define MOVE(f, t, ca, pro, fl) ((f) | ((t) << 6) | ((ca) << 12) | ((pro) << 16) | (fl))
+#define MOVE(f, t, ca, pro, fl, pc) ((f) | ((t) << 6) | ((ca) << 12) | ((pro) << 16) | (fl) | ((pc) << 24))
 
 // Extract info from a move
 #define fromSq(move)     ((move) & MOVE_FROM)
 #define toSq(move)      (((move) & MOVE_TO)    >>  6)
 #define capturing(move) (((move) & MOVE_CAPT)  >> 12)
 #define promotion(move) (((move) & MOVE_PROMO) >> 16)
+#define piece(move)     (((move) & MOVE_PIECE) >> 24)
 
 // Move types
 #define moveIsEnPas(move)   (move & FLAG_ENPAS)

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -26,7 +26,7 @@ enum { QUIET, NOISY };
 
 // Constructs and adds a move to the move list
 INLINE void AddMove(const Position *pos, MoveList *list, const Square from, const Square to, const Piece promo, const int flag) {
-    list->moves[list->count++].move = MOVE(from, to, pieceOn(to), promo, flag);
+    list->moves[list->count++].move = MOVE(from, to, pieceOn(to), promo, flag, pieceOn(from));
 }
 
 // Adds promotions

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -88,7 +88,7 @@ bool ProbeRoot(Position *pos, Move *move, unsigned *wdl, unsigned *dtz) {
              to    = TB_GET_TO(result),
              promo = TB_GET_PROMOTES(result);
 
-    *move = MOVE(from, to, 0, promo ? 6 - promo : 0, 0);
+    *move = MOVE(from, to, 0, promo ? 6 - promo : 0, 0, 0);
     *wdl = TB_GET_WDL(result);
     *dtz = TB_GET_DTZ(result);
 


### PR DESCRIPTION
This makes sure killers and tt moves actually match the current position, and fixes a bug with follow-up move (2 ply back) history where when the moved piece was captured by the counter-move (1 ply back), the move was using the counter-move history twice instead of fmh and cmh.