### PR TITLE
Pyrrhic fixes

### DIFF
--- a/src/pyrrhic/tbprobe.c
+++ b/src/pyrrhic/tbprobe.c
@@ -201,7 +201,7 @@ static void *map_file(FD fd, map_t *mapping)
   *mapping = statbuf.st_size;
   void *data = mmap(NULL, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
 #if defined(MADV_RANDOM)
-  madvise(*data, statbuf.st_size, MADV_RANDOM);
+  madvise(data, statbuf.st_size, MADV_RANDOM);
 #endif
   if (data == MAP_FAILED) {
     perror("mmap");

--- a/src/pyrrhic/tbprobe.c
+++ b/src/pyrrhic/tbprobe.c
@@ -201,7 +201,7 @@ static void *map_file(FD fd, map_t *mapping)
   *mapping = statbuf.st_size;
   void *data = mmap(NULL, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
 #if defined(MADV_RANDOM)
-  madvise(*baseAddress, statbuf.st_size, MADV_RANDOM);
+  madvise(*data, statbuf.st_size, MADV_RANDOM);
 #endif
   if (data == MAP_FAILED) {
     perror("mmap");


### PR DESCRIPTION
Fix mapping offset for wide DTZ tables.
Advice that the memory access pattern for TBs is random.