### PR TITLE
Penalize having pawns on the same color as own bishop

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -66,6 +66,7 @@ const int KingAtkPawn  = S(-16, 45);
 const int OpenForward  = S( 28, 31);
 const int SemiForward  = S( 17, 15);
 const int NBBehindPawn = S(  9, 32);
+const int BishopBadP   = S( -1, -5);
 
 // Passed pawn
 const int PawnPassed[RANK_NB] = {
@@ -283,6 +284,16 @@ INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const
 
         ei->attackedBy[color][pt] |= attackBB;
         ei->attackedBy[color][ALL] |= attackBB;
+
+        if (pt == BISHOP) {
+            Bitboard bishopSquares   = (BB(sq) & BlackSquaresBB) ? BlackSquaresBB : ~BlackSquaresBB;
+            Bitboard badPawns        = colorPieceBB(color, PAWN) & bishopSquares;
+            Bitboard blockedBadPawns = ShiftBB(pieceBB(ALL), down) & colorPieceBB(color, PAWN) & ~(FILE_A | FILE_B | FILE_G | FILE_H);
+
+            int count = PopCount(badPawns) * PopCount(blockedBadPawns);
+            eval += count * BishopBadP;
+            TraceCount(BishopBadP);
+        }
 
         // Forward mobility for rooks
         if (pt == ROOK) {

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -54,6 +54,7 @@ extern const int KingAtkPawn;
 extern const int OpenForward;
 extern const int SemiForward;
 extern const int NBBehindPawn;
+extern const int BishopBadP;
 
 // Passed pawn
 extern const int PawnPassed[RANK_NB];
@@ -179,6 +180,7 @@ static void InitBaseParams(TVector tparams) {
     InitBaseSingle(OpenForward);
     InitBaseSingle(SemiForward);
     InitBaseSingle(NBBehindPawn);
+    InitBaseSingle(BishopBadP);
 
     // Passed pawns
     InitBaseArray(PawnPassed, RANK_NB);
@@ -249,6 +251,7 @@ static void PrintParameters(TVector updates, TVector base) {
     PrintSingle(OpenForward, " ");
     PrintSingle(SemiForward, " ");
     PrintSingle(NBBehindPawn, "");
+    PrintSingle(BishopBadP, "  ");
 
     puts("\n// Passed pawn");
     PrintArray(PawnPassed, RANK_NB);
@@ -314,6 +317,7 @@ static void InitCoefficients(TCoeffs coeffs) {
     InitCoeffSingle(OpenForward);
     InitCoeffSingle(SemiForward);
     InitCoeffSingle(NBBehindPawn);
+    InitCoeffSingle(BishopBadP);
 
     // Passed pawns
     InitCoeffArray(PawnPassed, RANK_NB);

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -49,11 +49,11 @@
 // #define NPOSITIONS   (14669229) // Total FENS in the book
 
 
-#define NTERMS       (     550) // Number of terms being tuned
+#define NTERMS       (     551) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
-#define LRRATE       (    0.01) // Learning rate
+#define LRRATE       (    0.1) // Learning rate
 #define LRDROPRATE   (    1.00) // Cut LR by this each LR-step
 #define LRSTEPRATE   (     250) // Cut LR after this many epochs
 #define BETA_1       (     0.9) // ADAM Momemtum Coefficient
@@ -83,6 +83,7 @@ typedef struct EvalTrace {
     int OpenForward[COLOR_NB];
     int SemiForward[COLOR_NB];
     int NBBehindPawn[COLOR_NB];
+    int BishopBadP[COLOR_NB];
 
     int PawnPassed[RANK_NB][COLOR_NB];
     int PassedDefended[RANK_NB][COLOR_NB];


### PR DESCRIPTION
ELO   | 1.70 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 90992 W: 24283 L: 23838 D: 42871

ELO   | 3.52 +- 3.35 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.01 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 19656 W: 4790 L: 4591 D: 10275