### PR TITLE
Tweak LMP

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -399,7 +399,7 @@ move_loop:
             Depth lmrDepth = depth - Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
 
             // Quiet late move pruning
-            if (moveCount > (1 + depth * depth) / (2 - improving))
+            if (moveCount > (0 + depth * depth) / (2 - improving))
                 mp.onlyNoisy = true;
 
             // History pruning

--- a/src/search.c
+++ b/src/search.c
@@ -399,7 +399,7 @@ move_loop:
             Depth lmrDepth = depth - Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
 
             // Quiet late move pruning
-            if (moveCount > (0 + depth * depth) / (2 - improving))
+            if (moveCount > (improving ? depth * depth : depth * depth / 2))
                 mp.onlyNoisy = true;
 
             // History pruning

--- a/src/search.c
+++ b/src/search.c
@@ -399,10 +399,8 @@ move_loop:
             Depth lmrDepth = depth - Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
 
             // Quiet late move pruning
-            if (quiet && moveCount > (1 + depth * depth) / (2 - improving)) {
+            if (moveCount > (1 + depth * depth) / (2 - improving))
                 mp.onlyNoisy = true;
-                continue;
-            }
 
             // History pruning
             if (lmrDepth < 3 && ss->histScore < -1024 * depth)


### PR DESCRIPTION
Also minor speedup.

ELO   | 2.93 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 27488 W: 7244 L: 7012 D: 13232

ELO   | 5.39 +- 4.49 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 11032 W: 2738 L: 2567 D: 5727