### PR TITLE
Fix bug with history scoring

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -481,7 +481,7 @@ skip_search:
         // Remember attempted moves to adjust their history scores
         if (quiet && quietCount < 32)
             quiets[quietCount++] = move;
-        else if (noisyCount < 32)
+        else if (!quiet && noisyCount < 32)
             noisys[noisyCount++] = move;
     }
 


### PR DESCRIPTION
Quiet moves after the 32nd were remembered as noisy moves, wasting time updating scores that were never used, and preventing noisy moves from being remembered.

ELO   | 0.81 +- 1.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 138048 W: 36178 L: 35857 D: 66013