### PR TITLE
Allow continuation history for null moves

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -60,15 +60,15 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, int bon
     // Bonus to the move that caused the beta cutoff
     if (depth > 2) {
         QuietHistoryUpdate(bestMove, bonus);
-        if (prevMove1) ContHistoryUpdate(prevMove1, bestMove, bonus);
-        if (prevMove2) ContHistoryUpdate(prevMove2, bestMove, bonus);
+        ContHistoryUpdate(prevMove1, bestMove, bonus);
+        ContHistoryUpdate(prevMove2, bestMove, bonus);
     }
 
     // Penalize quiet moves that failed to produce a cut
     for (Move *move = quiets; move < quiets + qCount; ++move) {
         QuietHistoryUpdate(*move, -bonus);
-        if (prevMove1) ContHistoryUpdate(prevMove1, *move, -bonus);
-        if (prevMove2) ContHistoryUpdate(prevMove2, *move, -bonus);
+        ContHistoryUpdate(prevMove1, *move, -bonus);
+        ContHistoryUpdate(prevMove2, *move, -bonus);
     }
 }
 
@@ -97,8 +97,8 @@ INLINE int GetQuietHistory(const Thread *thread, Move move) {
     Move prevMove1 = pos->histPly >= 1 ? history(-1).move : NOMOVE;
     Move prevMove2 = pos->histPly >= 2 ? history(-2).move : NOMOVE;
 
-    int cmh = prevMove1 ? *ContEntry(prevMove1, move) : 0;
-    int fmh = prevMove2 ? *ContEntry(prevMove2, move) : 0;
+    int cmh = *ContEntry(prevMove1, move);
+    int fmh = *ContEntry(prevMove2, move);
 
     return *QuietEntry(move) + cmh + fmh;
 }


### PR DESCRIPTION
Also moves at root/ply 1.

Stopped STC at 70k games, LTC passed simplification and failed gainer bounds.

ELO   | 1.17 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 71624 W: 19233 L: 18991 D: 33400

ELO   | 4.00 +- 4.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 9296 W: 2356 L: 2249 D: 4691