### PR TITLE
Improve github actions

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,5 +21,5 @@ jobs:
     - name: Releases
       run: make release CC=${{ matrix.cc }}
     - name: PGO
-      if: ${{ matrix.cc == "gcc" }}
+      if: ${{ matrix.cc == 'gcc' }}
       run: make pgo CC=${{ matrix.cc }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -7,46 +7,60 @@ defaults:
     working-directory: src
 
 jobs:
-  Compile:
+  # Compile:
 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cc: [gcc, clang]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       cc: [gcc, clang]
 
-    steps:
-    - uses: actions/checkout@v1
+  #   steps:
+  #   - uses: actions/checkout@v1
 
-    - name: Basic
-      run: make CC=${{ matrix.cc }} basic
+  #   - name: Basic
+  #     run: make CC=${{ matrix.cc }} basic
 
-    - name: Dev
-      run: make CC=${{ matrix.cc }} dev
+  #   - name: Dev
+  #     run: make CC=${{ matrix.cc }} dev
 
-    - name: Releases
-      run: make CC=${{ matrix.cc }} release
+  #   - name: Releases
+  #     run: make CC=${{ matrix.cc }} release
 
-    - name: PGO
-      if: matrix.cc == 'gcc'
-      run: make CC=${{ matrix.cc }} pgo
+  #   - name: PGO
+  #     if: matrix.cc == 'gcc'
+  #     run: make CC=${{ matrix.cc }} pgo
 
-  Bench:
+  # Bench:
+
+  #   needs: Compile
+
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       cc: [gcc, clang]
+
+  #   steps:
+  #   - uses: actions/checkout@v1
+
+  #   - name: Compile
+  #     run: make CC=${{ matrix.cc }} basic
+
+  #   - name: Bench
+  #     run: |
+  #       expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
+  #       actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
+  #       if [[ $actual != $expected ]]; then echo "Expected $expected was $actual" && exit 1; fi
+
+  Perft:
 
     # needs: Compile
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cc: [gcc, clang]
 
-    steps:
-    - uses: actions/checkout@v1
+    # -name: Compile
+    #   run: make CC=${{ matrix.cc }} dev
 
-    - name: Compile
-      run: make CC=${{ matrix.cc }} basic
-
-    - name: Bench
+    -name: Perft
       run: |
-        expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
-        actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
-        if [[ $actual != $expected ]]; then echo "Expected $expected was $actual" && exit 1; fi
+        perft=$(wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd)
+        echo $perft

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -9,9 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: test
+    - name: GCC PGO
       run: cd src && make pgo
-    - name: release
+    - name: GCC releases
       run: cd src && make release
-    - name: sanitize
-      run: cd src && make pgo CC=clang
+    - name: Clang basic
+      run: cd src && make basic CC=clang
+    - name: Clang releases
+      run: cd src && make release CC=clang

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -61,7 +61,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Compile
-      run: make CC=${{ matrix.cc }} dev
+      run: make dev
 
     - name: Perft
       run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -20,12 +20,12 @@ jobs:
     - name: Basic
       run: make CC=${{ matrix.cc }} basic
 
-    - name: Releases
-      run: make CC=${{ matrix.cc }} release
+    # - name: Releases
+    #   run: make CC=${{ matrix.cc }} release
 
-    - name: PGO
-      if: matrix.cc == 'gcc'
-      run: make CC=${{ matrix.cc }} pgo
+    # - name: PGO
+    #   if: matrix.cc == 'gcc'
+    #   run: make CC=${{ matrix.cc }} pgo
 
   Bench:
 
@@ -43,4 +43,6 @@ jobs:
       run: make CC=${{ matrix.cc }} basic
 
     - name: Bench
-      run: ./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)'
+      run: expected = $(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
+           actual   = $(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
+           if [[ actual != expected ]]; then echo "Expected $expected was $actual" && exit 1; fi

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -43,4 +43,4 @@ jobs:
       run: make CC=${{ matrix.cc }} basic
 
     - name: Bench
-      run: ./weiss bench
+      run: ./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)'

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - uses: KyleMayes/install-llvm-action@v1
+      with:
+        version: "10.0"
     - name: Basic
       run: make basic CC=${{ matrix.cc }}
     - name: Releases

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -67,4 +67,5 @@ jobs:
       run: |
         wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd | while read p; do
           echo $p
+          ./weiss <<<'perft 6 $p'
         done

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,13 +3,13 @@ name: Make CI
 on: [push]
 
 defaults:
+  runs-on: ubuntu-latest
   run:
     working-directory: src
 
 jobs:
   Compile:
 
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         cc: [gcc, clang]

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,10 +16,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+
     - name: Basic
-      run: make basic CC=${{ matrix.cc }}
+      run: make CC=${{ matrix.cc }} basic
+
     - name: Releases
-      run: make release CC=${{ matrix.cc }}
+      run: make CC=${{ matrix.cc }} release
+
     - name: PGO
-      if: ${{ matrix.cc == 'gcc' }}
-      run: make pgo CC=${{ matrix.cc }}
+      if: matrix.cc == 'gcc'
+      run: make CC=${{ matrix.cc }} pgo

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -60,7 +60,10 @@ jobs:
     # -name: Compile
     #   run: make CC=${{ matrix.cc }} dev
 
-    -name: Perft
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Perft
       run: |
         perft=$(wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd)
         echo $perft

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -66,4 +66,6 @@ jobs:
     - name: Perft
       run: |
         perft=$(wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd)
-        echo $perft
+        perft | while read p; do
+          echo $p
+        done

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -26,3 +26,21 @@ jobs:
     - name: PGO
       if: matrix.cc == 'gcc'
       run: make CC=${{ matrix.cc }} pgo
+
+  Bench:
+
+    needs: Compile
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Compile
+      run: make CC=${{ matrix.cc }} basic
+
+    - name: Bench
+      run: ./weiss bench

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -43,6 +43,6 @@ jobs:
       run: make CC=${{ matrix.cc }} basic
 
     - name: Bench
-      run: expected = $(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
-           actual   = $(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
+      run: expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
+           actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
            if [[ actual != expected ]]; then echo "Expected $expected was $actual" && exit 1; fi

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,12 +16,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "10.0"
     - name: Basic
       run: make basic CC=${{ matrix.cc }}
     - name: Releases
       run: make release CC=${{ matrix.cc }}
     - name: PGO
+      if: ${{ matrix.cc == "gcc" }}
       run: make pgo CC=${{ matrix.cc }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,13 +3,13 @@ name: Make CI
 on: [push]
 
 defaults:
-  runs-on: ubuntu-latest
   run:
     working-directory: src
 
 jobs:
   Compile:
 
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         cc: [gcc, clang]

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -15,7 +15,7 @@ jobs:
         cc: [gcc, clang]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Basic
       run: make CC=${{ matrix.cc }} basic
@@ -40,7 +40,7 @@ jobs:
         cc: [gcc, clang]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Compile
       run: make CC=${{ matrix.cc }} basic

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -46,4 +46,4 @@ jobs:
       run: |
         expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
         actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
-        if [[ actual != expected ]]; then echo "Expected $expected was $actual" && exit 1; fi
+        if [[ $actual != $expected ]]; then echo "Expected $expected was $actual" && exit 1; fi

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -57,11 +57,11 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    # -name: Compile
-    #   run: make CC=${{ matrix.cc }} dev
-
     steps:
     - uses: actions/checkout@v1
+
+    - name: Compile
+      run: make CC=${{ matrix.cc }} dev
 
     - name: Perft
       run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -7,29 +7,29 @@ defaults:
     working-directory: src
 
 jobs:
-  Compile:
+  # Compile:
 
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        cc: [gcc, clang]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       cc: [gcc, clang]
 
-    steps:
-    - uses: actions/checkout@v1
+  #   steps:
+  #   - uses: actions/checkout@v1
 
-    - name: Basic
-      run: make CC=${{ matrix.cc }} basic
+  #   - name: Basic
+  #     run: make CC=${{ matrix.cc }} basic
 
-    # - name: Releases
-    #   run: make CC=${{ matrix.cc }} release
+  #   - name: Releases
+  #     run: make CC=${{ matrix.cc }} release
 
-    # - name: PGO
-    #   if: matrix.cc == 'gcc'
-    #   run: make CC=${{ matrix.cc }} pgo
+  #   - name: PGO
+  #     if: matrix.cc == 'gcc'
+  #     run: make CC=${{ matrix.cc }} pgo
 
   Bench:
 
-    needs: Compile
+    # needs: Compile
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -7,25 +7,28 @@ defaults:
     working-directory: src
 
 jobs:
-  # Compile:
+  Compile:
 
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       cc: [gcc, clang]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc: [gcc, clang]
 
-  #   steps:
-  #   - uses: actions/checkout@v1
+    steps:
+    - uses: actions/checkout@v1
 
-  #   - name: Basic
-  #     run: make CC=${{ matrix.cc }} basic
+    - name: Basic
+      run: make CC=${{ matrix.cc }} basic
 
-  #   - name: Releases
-  #     run: make CC=${{ matrix.cc }} release
+    - name: Dev
+      run: make CC=${{ matrix.cc }} dev
 
-  #   - name: PGO
-  #     if: matrix.cc == 'gcc'
-  #     run: make CC=${{ matrix.cc }} pgo
+    - name: Releases
+      run: make CC=${{ matrix.cc }} release
+
+    - name: PGO
+      if: matrix.cc == 'gcc'
+      run: make CC=${{ matrix.cc }} pgo
 
   Bench:
 

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - uses: KyleMayes/install-llvm-action@v1
     - name: Basic
       run: make basic CC=${{ matrix.cc }}
     - name: Releases

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -43,6 +43,7 @@ jobs:
       run: make CC=${{ matrix.cc }} basic
 
     - name: Bench
-      run: expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
-           actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
-           if [[ actual != expected ]]; then echo "Expected $expected was $actual" && exit 1; fi
+      run: |
+        expected = $(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
+        actual   = $(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
+        if [[ actual != expected ]]; then echo "Expected $expected was $actual" && exit 1; fi

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -2,8 +2,12 @@ name: Make CI
 
 on: [push]
 
+defaults:
+  run:
+    working-directory: src
+
 jobs:
-  compile:
+  Compile:
 
     runs-on: ubuntu-latest
     strategy:
@@ -12,9 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: basic
-      run: cd src && make basic CC=${{ matrix.cc }}
-    - name: releases
-      run: cd src && make release CC=${{ matrix.cc }}
-    - name: GCC PGO
-      run: cd src && make pgo CC=${{ matrix.cc }}
+    - name: Basic
+      run: make basic CC=${{ matrix.cc }}
+    - name: Releases
+      run: make release CC=${{ matrix.cc }}
+    - name: PGO
+      run: make pgo CC=${{ matrix.cc }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -65,7 +65,6 @@ jobs:
 
     - name: Perft
       run: |
-        perft=$(wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd)
-        perft | while read p; do
+        wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd | while read p; do
           echo $p
         done

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -44,6 +44,6 @@ jobs:
 
     - name: Bench
       run: |
-        expected = $(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
-        actual   = $(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
+        expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
+        actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
         if [[ actual != expected ]]; then echo "Expected $expected was $actual" && exit 1; fi

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -7,65 +7,46 @@ defaults:
     working-directory: src
 
 jobs:
-  # Compile:
-
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       cc: [gcc, clang]
-
-  #   steps:
-  #   - uses: actions/checkout@v1
-
-  #   - name: Basic
-  #     run: make CC=${{ matrix.cc }} basic
-
-  #   - name: Dev
-  #     run: make CC=${{ matrix.cc }} dev
-
-  #   - name: Releases
-  #     run: make CC=${{ matrix.cc }} release
-
-  #   - name: PGO
-  #     if: matrix.cc == 'gcc'
-  #     run: make CC=${{ matrix.cc }} pgo
-
-  # Bench:
-
-  #   needs: Compile
-
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       cc: [gcc, clang]
-
-  #   steps:
-  #   - uses: actions/checkout@v1
-
-  #   - name: Compile
-  #     run: make CC=${{ matrix.cc }} basic
-
-  #   - name: Bench
-  #     run: |
-  #       expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
-  #       actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
-  #       if [[ $actual != $expected ]]; then echo "Expected $expected was $actual" && exit 1; fi
-
-  Perft:
-
-    # needs: Compile
+  Compile:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc: [gcc, clang]
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Basic
+      run: make CC=${{ matrix.cc }} basic
+
+    - name: Dev
+      run: make CC=${{ matrix.cc }} dev
+
+    - name: Releases
+      run: make CC=${{ matrix.cc }} release
+
+    - name: PGO
+      if: matrix.cc == 'gcc'
+      run: make CC=${{ matrix.cc }} pgo
+
+  Bench:
+
+    needs: Compile
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc: [gcc, clang]
 
     steps:
     - uses: actions/checkout@v1
 
     - name: Compile
-      run: make dev
+      run: make CC=${{ matrix.cc }} basic
 
-    - name: Perft
+    - name: Bench
       run: |
-        wget -O- https://raw.githubusercontent.com/TerjeKir/EngineTests/master/testfiles/perftsuite.epd | while read p; do
-          echo $p
-          ./weiss <<<'perft 6 $p'
-        done
+        expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
+        actual=$(./weiss bench | tail -n 1 | grep -Po '(?<=[\s]{5})[0-9]+?(?= nodes)')
+        if [[ $actual != $expected ]]; then echo "Expected $expected was $actual" && exit 1; fi

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,17 +3,18 @@ name: Make CI
 on: [push]
 
 jobs:
-  Compile:
+  compile:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc: [gcc, clang]
 
     steps:
     - uses: actions/checkout@v1
+    - name: basic
+      run: cd src && make basic CC=${{ matrix.cc }}
+    - name: releases
+      run: cd src && make release CC=${{ matrix.cc }}
     - name: GCC PGO
-      run: cd src && make pgo
-    - name: GCC releases
-      run: cd src && make release
-    - name: Clang basic
-      run: cd src && make basic CC=clang
-    - name: Clang releases
-      run: cd src && make release CC=clang
+      run: cd src && make pgo CC=${{ matrix.cc }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,7 +3,7 @@ name: Make CI
 on: [push]
 
 jobs:
-  build:
+  Compile:
 
     runs-on: ubuntu-latest
 
@@ -13,3 +13,5 @@ jobs:
       run: cd src && make pgo
     - name: release
       run: cd src && make release
+    - name: sanitize
+      run: cd src && make pgo CC=clang


### PR DESCRIPTION
Tests more compilations and also verifies bench.

Commit messages must now have a bench node count in them. This also makes it easier to create tests on OB.

Bench: 19785851