### PR TITLE
Change TT probing when proving singularity

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -194,7 +194,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Probe transposition table
     bool ttHit;
-    Key key = pos->key ^ (((Key)ss->excluded) << 32);
+    Key key = pos->key;
     TTEntry *tte = ProbeTT(key, &ttHit);
 
     Move ttMove = ttHit ? tte->move : NOMOVE;
@@ -202,7 +202,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     Depth ttDepth = tte->depth;
     int ttBound = Bound(tte);
 
-    if (ttMove && !MoveIsPseudoLegal(pos, ttMove))
+    if (ttMove && (!MoveIsPseudoLegal(pos, ttMove) || ttMove == ss->excluded))
         ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;
 
     // Trust TT if not a pvnode and the entry depth is sufficiently high


### PR DESCRIPTION
Should be more or less the same, but there's some chance a different thread overwrites the entry for the same position with a different move, in which case using it and the other info is relevant.