### PR TITLE
Eval scale tweak

### DIFF
--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -99,6 +99,9 @@ enum {
     rank8BB = 0xFF00000000000000,
 
     BlackSquaresBB = 0xAA55AA55AA55AA55,
+
+    QueenSideBB = fileABB | fileBBB | fileCBB | fileDBB,
+    KingSideBB  = fileEBB | fileFBB | fileGBB | fileHBB,
 };
 
 extern const Bitboard FileBB[FILE_NB];

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -416,7 +416,7 @@ int ScaleFactor(const Position *pos, const int eval) {
     int pawnScale = 128 - x * x;
 
     if (!(strongPawns & QueenSideBB) || !(strongPawns & KingSideBB))
-        pawnScale -= 10;
+        pawnScale -= 20;
 
     if (   pos->nonPawnCount[WHITE] <= 2
         && pos->nonPawnCount[BLACK] <= 2

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -409,9 +409,14 @@ int ScaleFactor(const Position *pos, const int eval) {
 
     // Scale down eval the fewer pawns the stronger side has
     Color strong = eval > 0 ? WHITE : BLACK;
-    int strongPawnCount = PopCount(colorPieceBB(strong, PAWN));
+    Bitboard strongPawns = colorPieceBB(strong, PAWN);
+
+    int strongPawnCount = PopCount(strongPawns);
     int x = 8 - strongPawnCount;
     int pawnScale = 128 - x * x;
+
+    if (!(strongPawns & QueenSideBB) || !(strongPawns & KingSideBB))
+        pawnScale -= 10;
 
     if (   pos->nonPawnCount[WHITE] <= 2
         && pos->nonPawnCount[BLACK] <= 2
@@ -419,7 +424,7 @@ int ScaleFactor(const Position *pos, const int eval) {
         && Single(colorPieceBB(WHITE, BISHOP))
         && Single(colorPieceBB(BLACK, BISHOP))
         && Single(pieceBB(BISHOP) & BlackSquaresBB))
-        return pos->nonPawnCount[WHITE] == 1 ? 64 : MIN(96, pawnScale);
+        return MIN((pos->nonPawnCount[WHITE] == 1 ? 64 : 96), pawnScale);
 
     return pawnScale;
 }


### PR DESCRIPTION
Scale down the eval if the stronger side doesn't have pawns on both sides of the board.

-20 vs -10

ELO   | 5.22 +- 3.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9576 W: 1572 L: 1428 D: 6576

-10 vs master

ELO   | 5.33 +- 3.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.03 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9656 W: 1628 L: 1480 D: 6548