### PR TITLE
Add follow-up move history for 2 moves back

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -88,7 +88,6 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
-
     return  *QuietEntry(move)
           + *ContEntry(1, move)
           + *ContEntry(2, move)

--- a/src/history.h
+++ b/src/history.h
@@ -59,6 +59,7 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, int bon
         QuietHistoryUpdate(bestMove, bonus);
         ContHistoryUpdate(1, bestMove, bonus);
         ContHistoryUpdate(2, bestMove, bonus);
+        ContHistoryUpdate(4, bestMove, bonus);
     }
 
     // Penalize quiet moves that failed to produce a cut
@@ -66,6 +67,7 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, int bon
         QuietHistoryUpdate(*move, -bonus);
         ContHistoryUpdate(1, *move, -bonus);
         ContHistoryUpdate(2, *move, -bonus);
+        ContHistoryUpdate(4, *move, -bonus);
     }
 }
 
@@ -93,8 +95,9 @@ INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
 
     int cmh = *ContEntry(1, move);
     int fmh = *ContEntry(2, move);
+    int amh = *ContEntry(4, move);
 
-    return *QuietEntry(move) + cmh + fmh;
+    return *QuietEntry(move) + cmh + fmh + amh;
 }
 
 INLINE int GetCaptureHistory(const Thread *thread, Move move) {

--- a/src/history.h
+++ b/src/history.h
@@ -26,7 +26,7 @@
 #include "types.h"
 
 
-#define QuietEntry(move)        (&thread->history[sideToMove][fromSq(move)][toSq(move)])
+#define QuietEntry(move)        (&thread->history[thread->pos.stm][fromSq(move)][toSq(move)])
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
@@ -45,8 +45,6 @@ INLINE int Bonus(Depth depth) {
 
 // Updates various history heuristics when a move causes a beta cutoff
 INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, int bonus, Depth depth, Move quiets[], int qCount) {
-
-    const Position *pos = &thread->pos;
 
     // Update killers
     if (ss->killers[0] != bestMove) {
@@ -91,13 +89,10 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
 
-    const Position *pos = &thread->pos;
-
-    int cmh = *ContEntry(1, move);
-    int fmh = *ContEntry(2, move);
-    int amh = *ContEntry(4, move);
-
-    return *QuietEntry(move) + cmh + fmh + amh;
+    return  *QuietEntry(move)
+          + *ContEntry(1, move)
+          + *ContEntry(2, move)
+          + *ContEntry(4, move);
 }
 
 INLINE int GetCaptureHistory(const Thread *thread, Move move) {

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -65,7 +65,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
     for (int i = list->next; i < list->count; ++i) {
         Move move = list->moves[i].move;
         list->moves[i].score =
-            stage == GEN_QUIET ? GetQuietHistory(thread, move)
+            stage == GEN_QUIET ? GetQuietHistory(thread, mp->ss, move)
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
@@ -147,9 +147,10 @@ Move NextMove(MovePicker *mp) {
 }
 
 // Init normal movepicker
-void InitNormalMP(MovePicker *mp, Thread *thread, Depth depth, Move ttMove, Move kill1, Move kill2) {
+void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move kill1, Move kill2) {
     mp->list.count = mp->list.next = 0;
     mp->thread    = thread;
+    mp->ss        = ss;
     mp->ttMove    = ttMove;
     mp->stage     = ttMove ? TTMOVE : GEN_NOISY;
     mp->depth     = depth;
@@ -160,7 +161,7 @@ void InitNormalMP(MovePicker *mp, Thread *thread, Depth depth, Move ttMove, Move
 }
 
 // Init noisy movepicker
-void InitNoisyMP(MovePicker *mp, Thread *thread) {
-    InitNormalMP(mp, thread, 0, NOMOVE, NOMOVE, NOMOVE);
+void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss) {
+    InitNormalMP(mp, thread, ss, 0, NOMOVE, NOMOVE, NOMOVE);
     mp->onlyNoisy = true;
 }

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -27,6 +27,7 @@ typedef enum MPStage {
 
 typedef struct MovePicker {
     Thread *thread;
+    Stack *ss;
     MoveList list;
     MPStage stage;
     Depth depth;
@@ -37,5 +38,5 @@ typedef struct MovePicker {
 
 
 Move NextMove(MovePicker *mp);
-void InitNormalMP(MovePicker *mp, Thread *thread, Depth depth, Move ttMove, Move kill1, Move kill2);
-void InitNoisyMP(MovePicker *mp, Thread *thread);
+void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move kill1, Move kill2);
+void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss);

--- a/src/threads.c
+++ b/src/threads.c
@@ -121,6 +121,8 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
         t->rootMoveCount = rootMoveCount;
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
+        for (Depth d = -2; d < 0; ++d)
+            (t->ss+SS_OFFSET+d)->continuation = &t->continuation[EMPTY][0];
     }
 }
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -121,7 +121,7 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
         t->rootMoveCount = rootMoveCount;
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
-        for (Depth d = -2; d < 0; ++d)
+        for (Depth d = -4; d < 0; ++d)
             (t->ss+SS_OFFSET+d)->continuation = &t->continuation[EMPTY][0];
     }
 }

--- a/src/threads.h
+++ b/src/threads.h
@@ -29,7 +29,13 @@
 #define MULTI_PV_MAX 64
 
 
+typedef int16_t ButterflyHistory[COLOR_NB][64][64];
+typedef int16_t CaptureToHistory[PIECE_NB][64][TYPE_NB];
+typedef int16_t PieceToHistory[PIECE_NB][64];
+
+
 typedef struct {
+    PieceToHistory *continuation;
     int eval;
     int histScore;
     Depth ply;
@@ -60,9 +66,9 @@ typedef struct Thread {
     // Anything below here is not zeroed out between searches
     Position pos;
     PawnCache pawnCache;
-    int16_t history[COLOR_NB][64][64];
-    int16_t captureHistory[PIECE_NB][64][TYPE_NB];
-    int16_t continuation[PIECE_NB][64][PIECE_NB][64];
+    ButterflyHistory history;
+    CaptureToHistory captureHistory;
+    PieceToHistory continuation[PIECE_NB][64];
 
     int index;
     int count;

--- a/src/threads.h
+++ b/src/threads.h
@@ -32,6 +32,7 @@
 typedef int16_t ButterflyHistory[COLOR_NB][64][64];
 typedef int16_t CaptureToHistory[PIECE_NB][64][TYPE_NB];
 typedef int16_t PieceToHistory[PIECE_NB][64];
+typedef PieceToHistory ContinuationHistory[PIECE_NB][64];
 
 
 typedef struct {
@@ -68,7 +69,7 @@ typedef struct Thread {
     PawnCache pawnCache;
     ButterflyHistory history;
     CaptureToHistory captureHistory;
-    PieceToHistory continuation[PIECE_NB][64];
+    ContinuationHistory continuation;
 
     int index;
     int count;


### PR DESCRIPTION
Also use search stack to hold points to continuation history to avoid a lot of ifs when looking it up. The rewrite easily passed simplification bounds, and adding fmh 2 moves back easily passed STC vs the rewrite and LTC vs master.

ELO   | 6.13 +- 5.03 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9864 W: 2751 L: 2577 D: 4536

ELO   | 14.45 +- 8.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 3512 W: 927 L: 781 D: 1804