### PR TITLE
Increase input buffer to 8192 bytes

### DIFF
--- a/src/uci.h
+++ b/src/uci.h
@@ -26,7 +26,7 @@
 #define NAME "Weiss 2.1-dev"
 
 #define START_FEN "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-#define INPUT_SIZE 4096
+#define INPUT_SIZE 8192
 
 
 enum InputCommands {


### PR DESCRIPTION
Weiss crashes when a game gets to about 800 moves and the position command with all the moves exceeds 4096 bytes. Now crashes around 1600 moves instead which I think is theoretically reachable but so unlikely I won't bother with until it happens once.