### PR TITLE
Fix bug in passed pawn evaluation

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/board.c
+++ b/src/board.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/board.h
+++ b/src/board.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -178,7 +178,7 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
             eval += PawnPassed[rank];
             TraceIncr(PawnPassed[rank]);
 
-            if (BB(sq) & PawnBBAttackBB(pawns, color)) {
+            if (BB(sq) & PawnBBAttackBB(colorPieceBB(color, PAWN), color)) {
                 eval += PassedDefended[rank];
                 TraceIncr(PassedDefended[rank]);
             }

--- a/src/evaluate.h
+++ b/src/evaluate.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/history.h
+++ b/src/history.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/makemove.h
+++ b/src/makemove.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/move.c
+++ b/src/move.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/move.h
+++ b/src/move.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/psqt.c
+++ b/src/psqt.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/psqt.h
+++ b/src/psqt.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/search.c
+++ b/src/search.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/search.h
+++ b/src/search.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/syzygy.h
+++ b/src/syzygy.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/tests.c
+++ b/src/tests.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/tests.h
+++ b/src/tests.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/threads.c
+++ b/src/threads.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/threads.h
+++ b/src/threads.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/time.c
+++ b/src/time.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/time.h
+++ b/src/time.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/types.h
+++ b/src/types.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/uci.c
+++ b/src/uci.c
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by

--- a/src/uci.h
+++ b/src/uci.h
@@ -1,6 +1,6 @@
 /*
   Weiss is a UCI compliant chess engine.
-  Copyright (C) 2020  Terje Kirstihagen
+  Copyright (C) 2022 Terje Kirstihagen
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Mistakenly used the temporary pawn bitboard that is consumed by the evaluation loop when checking for protected past pawns.

Seems to have no impact on playing strength, but still a nice catch:

ELO   | -0.36 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 71600 W: 14796 L: 14870 D: 41934

Closes #559 