### PR TITLE
Switch back to flat depth offset for TT replacement

### DIFF
--- a/src/transposition.c
+++ b/src/transposition.c
@@ -57,7 +57,7 @@ void StoreTTEntry(TTEntry *tte, const Key key,
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (key != tte->key || depth * 2 >= tte->depth || bound == BOUND_EXACT)
+    if (key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT)
         tte->key   = key,
         tte->score = score,
         tte->depth = depth,


### PR DESCRIPTION
Depth + 4 (or around there) is the standard, but a while back depth * 2 tested better. After recent changes it seems the flat offset is doing better again.

ELO   | 2.91 +- 2.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 22768 W: 4574 L: 4383 D: 13811

ELO   | 2.08 +- 2.07 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 32040 W: 4857 L: 4665 D: 22518