### PR TITLE
Avoid generating non-blocking quiet moves when in check

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -128,7 +128,8 @@ INLINE void GenPieceType(const Position *pos, MoveList *list, const Color color,
 
     const Bitboard occupied = pieceBB(ALL);
     const Bitboard enemies  = pos->checkers && pt != KING ? pos->checkers : colorBB(!color);
-    const Bitboard targets  = type == QUIET ? ~occupied : enemies;
+    const Bitboard open     = pos->checkers && pt != KING ? BetweenBB[kingSq(color)][Lsb(pos->checkers)] : ~occupied;
+    const Bitboard targets  = type == QUIET ? open : enemies;
 
     Bitboard pieces = colorPieceBB(color, pt);
 

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -128,8 +128,8 @@ INLINE void GenPieceType(const Position *pos, MoveList *list, const Color color,
 
     const Bitboard occupied = pieceBB(ALL);
     const Bitboard enemies  = pos->checkers && pt != KING ? pos->checkers : colorBB(!color);
-    const Bitboard open     = pos->checkers && pt != KING ? BetweenBB[kingSq(color)][Lsb(pos->checkers)] : ~occupied;
-    const Bitboard targets  = type == QUIET ? open : enemies;
+    const Bitboard empty    = pos->checkers && pt != KING ? BetweenBB[kingSq(color)][Lsb(pos->checkers)] : ~occupied;
+    const Bitboard targets  = type == QUIET ? empty : enemies;
 
     Bitboard pieces = colorPieceBB(color, pt);
 


### PR DESCRIPTION
ELO   | 12.17 +- 7.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 4400 W: 1219 L: 1065 D: 2116