### PR TITLE
Reduce depth for cut nodes with no TT move

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -292,6 +292,9 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (pvNode && depth >= 4 && !ttMove)
         depth--;
 
+    if (cutnode && depth >= 7 && !ttMove)
+        depth--;
+
     // Skip pruning in check, in pv nodes, during early iterations, when proving singularity, or when looking for terminal scores
     if (inCheck || pvNode || !thread->doPruning || ss->excluded || abs(beta) >= TBWIN_IN_MAX)
         goto move_loop;


### PR DESCRIPTION
ELO   | 4.75 +- 4.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 13456 W: 3612 L: 3428 D: 6416

ELO   | 6.20 +- 4.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9240 W: 2329 L: 2164 D: 4747