### PR TITLE
Use + instead of %20 in queries so the url is more humanly readable

### DIFF
--- a/src/query/query.c
+++ b/src/query/query.c
@@ -60,12 +60,8 @@ char *Query(char *hostname, char *msg_fmt, const Position *pos) {
 
     // Replace spaces with %20
     char *ptr;
-    while ((ptr = strchr(message + 4, ' ')) != NULL) {
-        memmove(ptr + 2, ptr, strlen(ptr));
-        *ptr++ = '%';
-        *ptr++ = '2';
-        *ptr   = '0';
-    }
+    while ((ptr = strchr(message + 4, ' ')) != NULL)
+        *ptr = '+';
 
     printf("info string Query: %s", message);
 


### PR DESCRIPTION
%20 is technically the correct replacement for spaces, but + is supported by both lichess and dbcn so, for now at least, it doesn't matter.