### PR TITLE
Only IIR in pv nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -239,7 +239,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     bool improving = !inCheck && eval > (ss-2)->eval;
 
     // Internal iterative reduction based on Rebel's idea
-    if (depth >= 4 && !ttMove)
+    if (pvNode && depth >= 4 && !ttMove)
         depth -= 2;
 
     // Skip pruning in check, in pv nodes, during early iterations, and when proving singularity

--- a/src/search.c
+++ b/src/search.c
@@ -240,7 +240,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Internal iterative reduction based on Rebel's idea
     if (depth >= 4 && !ttMove)
-        depth--;
+        depth -= 2;
 
     // Skip pruning in check, in pv nodes, during early iterations, and when proving singularity
     if (inCheck || pvNode || !thread->doPruning || ss->excluded)

--- a/src/search.c
+++ b/src/search.c
@@ -240,7 +240,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Internal iterative reduction based on Rebel's idea
     if (pvNode && depth >= 4 && !ttMove)
-        depth -= 2;
+        depth--;
 
     // Skip pruning in check, in pv nodes, during early iterations, and when proving singularity
     if (inCheck || pvNode || !thread->doPruning || ss->excluded)


### PR DESCRIPTION
Reducing by 2 in pv nodes beat master:

ELO   | 3.54 +- 3.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 20512 W: 5533 L: 5324 D: 9655

ELO   | 4.30 +- 3.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14792 W: 3675 L: 3492 D: 7625

And reducing by 1 beat that (yellow LTC):

ELO   | 1.67 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 99584 W: 26941 L: 26462 D: 46181

ELO   | 0.25 +- 2.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 55384 W: 13450 L: 13410 D: 28524