### PR TITLE
Tweak NMP condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -255,7 +255,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Null Move Pruning
     if (   depth >= 3
         && eval >= beta
-        && ss->eval >= beta
+        && ss->eval >= beta + MAX(0, 120 - 20 * depth)
         && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 


### PR DESCRIPTION
Require static eval to be higher at low depths in order to attempt null move pruning.

ELO   | 3.44 +- 3.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 21736 W: 5912 L: 5697 D: 10127

ELO   | 4.41 +- 3.95 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14168 W: 3483 L: 3303 D: 7382