### PR TITLE
Simplify NMP condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -255,7 +255,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Null Move Pruning
     if (   depth >= 3
         && eval >= beta
-        && ss->eval >= beta + MAX(0, 120 - 20 * depth)
+        && ss->eval >= beta + 120 - 20 * depth
         && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 


### PR DESCRIPTION
Try NMP even when static eval is below beta at higher depths as long as the TT score still beats beta.

ELO   | 4.21 +- 3.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 16112 W: 4413 L: 4218 D: 7481

ELO   | 0.92 +- 3.61 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 17288 W: 4223 L: 4177 D: 8888