### PR TITLE
Tweak SEE pruning

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -374,7 +374,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, -50 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -50 * depth : -90 * depth))
                 continue;
         }
 


### PR DESCRIPTION
ELO   | 2.55 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 36208 W: 9924 L: 9658 D: 16626

ELO   | 2.45 +- 2.53 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 35760 W: 8994 L: 8742 D: 18024