### PR TITLE
Separate continuation history for positions in check and not

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -153,7 +153,7 @@ moveloop:
 
 search:
 
-        ss->continuation = &thread->continuation[moveIsCapture(move)][piece(move)][toSq(move)];
+        ss->continuation = &thread->continuation[inCheck][moveIsCapture(move)][piece(move)][toSq(move)];
 
         // Recursively search the positions after making the moves, skipping illegal ones
         if (!MakeMove(pos, move)) continue;
@@ -316,7 +316,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         Color nullMoverTemp = thread->nullMover;
         thread->nullMover = sideToMove;
 
-        ss->continuation = &thread->continuation[0][EMPTY][0];
+        ss->continuation = &thread->continuation[0][0][EMPTY][0];
 
         MakeNullMove(pos);
         int score = -AlphaBeta(thread, ss+1, -beta, -alpha, nullDepth, !cutnode);
@@ -347,7 +347,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             if (!MakeMove(pos, move)) continue;
 
-            ss->continuation = &thread->continuation[moveIsCapture(move)][piece(move)][toSq(move)];
+            ss->continuation = &thread->continuation[inCheck][moveIsCapture(move)][piece(move)][toSq(move)];
 
             // See if a quiescence search beats the threshold
             int score = -Quiescence(thread, ss+1, -probCutBeta, -probCutBeta+1);
@@ -469,7 +469,7 @@ move_loop:
             goto skip_search;
         }
 
-        ss->continuation = &thread->continuation[moveIsCapture(move)][piece(move)][toSq(move)];
+        ss->continuation = &thread->continuation[inCheck][moveIsCapture(move)][piece(move)][toSq(move)];
 
         const Depth newDepth = depth - 1 + extension;
 

--- a/src/threads.c
+++ b/src/threads.c
@@ -122,7 +122,7 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
         for (Depth d = -4; d < 0; ++d)
-            (t->ss+SS_OFFSET+d)->continuation = &t->continuation[0][EMPTY][0];
+            (t->ss+SS_OFFSET+d)->continuation = &t->continuation[0][0][EMPTY][0];
     }
 }
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -69,7 +69,7 @@ typedef struct Thread {
     PawnCache pawnCache;
     ButterflyHistory history;
     CaptureToHistory captureHistory;
-    ContinuationHistory continuation[2];
+    ContinuationHistory continuation[2][2];
 
     int index;
     int count;


### PR DESCRIPTION
ELO   | 2.95 +- 2.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 25056 W: 6077 L: 5864 D: 13115