### PR TITLE
Wait for the search to complete on UCI stop command

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -38,6 +38,7 @@
 
 SearchLimits Limits = { .multiPV = 1 };
 volatile bool ABORT_SIGNAL;
+volatile bool SEARCH_STOPPED = true;
 
 static int Reductions[2][32][32];
 
@@ -626,6 +627,8 @@ static void *IterativeDeepening(void *voidThread) {
 // Root of search
 void *SearchPosition(void *pos) {
 
+    SEARCH_STOPPED = false;
+
     InitTimeManagement();
     PrepareSearch(pos, Limits.searchmoves);
     bool threadsSpawned = false;
@@ -654,6 +657,9 @@ conclusion:
 
     // Print conclusion
     PrintConclusion(threads);
+
+    SEARCH_STOPPED = true;
+    Wake();
 
     return NULL;
 }

--- a/src/search.h
+++ b/src/search.h
@@ -35,6 +35,7 @@ typedef struct {
 
 extern SearchLimits Limits;
 extern volatile bool ABORT_SIGNAL;
+extern volatile bool SEARCH_STOPPED;
 
 
 void *SearchPosition(void *pos);

--- a/src/uci.c
+++ b/src/uci.c
@@ -160,6 +160,7 @@ static void Info() {
 static void Stop() {
     ABORT_SIGNAL = true;
     Wake();
+    Wait(&SEARCH_STOPPED);
 }
 
 // Signals the engine is ready


### PR DESCRIPTION
Fixes a crash when the engine is told to stop and immediately start a new search.

Thanks to mrbdzz / skiminki for the report and the fix.