### PR TITLE
No NMP if previous move has good hist score

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -256,7 +256,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (   depth >= 3
         && eval >= beta
         && ss->eval >= beta + 120 - 20 * depth
-        && (ss-1)->histScore < 25000
+        && (ss-1)->histScore < 15000
         && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 

--- a/src/search.c
+++ b/src/search.c
@@ -256,7 +256,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (   depth >= 3
         && eval >= beta
         && ss->eval >= beta + 120 - 20 * depth
-        && (ss-1)->histScore < 15000
+        && (ss-1)->histScore < 35000
         && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 

--- a/src/search.c
+++ b/src/search.c
@@ -256,6 +256,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (   depth >= 3
         && eval >= beta
         && ss->eval >= beta + 120 - 20 * depth
+        && (ss-1)->histScore < 25000
         && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
@@ -331,7 +332,7 @@ move_loop:
 
         bool quiet = moveIsQuiet(move);
 
-        int histScore = GetHistory(thread, move);
+        ss->histScore = GetHistory(thread, move);
 
         // Misc pruning
         if (  !root
@@ -351,7 +352,7 @@ move_loop:
             }
 
             // History pruning
-            if (lmrDepth < 3 && histScore < -1024 * depth)
+            if (lmrDepth < 3 && ss->histScore < -1024 * depth)
                 continue;
 
             // SEE pruning
@@ -430,7 +431,7 @@ move_loop:
             // Reduce more for the side that last null moved
             r += sideToMove == thread->nullMover;
             // Adjust reduction by move history
-            r -= histScore / 8192;
+            r -= ss->histScore / 8192;
             // Reduce quiets more if ttMove is a capture
             r += quiet && moveIsCapture(ttMove);
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -31,6 +31,7 @@
 
 typedef struct {
     int eval;
+    int histScore;
     Depth ply;
     Move excluded;
     Move killers[2];


### PR DESCRIPTION
If the opponent's previous move's history is good, it's unlikely we can pass our turn and still be winning.

Probably matters more at LTC because higher depths are reached, where the condition on static eval is loosened a lot.

(STC 25000, LTC 35000)

ELO   | 2.74 +- 2.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 31072 W: 8385 L: 8140 D: 14547

ELO   | 9.31 +- 6.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 5784 W: 1494 L: 1339 D: 2951