### PR TITLE
Skip pruning directly after a null move

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -297,7 +297,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         depth--;
 
     // Skip pruning in check, in pv nodes, during early iterations, when proving singularity, or when looking for terminal scores
-    if (inCheck || pvNode || !thread->doPruning || ss->excluded || abs(beta) >= TBWIN_IN_MAX)
+    if (inCheck || pvNode || !thread->doPruning || ss->excluded || abs(beta) >= TBWIN_IN_MAX || history(-1).move == NOMOVE)
         goto move_loop;
 
     // Reverse Futility Pruning
@@ -312,7 +312,6 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         && eval >= ss->eval
         && ss->eval >= beta + 120 - 15 * depth
         && (ss-1)->histScore < 35000
-        && history(-1).move != NOMOVE
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
         Depth nullDepth = depth - (3 + depth / 5 + MIN(3, (eval - beta) / 256));

--- a/src/search.c
+++ b/src/search.c
@@ -296,7 +296,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (cutnode && depth >= 7 && !ttMove)
         depth--;
 
-    // Skip pruning in check, in pv nodes, during early iterations, when proving singularity, or when looking for terminal scores
+    // Skip pruning in check, pv nodes, early iterations, when proving singularity, looking for terminal scores, or after a null move
     if (inCheck || pvNode || !thread->doPruning || ss->excluded || abs(beta) >= TBWIN_IN_MAX || history(-1).move == NOMOVE)
         goto move_loop;
 


### PR DESCRIPTION
Passed STC, failed LTC as a gainer, but I like it and it would pass non-regression.

ELO   | 2.28 +- 2.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 43512 W: 11489 L: 11204 D: 20819

ELO   | -0.56 +- 2.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | -2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 28656 W: 6729 L: 6775 D: 15152