### PR TITLE
No NMP if static eval is below beta

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -308,6 +308,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // Null Move Pruning
     if (   eval >= beta
+        && eval >= ss->eval
         && ss->eval >= beta + 120 - 15 * depth
         && (ss-1)->histScore < 35000
         && history(-1).move != NOMOVE


### PR DESCRIPTION
ELO   | 2.51 +- 4.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 13152 W: 3487 L: 3392 D: 6273

ELO   | 1.15 +- 3.26 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 20872 W: 5055 L: 4986 D: 10831