### PR TITLE
Store checkmated and stalemated positions in TT

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -517,9 +517,9 @@ skip_search:
 
     // Checkmate or stalemate
     if (!moveCount)
-        return ss->excluded ? alpha
-             : inCheck      ? -MATE + ss->ply
-                            : 0;
+        bestScore =  ss->excluded ? alpha
+                   : inCheck      ? -MATE + ss->ply
+                                  : 0;
 
     // Make sure score isn't above the max score given by TBs
     bestScore = MIN(bestScore, maxScore);


### PR DESCRIPTION
ELO   | 0.57 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 80536 W: 21708 L: 21575 D: 37253

ELO   | 2.04 +- 2.12 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 50160 W: 12344 L: 12049 D: 25767