### PR TITLE
Implement buckets and aging for TT

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -381,7 +381,7 @@ move_loop:
                 continue;
         }
 
-        __builtin_prefetch(GetTTBucket(KeyAfter(pos, move)));
+        TTPrefetch(KeyAfter(pos, move));
 
         // Make the move, skipping to the next if illegal
         if (!MakeMove(pos, move)) continue;

--- a/src/search.c
+++ b/src/search.c
@@ -661,7 +661,7 @@ void *SearchPosition(void *pos) {
     SEARCH_STOPPED = false;
 
     InitTimeManagement();
-    AgeTT();
+    TTNewSearch();
     PrepareSearch(pos, Limits.searchmoves);
     bool threadsSpawned = false;
 

--- a/src/search.c
+++ b/src/search.c
@@ -381,7 +381,7 @@ move_loop:
                 continue;
         }
 
-        __builtin_prefetch(GetEntry(KeyAfter(pos, move)));
+        __builtin_prefetch(GetTTBucket(KeyAfter(pos, move)));
 
         // Make the move, skipping to the next if illegal
         if (!MakeMove(pos, move)) continue;

--- a/src/search.c
+++ b/src/search.c
@@ -198,7 +198,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     Move ttMove = ttHit ? tte->move : NOMOVE;
     int ttScore = ttHit ? ScoreFromTT(tte->score, ss->ply) : NOSCORE;
     Depth ttDepth = tte->depth;
-    int ttBound = tte->bound;
+    int ttBound = tte->bound & 0x3;
 
     if (ttMove && !MoveIsPseudoLegal(pos, ttMove))
         ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;

--- a/src/search.c
+++ b/src/search.c
@@ -198,7 +198,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     Move ttMove = ttHit ? tte->move : NOMOVE;
     int ttScore = ttHit ? ScoreFromTT(tte->score, ss->ply) : NOSCORE;
     Depth ttDepth = tte->depth;
-    int ttBound = tte->bound & 0x3;
+    int ttBound = tte->ageBound & TT_BOUND_MASK;
 
     if (ttMove && !MoveIsPseudoLegal(pos, ttMove))
         ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;

--- a/src/search.c
+++ b/src/search.c
@@ -198,7 +198,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     Move ttMove = ttHit ? tte->move : NOMOVE;
     int ttScore = ttHit ? ScoreFromTT(tte->score, ss->ply) : NOSCORE;
     Depth ttDepth = tte->depth;
-    int ttBound = tte->ageBound & TT_BOUND_MASK;
+    int ttBound = Bound(tte);
 
     if (ttMove && !MoveIsPseudoLegal(pos, ttMove))
         ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;

