### PR TITLE
Play TT move in QSearch

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -161,7 +161,7 @@ void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move t
 }
 
 // Init noisy movepicker
-void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss) {
-    InitNormalMP(mp, thread, ss, 0, NOMOVE, NOMOVE, NOMOVE);
+void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss, Move ttMove) {
+    InitNormalMP(mp, thread, ss, 0, ttMove, NOMOVE, NOMOVE);
     mp->onlyNoisy = true;
 }

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -39,4 +39,4 @@ typedef struct MovePicker {
 
 Move NextMove(MovePicker *mp);
 void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move kill1, Move kill2);
-void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss);
+void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss, Move ttMove);

--- a/src/search.c
+++ b/src/search.c
@@ -124,7 +124,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
 
 moveloop:
 
-    if (!inCheck) InitNoisyMP(&mp, thread, ss); else InitNormalMP(&mp, thread, ss, 0, NOMOVE, NOMOVE, NOMOVE);
+    if (!inCheck) InitNoisyMP(&mp, thread, ss, ttMove); else InitNormalMP(&mp, thread, ss, 0, ttMove, NOMOVE, NOMOVE);
 
     // Move loop
     Move bestMove = NOMOVE;
@@ -338,7 +338,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
              && ttBound & BOUND_UPPER
              && ttScore < probCutBeta)) {
 
-        InitNoisyMP(&mp, thread, ss);
+        InitNoisyMP(&mp, thread, ss, NOMOVE);
 
         Move move;
         while ((move = NextMove(&mp))) {


### PR DESCRIPTION
ELO   | 2.63 +- 2.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 33152 W: 8845 L: 8594 D: 15713

ELO   | 3.01 +- 3.01 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 24552 W: 6025 L: 5812 D: 12715