### PR TITLE
Ensure depth 1 finishes

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -59,7 +59,8 @@ void InitTimeManagement() {
 
 // Check time situation
 bool OutOfTime(Thread *thread) {
-    if (   thread->index != 0
+    if (    thread->index != 0
+        ||  thread->depth == 1
         || (thread->pos.nodes & 2047) != 2047)
         return false;
 


### PR DESCRIPTION
When allowing double extensions, sometimes depth 1 will not finish before time is checked, and at very short time controls this can lead to aborting the search without having decided on a move to play. This change ensures depth 1 finished so there is a move chosen.