### PR TITLE
Singular Extension at lower depths

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -423,7 +423,7 @@ move_loop:
         Depth extension = 0;
 
         // Singular extension
-        if (   depth > 8
+        if (   depth > 6
             && move == ttMove
             && !ss->excluded
             && ttDepth > depth - 3


### PR DESCRIPTION
ELO   | 11.48 +- 7.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 4784 W: 1382 L: 1224 D: 2178

ELO   | 3.23 +- 3.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 22072 W: 5405 L: 5200 D: 11467