### PR TITLE
Tweak NMP static eval condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -255,7 +255,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Null Move Pruning
     if (   depth >= 3
         && eval >= beta
-        && ss->eval >= beta + 120 - 20 * depth
+        && ss->eval >= beta + 120 - 15 * depth
         && (ss-1)->histScore < 35000
         && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {


### PR DESCRIPTION
ELO   | 1.55 +- 2.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.92 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 40816 W: 11016 L: 10834 D: 18966

ELO   | 3.27 +- 3.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 21784 W: 5333 L: 5128 D: 11323