### PR TITLE
Validate move from TT earlier

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -148,8 +148,8 @@ Move NextMove(MovePicker *mp) {
 void InitNormalMP(MovePicker *mp, Thread *thread, Depth depth, Move ttMove, Move kill1, Move kill2) {
     mp->list.count = mp->list.next = 0;
     mp->thread    = thread;
-    mp->ttMove    = MoveIsPseudoLegal(&thread->pos, ttMove) ? ttMove : NOMOVE;
-    mp->stage     = mp->ttMove ? TTMOVE : GEN_NOISY;
+    mp->ttMove    = ttMove;
+    mp->stage     = ttMove ? TTMOVE : GEN_NOISY;
     mp->depth     = depth;
     mp->kill1     = kill1;
     mp->kill2     = kill2;

--- a/src/search.c
+++ b/src/search.c
@@ -183,6 +183,9 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     Depth ttDepth = tte->depth;
     int ttBound = tte->bound;
 
+    if (ttHit && !MoveIsPseudoLegal(pos, ttMove))
+        ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;
+
     // Trust TT if not a pvnode and the entry depth is sufficiently high
     if (   !pvNode
         && ttHit


### PR DESCRIPTION
The pseudo-legality check is now cheaper than before, so the cost of validating the tt move earlier is low enough that it doesn't seem to matter. Validating the tt move earlier is an extra hedge against hash collisions, as well as against mismatched entries caused by data races when using multiple threads. I doubt this matters for playing strength, but maybe in conditions like at TCEC it makes a difference.