### PR TITLE
Singular extension at yet lower depths

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -425,7 +425,7 @@ move_loop:
         // Avoid extending too far
         if (ss->ply < thread->depth * 2) {
             // Singular extension
-            if (   depth > 6
+            if (   depth > 4
                 && move == ttMove
                 && !ss->excluded
                 && ttDepth > depth - 3


### PR DESCRIPTION
ELO   | 2.25 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 43760 W: 11463 L: 11180 D: 21117

ELO   | 2.36 +- 2.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 36816 W: 8882 L: 8632 D: 19302