### PR TITLE
Adjust RFP margin by previous moves history score

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -272,6 +272,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Reverse Futility Pruning
     if (   depth < 7
+        && eval >= beta
         && eval - 175 * depth / (1 + improving) - (ss-1)->histScore / 400 >= beta
         && (!ttMove || GetHistory(thread, ss, ttMove) > 10000))
         return eval;

--- a/src/search.c
+++ b/src/search.c
@@ -272,7 +272,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Reverse Futility Pruning
     if (   depth < 7
-        && eval - 175 * depth / (1 + improving) >= beta
+        && eval - 175 * depth / (1 + improving) - (ss-1)->histScore / 400 >= beta
         && (!ttMove || GetHistory(thread, ss, ttMove) > 10000))
         return eval;
 


### PR DESCRIPTION
ELO   | 4.52 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14376 W: 3856 L: 3669 D: 6851

ELO   | 4.78 +- 4.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 12856 W: 3235 L: 3058 D: 6563