### PR TITLE
Fix score when playing moves from syzygy

### DIFF
--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -90,7 +90,7 @@ bool ProbeRoot(Position *pos, Move *move, unsigned *wdl, unsigned *dtz) {
 
     *move = MOVE(from, to, 0, 0, promo ? 6 - promo : 0, 0);
     *wdl = TB_GET_WDL(result);
-    *dtz = TB_GET_DTZ(result);
+    *dtz = TB_GET_DTZ(result) - 1;
 
     return true;
 }


### PR DESCRIPTION
DTZ is given as moves until zeroing 50mr rule in the position before the move, subtracting one to give the distance after the chosen move.