### PR TITLE
better repetition scores

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -165,9 +165,14 @@ INLINE void SqToStr(Square sq, char *str) {
     str[1] = '1' + RankOf(sq);
 }
 
-INLINE bool IsRepetition(const Position *pos) {
+INLINE bool IsRepetition(const Position *pos, int count) {
+    int c = 0;
     for (int i = 4; i <= pos->rule50 && i <= pos->histPly; i += 2)
+    {
         if (pos->key == history(-i).key)
+            c++;
+        if (c == count)
             return true;
+    }
     return false;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -79,7 +79,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     int bestScore = -INFINITE;
 
     // Position is drawn
-    if (IsRepetition(pos) || pos->rule50 >= 100)
+    if (IsRepetition(pos, 1 + pvNode) || pos->rule50 >= 100)
         return 8 - (pos->nodes & 0x7);
 
     // Probe transposition table
@@ -204,7 +204,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (!root) {
 
         // Position is drawn
-        if (IsRepetition(pos) || pos->rule50 >= 100)
+        if (IsRepetition(pos, 1 + pvNode) || pos->rule50 >= 100)
             return 8 - (pos->nodes & 0x7);
 
         // Max depth reached


### PR DESCRIPTION
https://tcec-chess.com/#game=2&round=fl&season=cup11 in the tcec game between stockfish and leela weiss often reports 0.0 as the score because it sees a repetition in 1 and thinks the game can be drawn while it actually cant be, this patch increases the required repetition for pvnodes to 2. You might want to test this on OB for non regression though...


Bench: 17776946

also while testing this i encountered this
```
position fen k4q2/5r2/Pp1p1r2/1PpPp1b1/4P1P1/2R2PB1/6Rp/5Q1K b - - 65 179
go
info depth 1 seldepth 6 multipv 1 score cp 37 time 0 nodes 44 nps 44000 tbhits 0 hashfull 0 pv f6f3
info depth 2 seldepth 6 multipv 1 score cp 37 time 3 nodes 87 nps 21750 tbhits 0 hashfull 0 pv f6f3 c3f3
info depth 3 seldepth 6 multipv 1 score cp 37 time 7 nodes 137 nps 17125 tbhits 0 hashfull 0 pv f6f3 c3f3 f7f3
info depth 4 seldepth 6 multipv 1 score cp 1595 time 10 nodes 201 nps 18272 tbhits 0 hashfull 0 pv f6f3 c3f3 f7f3 h1h2
info depth 5 seldepth 8 multipv 1 score cp 1595 time 14 nodes 287 nps 19133 tbhits 0 hashfull 0 pv f6f3 c3f3 f7f3 h1h2 f3f1
info depth 6 seldepth 9 multipv 1 score cp 1663 time 18 nodes 545 nps 28684 tbhits 0 hashfull 0 pv f6f3 c3c2 f3f1 h1h2 f1b1 c2b2
info depth 7 seldepth 11 multipv 1 score cp -111 time 22 nodes 1497 nps 65086 tbhits 0 hashfull 0 pv f6f3 c3f3 f7f3 g2f2 f3f2 g3f2 c5c4
info depth 8 seldepth 10 multipv 1 score cp -117 time 27 nodes 1799 nps 64250 tbhits 0 hashfull 0 pv f6f3 c3f3 f7f3 g2f2 f3f2 g3f2 g5f4 f2h4
info depth 9 seldepth 14 multipv 1 score cp -228 time 32 nodes 4254 nps 128909 tbhits 0 hashfull 0 pv f6f3 c3f3 f7f3 g2f2 f3f2 f1f2 f8f2 g3f2 c5c4
```

the score jump to 1600 looks very weird.. just blundering the queen away, i know its very low depth but even there this shouldnt really happen i guess?
