### PR TITLE
RFP only when no TT move or TT move has good history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -250,7 +250,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval - 175 * depth / (1 + improving) >= beta
-        && (!ttHit || GetHistory(thread, ttMove) > 0)
+        && (!ttMove || GetHistory(thread, ttMove) > 0)
         && abs(beta) < TBWIN_IN_MAX)
         return eval;
 

--- a/src/search.c
+++ b/src/search.c
@@ -250,6 +250,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval - 175 * depth / (1 + improving) >= beta
+        && (!ttHit || GetHistory(thread, ttMove) > 0)
         && abs(beta) < TBWIN_IN_MAX)
         return eval;
 

--- a/src/search.c
+++ b/src/search.c
@@ -250,7 +250,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval - 175 * depth / (1 + improving) >= beta
-        && (!ttMove || GetHistory(thread, ttMove) > 0)
+        && (!ttMove || GetHistory(thread, ttMove) > 10000)
         && abs(beta) < TBWIN_IN_MAX)
         return eval;
 


### PR DESCRIPTION
ELO   | 3.52 +- 3.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 20728 W: 5621 L: 5411 D: 9696

ELO   | 2.60 +- 2.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 31568 W: 7785 L: 7549 D: 16234