### PR TITLE
Cleanup

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -423,7 +423,7 @@ bool PositionOk(const Position *pos) {
         assert(nonPawnCount[c] == pos->nonPawnCount[c]);
     }
 
-    assert(pieceBB(ALL) == colorBB(WHITE) | colorBB(BLACK));
+    assert(pieceBB(ALL) == (colorBB(WHITE) | colorBB(BLACK)));
 
     assert(sideToMove == WHITE || sideToMove == BLACK);
 

--- a/src/move.h
+++ b/src/move.h
@@ -59,13 +59,13 @@
 #define promotion(move) (((move) & MOVE_PROMO) >> 20)
 
 // Move types
-#define moveIsEnPas(move)   (move & FLAG_ENPAS)
-#define moveIsPStart(move)  (move & FLAG_PAWNSTART)
-#define moveIsCastle(move)  (move & FLAG_CASTLE)
-#define moveIsSpecial(move) (move & (MOVE_FLAGS | MOVE_PROMO))
-#define moveIsCapture(move) (move & MOVE_CAPT)
-#define moveIsNoisy(move)   (move & (MOVE_CAPT | MOVE_PROMO | FLAG_ENPAS))
-#define moveIsQuiet(move)   (!moveIsNoisy(move))
+#define moveIsEnPas(move)   ((bool)(move & FLAG_ENPAS))
+#define moveIsPStart(move)  ((bool)(move & FLAG_PAWNSTART))
+#define moveIsCastle(move)  ((bool)(move & FLAG_CASTLE))
+#define moveIsSpecial(move) ((bool)(move & (MOVE_FLAGS | MOVE_PROMO)))
+#define moveIsCapture(move) ((bool)(move & MOVE_CAPT))
+#define moveIsNoisy(move)   ((bool)(move & (MOVE_CAPT | MOVE_PROMO | FLAG_ENPAS)))
+#define moveIsQuiet(move)   ((bool)(!moveIsNoisy(move)))
 
 
 // Checks legality of a specific castle move given the current position

--- a/src/search.c
+++ b/src/search.c
@@ -212,7 +212,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
         // Give a history bonus to quiet tt moves that causes a cutoff
         if (ttScore >= beta && moveIsQuiet(ttMove))
-            HistoryBonus(QuietEntry(ttMove), Bonus(depth));
+            QuietHistoryUpdate(ttMove, Bonus(depth));
 
         return ttScore;
     }

--- a/src/search.c
+++ b/src/search.c
@@ -285,7 +285,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         thread->nullMover = sideToMove;
 
         MakeNullMove(pos);
-        int score = -AlphaBeta(thread, ss+1, -beta, -beta+1, nullDepth);
+        int score = -AlphaBeta(thread, ss+1, -beta, -alpha, nullDepth);
         TakeNullMove(pos);
 
         thread->nullMover = nullMoverTemp;


### PR DESCRIPTION
TT cut history update now uses same new 8k divisor as the other quiet hist updates.

Otherwise no functional change.