### PR TITLE
Doubled pawns also with some distance

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -54,6 +54,7 @@ const int Tempo = 15;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);
+const int PawnDoubled2 = S(-10,-25);
 const int PawnIsolated = S( -8,-16);
 const int PawnSupport  = S( 22, 17);
 const int PawnThreat   = S( 80, 34);
@@ -149,9 +150,14 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard pawnAttacks = PawnBBAttackBB(pawns, color);
 
     // Doubled pawns (only when one is blocking the other from moving)
-    count = PopCount(pawns & (ShiftBB(pawns, NORTH) | ShiftBB(pawns, 2 * NORTH)));
+    count = PopCount(pawns & (ShiftBB(pawns, NORTH)));
     eval += PawnDoubled * count;
     TraceCount(PawnDoubled);
+
+    // Doubled pawns (only when one is blocking the other from moving)
+    count = PopCount(pawns & (ShiftBB(pawns, 2 * NORTH)));
+    eval += PawnDoubled2 * count;
+    TraceCount(PawnDoubled2);
 
     // Pawns defending pawns
     count = PopCount(pawns & PawnBBAttackBB(pawns, !color));

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -149,12 +149,12 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard pawns = colorPieceBB(color, PAWN);
     Bitboard pawnAttacks = PawnBBAttackBB(pawns, color);
 
-    // Doubled pawns (only when one is blocking the other from moving)
+    // Doubled pawns (one directly in front of the other)
     count = PopCount(pawns & ShiftBB(pawns, NORTH));
     eval += PawnDoubled * count;
     TraceCount(PawnDoubled);
 
-    // Doubled pawns (only when one is blocking the other from moving)
+    // Doubled pawns (one square between them)
     count = PopCount(pawns & ShiftBB(pawns, 2 * NORTH));
     eval += PawnDoubled2 * count;
     TraceCount(PawnDoubled2);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -149,7 +149,7 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard pawnAttacks = PawnBBAttackBB(pawns, color);
 
     // Doubled pawns (only when one is blocking the other from moving)
-    count = PopCount(pawns & ShiftBB(pawns, NORTH));
+    count = PopCount(pawns & (ShiftBB(pawns, NORTH) | ShiftBB(pawns, 2 * NORTH)));
     eval += PawnDoubled * count;
     TraceCount(PawnDoubled);
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -150,12 +150,12 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard pawnAttacks = PawnBBAttackBB(pawns, color);
 
     // Doubled pawns (only when one is blocking the other from moving)
-    count = PopCount(pawns & (ShiftBB(pawns, NORTH)));
+    count = PopCount(pawns & ShiftBB(pawns, NORTH));
     eval += PawnDoubled * count;
     TraceCount(PawnDoubled);
 
     // Doubled pawns (only when one is blocking the other from moving)
-    count = PopCount(pawns & (ShiftBB(pawns, 2 * NORTH)));
+    count = PopCount(pawns & ShiftBB(pawns, 2 * NORTH));
     eval += PawnDoubled2 * count;
     TraceCount(PawnDoubled2);
 

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -43,6 +43,7 @@ extern const int PieceSqValue[6][64];
 
 // Misc
 extern const int PawnDoubled;
+extern const int PawnDoubled2;
 extern const int PawnIsolated;
 extern const int PawnSupport;
 extern const int PawnThreat;
@@ -167,6 +168,7 @@ void InitBaseParams(TVector tparams) {
 
     // Misc
     InitBaseSingle(PawnDoubled);
+    InitBaseSingle(PawnDoubled2);
     InitBaseSingle(PawnIsolated);
     InitBaseSingle(PawnSupport);
     InitBaseSingle(PawnThreat);
@@ -236,6 +238,7 @@ void PrintParameters(TVector updates, TVector base) {
 
     puts("\n// Misc bonuses and maluses");
     PrintSingle(PawnDoubled, " ");
+    PrintSingle(PawnDoubled2, "");
     PrintSingle(PawnIsolated, "");
     PrintSingle(PawnSupport, " ");
     PrintSingle(PawnThreat, "  ");
@@ -300,6 +303,7 @@ void InitCoefficients(TCoeffs coeffs) {
 
     // Misc
     InitCoeffSingle(PawnDoubled);
+    InitCoeffSingle(PawnDoubled2);
     InitCoeffSingle(PawnIsolated);
     InitCoeffSingle(PawnSupport);
     InitCoeffSingle(PawnThreat);

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -49,7 +49,7 @@
 // #define NPOSITIONS   (14669229) // Total FENS in the book
 
 
-#define NTERMS       (     549) // Number of terms being tuned
+#define NTERMS       (     550) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -72,6 +72,7 @@ typedef struct EvalTrace {
     int PSQT[6][64][COLOR_NB];
 
     int PawnDoubled[COLOR_NB];
+    int PawnDoubled2[COLOR_NB];
     int PawnIsolated[COLOR_NB];
     int PawnSupport[COLOR_NB];
     int PawnThreat[COLOR_NB];


### PR DESCRIPTION
Used to only penalize doubled pawns when directly in front of each other, this adds a penalty also when there is one square between them.

ELO   | 3.62 +- 3.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 19968 W: 5480 L: 5272 D: 9216

ELO   | 1.62 +- 1.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 92200 W: 22500 L: 22071 D: 47629