### PR TITLE
Save QSearch results to TT

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -127,6 +127,7 @@ moveloop:
     if (!inCheck) InitNoisyMP(&mp, thread, ss); else InitNormalMP(&mp, thread, ss, 0, NOMOVE, NOMOVE, NOMOVE);
 
     // Move loop
+    Move bestMove = NOMOVE;
     Move move;
     while ((move = NextMove(&mp))) {
 
@@ -166,6 +167,7 @@ search:
             // If score beats alpha we update alpha
             if (score > alpha) {
                 alpha = score;
+                bestMove = move;
 
                 // If score beats beta we have a cutoff
                 if (score >= beta)
@@ -177,6 +179,9 @@ search:
     // Checkmate
     if (inCheck && bestScore == -INFINITE)
         return -MATE + ss->ply;
+
+    StoreTTEntry(tte, key, bestMove, ScoreToTT(bestScore, ss->ply), 0,
+                 bestScore >= beta ? BOUND_LOWER : BOUND_UPPER);
 
     return bestScore;
 }


### PR DESCRIPTION
ELO   | 5.41 +- 4.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 11504 W: 3158 L: 2979 D: 5367

ELO   | 6.89 +- 5.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 8168 W: 2034 L: 1872 D: 4262