### PR TITLE
LMR more when few pieces are left

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -467,6 +467,8 @@ move_loop:
             // Reduce quiets more if ttMove is a capture
             r += quiet && moveIsCapture(ttMove);
 
+            r += pos->nonPawnCount[sideToMove] < 2;
+
             // Depth after reductions, avoiding going straight to quiescence as well as extending
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);
 


### PR DESCRIPTION
ELO   | 2.88 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 28760 W: 7770 L: 7532 D: 13458

ELO   | 4.82 +- 4.19 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 12696 W: 3149 L: 2973 D: 6574