### PR TITLE
Prefetch TT entries in QS too

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -152,6 +152,7 @@ moveloop:
         }
 
 search:
+        TTPrefetch(KeyAfter(pos, move));
 
         ss->continuation = &thread->continuation[inCheck][moveIsCapture(move)][piece(move)][toSq(move)];
 


### PR DESCRIPTION
ELO   | 2.97 +- 2.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 26912 W: 7095 L: 6865 D: 12952