### PR TITLE
Square rule for passed pawns

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -331,9 +331,15 @@ INLINE int EvalPassedPawns(const Position *pos, const EvalInfo *ei, const Color 
         Square sq = PopLsb(&passers);
         Square forward = sq + up;
         int rank = RelativeRank(color, RankOf(sq));
+        int file = FileOf(sq);
         int r = rank - RANK_4;
 
         if (rank < RANK_4) continue;
+
+        Square promoSq = RelativeSquare(color, MakeSquare(RANK_8, file));
+        if (Distance(sq, promoSq) < Distance(kingSq(!color), promoSq) - ((!color) == sideToMove)) {
+            eval += S(0, 150);
+        }
 
         count = Distance(forward, kingSq( color));
         eval += count * PassedDistUs[r];

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -81,6 +81,7 @@ const int PassedDistUs[4] = {
 };
 const int PassedDistThem = S( -3, 19);
 const int PassedRookBack = S( 11, 23);
+const int PassedSquare   = S(  0,150);
 
 // Pawn phalanx
 const int PawnPhalanx[RANK_NB] = {
@@ -338,7 +339,8 @@ INLINE int EvalPassedPawns(const Position *pos, const EvalInfo *ei, const Color 
 
         Square promoSq = RelativeSquare(color, MakeSquare(RANK_8, file));
         if (pos->nonPawnCount[!color] == 0 && Distance(sq, promoSq) < Distance(kingSq(!color), promoSq) - ((!color) == sideToMove)) {
-            eval += S(0, 150);
+            eval += PassedSquare;
+            TraceIncr(PassedSquare);
         }
 
         count = Distance(forward, kingSq( color));

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -337,7 +337,7 @@ INLINE int EvalPassedPawns(const Position *pos, const EvalInfo *ei, const Color 
         if (rank < RANK_4) continue;
 
         Square promoSq = RelativeSquare(color, MakeSquare(RANK_8, file));
-        if (Distance(sq, promoSq) < Distance(kingSq(!color), promoSq) - ((!color) == sideToMove)) {
+        if (pos->nonPawnCount[!color] == 0 && Distance(sq, promoSq) < Distance(kingSq(!color), promoSq) - ((!color) == sideToMove)) {
             eval += S(0, 150);
         }
 

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -61,6 +61,7 @@ extern const int PassedBlocked[4];
 extern const int PassedDistUs[4];
 extern const int PassedDistThem;
 extern const int PassedRookBack;
+extern const int PassedSquare;
 
 // Pawn phalanx
 extern const int PawnPhalanx[RANK_NB];
@@ -179,6 +180,7 @@ void InitBaseParams(TVector tparams) {
     InitBaseArray(PassedDistUs, 4);
     InitBaseSingle(PassedDistThem);
     InitBaseSingle(PassedRookBack);
+    InitBaseSingle(PassedSquare);
 
     // Pawn phalanx
     InitBaseArray(PawnPhalanx, RANK_NB);
@@ -242,6 +244,7 @@ void PrintParameters(TVector updates, TVector base) {
     PrintArray(PassedDistUs, 4);
     PrintSingle(PassedDistThem, "");
     PrintSingle(PassedRookBack, "");
+    PrintSingle(PassedSquare, "  ");
 
     puts("\n// Pawn phalanx");
     PrintArray(PawnPhalanx, RANK_NB);
@@ -300,6 +303,7 @@ void InitCoefficients(TCoeffs coeffs) {
     InitCoeffArray(PassedDistUs, 4);
     InitCoeffSingle(PassedDistThem);
     InitCoeffSingle(PassedRookBack);
+    InitCoeffSingle(PassedSquare);
 
     // Pawn phalanx
     InitCoeffArray(PawnPhalanx, RANK_NB);

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -39,17 +39,17 @@
 #define TraceDanger(d) T.danger[color] = d
 
 
-// #define DATASET      "../../Datasets/Andrew/BIG.book"
-// #define NPOSITIONS   ( 42484641) // Total FENS in the book
+#define DATASET      "../../Datasets/Andrew/BIG.book"
+#define NPOSITIONS   ( 42484641) // Total FENS in the book
 
 // #define DATASET      "../../Datasets/lichess-big3-resolved.book"
 // #define NPOSITIONS   ( 7153652) // Total FENS in the book
 
-#define DATASET      "../../Datasets/Andrew/COMBO.book"
-#define NPOSITIONS   (14669229) // Total FENS in the book
+// #define DATASET      "../../Datasets/Andrew/COMBO.book"
+// #define NPOSITIONS   (14669229) // Total FENS in the book
 
 
-#define NTERMS       (     528) // Number of terms being tuned
+#define NTERMS       (     529) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -89,6 +89,7 @@ typedef struct EvalTrace {
     int PassedDistUs[RANK_NB][COLOR_NB];
     int PassedDistThem[COLOR_NB];
     int PassedRookBack[COLOR_NB];
+    int PassedSquare[COLOR_NB];
     int PawnPhalanx[RANK_NB][COLOR_NB];
     int KingLineDanger[28][COLOR_NB];
     int Mobility[4][28][COLOR_NB];


### PR DESCRIPTION
Use the square rule when only pawns are left to help determine if passed pawns are queening.

ELO   | 5.28 +- 4.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 11856 W: 3261 L: 3081 D: 5514

ELO   | 3.63 +- 3.48 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 18752 W: 4695 L: 4499 D: 9558