### PR TITLE
New history bonus formula

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -32,7 +32,7 @@
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus) {
-    *cur += 32 * bonus - *cur * abs(bonus) / 512;
+    *cur += bonus - *cur * abs(bonus) / 16384;
 }
 
 // Updates various history heuristics when a move causes a beta cutoff
@@ -49,7 +49,7 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
         ss->killers[0] = bestMove;
     }
 
-    int bonus = depth * depth;
+    int bonus = MIN(2100, 350 * depth - 350);
 
     // Bonus to the move that caused the beta cutoff
     if (depth > 2) {
@@ -69,7 +69,7 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
 // Updates various history heuristics when a move causes a beta cutoff
 INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth, Move quiets[], int qCount, Move noisys[], int nCount) {
 
-    int bonus = depth * depth;
+    int bonus = MIN(2100, 350 * depth - 350);
 
     // Update quiet history if bestMove is quiet
     if (moveIsQuiet(bestMove))


### PR DESCRIPTION
Give more bonus at low depth, and limit the maximum bonus given.

ELO   | 23.19 +- 10.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.05 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 2296 W: 701 L: 548 D: 1047

ELO   | 14.72 +- 8.05 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 3448 W: 904 L: 758 D: 1786