--- a/src/search.c
+++ b/src/search.c
@@ -661,6 +661,7 @@ void *SearchPosition(void *pos) {
     SEARCH_STOPPED = false;
 
     InitTimeManagement();
+    AgeTT();
     PrepareSearch(pos, Limits.searchmoves);
     bool threadsSpawned = false;
 

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -35,18 +35,18 @@ TranspositionTable TT = { .requestedMB = DEFAULTHASH };
 // Probe the transposition table
 TTEntry* ProbeTT(const Key key, bool *ttHit) {
 
-    TTEntry* tte = GetTTBucket(key)->entries;
+    TTEntry* first = GetTTBucket(key)->entries;
 
-    for (int i = 0; i < BUCKETSIZE; ++i)
-        if (tte[i].key == key) {
-            tte[i].genBound = TT.generation | Bound(&tte[i]);
-            return *ttHit = true, &tte[i];
+    for (TTEntry *entry = first; entry < first + BUCKETSIZE; ++entry)
+        if (entry->key == key) {
+            entry->genBound = TT.generation | Bound(entry);
+            return *ttHit = true, entry;
         }
 
-    TTEntry *replace = tte;
-    for (int i = 1; i < BUCKETSIZE; ++i)
-        if (EntryValue(replace) > EntryValue(&tte[i]))
-            replace = &tte[i];
+    TTEntry *replace = first;
+    for (TTEntry *entry = first + 1; entry < first + BUCKETSIZE; ++entry)
+        if (EntryValue(replace) > EntryValue(entry))
+            replace = entry;
 
     return *ttHit = false, replace;
 }

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -38,9 +38,9 @@ TTEntry* ProbeTT(const Key key, bool *ttHit) {
     TTEntry* first = GetTTBucket(key)->entries;
 
     for (TTEntry *entry = first; entry < first + BUCKETSIZE; ++entry)
-        if (entry->key == key) {
+        if (entry->key == key || !Bound(entry)) {
             entry->genBound = TT.generation | Bound(entry);
-            return *ttHit = true, entry;
+            return *ttHit = Bound(entry), entry;
         }
 
     TTEntry *replace = first;

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -108,8 +108,9 @@ INLINE void RequestTTSize(int megabytes) {
     puts("info string Hash will resize after next 'isready'.");
 }
 
-INLINE void AgeTT() {
+INLINE void TTNewSearch() {
     TT.generation += TT_GEN_DELTA;
+    TT.dirty = true;
 }
 
 TTEntry* ProbeTT(Key key, bool *ttHit);

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -32,23 +32,28 @@
 
 #define BUCKETSIZE 2
 
-static const unsigned GENERATION_BITS  = 3;                                // nb of bits reserved for other things
-static const int      GENERATION_DELTA = (1 << GENERATION_BITS);           // increment for generation field
-static const int      GENERATION_CYCLE = 255 + (1 << GENERATION_BITS);     // cycle length
-static const int      GENERATION_MASK  = (0xFF << GENERATION_BITS) & 0xFF; // mask to pull out generation number
-
 #define ValidBound(bound) (bound >= BOUND_UPPER && bound <= BOUND_EXACT)
 #define ValidScore(score) (score >= -MATE && score <= MATE)
 
 
 enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 
+// Constants used for operating on the combined bound + age field
+enum {
+    TT_BOUND_BITS = 2,                              // Number of bits representing bound
+    TT_BOUND_MASK = (1 << TT_BOUND_BITS) - 1,       // Mask to pull out bound
+    TT_AGE_OFFSET = TT_BOUND_BITS,                  // Number of bits reserved for other things
+    TT_AGE_DELTA  = 1 << TT_AGE_OFFSET,             // Increment for age each turn
+    TT_AGE_CYCLE  = 255 + (1 << TT_AGE_OFFSET),     // Cycle length
+    TT_AGE_MASK   = (0xFF << TT_AGE_OFFSET) & 0xFF, // Mask to pull out generation number
+};
+
 typedef struct {
     Key key;
     Move move;
     int16_t score;
     uint8_t depth;
-    uint8_t bound;
+    uint8_t ageBound;
 } TTEntry;
 
 typedef struct {
@@ -94,7 +99,7 @@ INLINE void RequestTTSize(int megabytes) {
 }
 
 INLINE void AgeTT() {
-    TT.age += GENERATION_DELTA;
+    TT.age += TT_AGE_DELTA;
 }
 
 TTEntry* ProbeTT(Key key, bool *ttHit);

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -42,7 +42,7 @@ enum { BOUND_NONE, BOUND_UPPER, BOUND_LOWER, BOUND_EXACT };
 enum {
     TT_BOUND_BITS = 2,                              // Number of bits representing bound
     TT_BOUND_MASK = (1 << TT_BOUND_BITS) - 1,       // Mask to pull out bound
-    TT_GEN_OFFSET = TT_BOUND_BITS + 1,                  // Number of bits reserved for other things
+    TT_GEN_OFFSET = TT_BOUND_BITS + 1,              // Number of bits reserved for other things
     TT_GEN_DELTA  = 1 << TT_GEN_OFFSET,             // Increment for generation each turn
     TT_GEN_CYCLE  = 255 + (1 << TT_GEN_OFFSET),     // Cycle length
     TT_GEN_MASK   = (0xFF << TT_GEN_OFFSET) & 0xFF, // Mask to pull out generation number

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -99,6 +99,10 @@ INLINE TTBucket *GetTTBucket(Key key) {
     return &TT.table[((uint32_t)key * (uint64_t)TT.count) >> 32];
 }
 
+INLINE void TTPrefetch(Key key) {
+    __builtin_prefetch(GetTTBucket(key));
+}
+
 INLINE void RequestTTSize(int megabytes) {
     TT.requestedMB = megabytes;
     puts("info string Hash will resize after next 'isready'.");

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -30,6 +30,8 @@
 #define MAXHASH 65536
 #define DEFAULTHASH 32
 
+#define BUCKETSIZE 2
+
 #define ValidBound(bound) (bound >= BOUND_UPPER && bound <= BOUND_EXACT)
 #define ValidScore(score) (score >= -MATE && score <= MATE)
 
@@ -45,8 +47,12 @@ typedef struct {
 } TTEntry;
 
 typedef struct {
+    TTEntry entries[2];
+} TTBucket;
+
+typedef struct {
     void *mem;
-    TTEntry *table;
+    TTBucket *table;
     uint64_t count;
     uint64_t currentMB;
     uint64_t requestedMB;
@@ -71,7 +77,7 @@ INLINE int ScoreFromTT (const int score, const uint8_t ply) {
                                   : score;
 }
 
-INLINE TTEntry *GetEntry(Key key) {
+INLINE TTBucket *GetTTBucket(Key key) {
     // https://lemire.me/blog/2016/06/27/a-fast-alternative-to-the-modulo-reduction/
     return &TT.table[((uint32_t)key * (uint64_t)TT.count) >> 32];
 }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -93,6 +93,10 @@ INLINE void RequestTTSize(int megabytes) {
     puts("info string Hash will resize after next 'isready'.");
 }
 
+INLINE void AgeTT() {
+    TT.age += GENERATION_DELTA;
+}
+
 TTEntry* ProbeTT(Key key, bool *ttHit);
 void StoreTTEntry(TTEntry *tte, Key key, Move move, int score, Depth depth, int bound);
 int HashFull();

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -32,6 +32,11 @@
 
 #define BUCKETSIZE 2
 
+static const unsigned GENERATION_BITS  = 3;                                // nb of bits reserved for other things
+static const int      GENERATION_DELTA = (1 << GENERATION_BITS);           // increment for generation field
+static const int      GENERATION_CYCLE = 255 + (1 << GENERATION_BITS);     // cycle length
+static const int      GENERATION_MASK  = (0xFF << GENERATION_BITS) & 0xFF; // mask to pull out generation number
+
 #define ValidBound(bound) (bound >= BOUND_UPPER && bound <= BOUND_EXACT)
 #define ValidScore(score) (score >= -MATE && score <= MATE)
 
@@ -56,6 +61,7 @@ typedef struct {
     uint64_t count;
     uint64_t currentMB;
     uint64_t requestedMB;
+    uint8_t age;
     bool dirty;
 } TranspositionTable;
 

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -78,7 +78,7 @@ INLINE uint8_t      Bound(TTEntry *entry) { return entry->genBound & TT_BOUND_MA
 INLINE uint8_t Generation(TTEntry *entry) { return entry->genBound & TT_GEN_MASK; }
 INLINE uint8_t        Age(TTEntry *entry) { return (TT_GEN_CYCLE + TT.generation - entry->genBound) & TT_GEN_MASK; }
 
-INLINE uint8_t EntryValue(TTEntry *entry) { return entry->depth - Age(entry); }
+INLINE int EntryValue(TTEntry *entry) { return entry->depth - Age(entry); }
 
 // Mate scores are stored as mate in 0 as they depend on the current ply
 INLINE int ScoreToTT (const int score, const uint8_t ply) {

--- a/src/uci.c
+++ b/src/uci.c
@@ -66,7 +66,6 @@ static void ParseTimeControl(const char *str, const Position *pos) {
 INLINE void Go(Position *pos, char *str) {
     ABORT_SIGNAL = false;
     InitTT();
-    TT.dirty = true;
     ParseTimeControl(str, pos);
     StartMainThread(SearchPosition, pos);
 }


### PR DESCRIPTION
Bucket size 2, age and bound stored together as a uint8_t. Improves strength when TT is small (in context of the time control). Otherwise seems to be a wash.

Tests with smaller than normal TT size (for Weiss).

ELO   | 6.54 +- 5.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9136 W: 2550 L: 2378 D: 4208

ELO   | 2.23 +- 2.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 41720 W: 10255 L: 9987 D: 21478