### PR TITLE
Use the null move eval trick in QS as well

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -343,7 +343,7 @@ INLINE int EvalPassedPawns(const Position *pos, const EvalInfo *ei, const Color 
             TraceIncr(PassedSquare);
         }
 
-        count = Distance(forward, kingSq( color));
+        count = Distance(forward, kingSq(color));
         eval += count * PassedDistUs[r];
         TraceCount(PassedDistUs[r]);
 
@@ -468,8 +468,8 @@ int EvalPosition(const Position *pos, PawnCache pc) {
     TraceScale(scale);
 
     // Adjust score by phase
-    eval =  (MgScore(eval) * pos->phase
-          +  EgScore(eval) * (MidGame - pos->phase) * scale / 128)
+    eval = (  MgScore(eval) * pos->phase
+            + EgScore(eval) * (MidGame - pos->phase) * scale / 128)
           / MidGame;
 
     // Return the evaluation, negated if we are black

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -60,14 +60,13 @@ static void SortMoves(MoveList *list, int threshold) {
 static void ScoreMoves(MovePicker *mp, const int stage) {
 
     const Thread *thread = mp->thread;
-    const Position *pos = &thread->pos;
     MoveList *list = &mp->list;
 
     for (int i = list->next; i < list->count; ++i) {
         Move move = list->moves[i].move;
         list->moves[i].score =
             stage == GEN_QUIET ? GetQuietHistory(thread, move)
-                               : GetCaptureHistory(thread, move) + PieceValue[MG][pieceOn(toSq(move))];
+                               : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
     SortMoves(list, -1000 * mp->depth);


### PR DESCRIPTION
Null move pruning can reduce the depth down to a quiescence search, so the trick can be used here too to save some time.

Also a few code cleanups and switch to using info encoded directly in the move rather than looking up on the board.

ELO   | 2.36 +- 2.46 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 41008 W: 11135 L: 10856 D: 19017