### PR TITLE
Remove depth condition for NMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -278,8 +278,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         return eval;
 
     // Null Move Pruning
-    if (   depth >= 3
-        && eval >= beta
+    if (   eval >= beta
         && ss->eval >= beta + 120 - 15 * depth
         && (ss-1)->histScore < 35000
         && history(-1).move != NOMOVE


### PR DESCRIPTION
Simplification.

ELO   | 0.15 +- 2.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 37104 W: 9839 L: 9823 D: 17442

ELO   | 0.18 +- 2.45 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 37224 W: 9003 L: 8984 D: 19237