### PR TITLE
Simplify away LMP of noisy moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -398,10 +398,6 @@ move_loop:
 
             Depth lmrDepth = depth - Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
 
-            // Late move pruning
-            if (moveCount > (3 + 2 * depth * depth) / (2 - improving))
-                break;
-
             // Quiet late move pruning
             if (quiet && moveCount > (1 + depth * depth) / (2 - improving)) {
                 mp.onlyNoisy = true;


### PR DESCRIPTION
Simplification bounds:

ELO   | 6.18 +- 5.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 6520 W: 1630 L: 1514 D: 3376