### PR TITLE
Multi Cut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -389,6 +389,8 @@ move_loop:
             // Extend as this move seems forced
             if (score < threshold)
                 extension = 1;
+            else if (threshold >= beta)
+                return threshold;
 
             // Replay ttMove
             MakeMove(pos, move);


### PR DESCRIPTION
If the TT move was shown to beat beta, and a second move was now shown to beat it with a reduced depth search, it is fairly safe to assume some move in this position beats beta also when searched to full depth.

ELO   | 4.79 +- 4.21 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 13360 W: 3516 L: 3332 D: 6512

ELO   | 3.16 +- 3.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 22664 W: 5440 L: 5234 D: 11990