### PR TITLE
Store static eval in TT

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -186,7 +186,7 @@ search:
     if (inCheck && bestScore == -INFINITE)
         return -MATE + ss->ply;
 
-    StoreTTEntry(tte, key, bestMove, ScoreToTT(bestScore, ss->ply), 0,
+    StoreTTEntry(tte, key, bestMove, ScoreToTT(bestScore, ss->ply), eval, 0,
                  bestScore >= beta ? BOUND_LOWER : BOUND_UPPER);
 
     return bestScore;
@@ -241,11 +241,12 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     Move ttMove = ttHit ? tte->move : NOMOVE;
     int ttScore = ttHit ? ScoreFromTT(tte->score, ss->ply) : NOSCORE;
+    int ttEval = ttHit ? tte->eval : NOSCORE;
     Depth ttDepth = tte->depth;
     int ttBound = Bound(tte);
 
     if (ttMove && (!MoveIsPseudoLegal(pos, ttMove) || ttMove == ss->excluded))
-        ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;
+        ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE, ttEval = NOSCORE;
 
     // Trust TT if not a pvnode and the entry depth is sufficiently high
     if (   !pvNode
@@ -271,7 +272,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
         // Draw scores are exact, while wins are lower bounds and losses upper bounds (mate scores are better/worse)
         if (bound == BOUND_EXACT || (bound == BOUND_LOWER ? tbScore >= beta : tbScore <= alpha)) {
-            StoreTTEntry(tte, pos->key, NOMOVE, ScoreToTT(tbScore, ss->ply), MAX_PLY, bound);
+            StoreTTEntry(tte, pos->key, NOMOVE, ScoreToTT(tbScore, ss->ply), NOSCORE, MAX_PLY, bound);
             return tbScore;
         }
 
@@ -288,9 +289,10 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     const bool inCheck = pos->checkers;
 
     // Do a static evaluation for pruning considerations
-    int eval = ss->eval = inCheck          ? NOSCORE
-                        : lastMoveNullMove ? -(ss-1)->eval + 2 * Tempo
-                                           : EvalPosition(pos, thread->pawnCache);
+    int eval = ss->eval = inCheck           ? NOSCORE
+                        : lastMoveNullMove  ? -(ss-1)->eval + 2 * Tempo
+                        : ttEval != NOSCORE ? ttEval
+                                            : EvalPosition(pos, thread->pawnCache);
 
     // Use ttScore as eval if it is more informative
     if (   ttScore != NOSCORE
@@ -557,7 +559,7 @@ skip_extensions:
 
     // Store in TT
     if (!ss->excluded && (!root || !thread->multiPV))
-        StoreTTEntry(tte, pos->key, bestMove, ScoreToTT(bestScore, ss->ply), depth,
+        StoreTTEntry(tte, pos->key, bestMove, ScoreToTT(bestScore, ss->ply), ss->eval, depth,
                        bestScore >= beta  ? BOUND_LOWER
                      : pvNode && bestMove ? BOUND_EXACT
                                           : BOUND_UPPER);

--- a/src/search.c
+++ b/src/search.c
@@ -93,11 +93,12 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
 
     Move ttMove = ttHit ? tte->move : NOMOVE;
     int ttScore = ttHit ? ScoreFromTT(tte->score, ss->ply) : NOSCORE;
+    int ttEval  = ttHit ? tte->eval : NOSCORE;
     // Depth ttDepth = tte->depth;
     int ttBound = Bound(tte);
 
     if (ttMove && !MoveIsPseudoLegal(pos, ttMove))
-        ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE;
+        ttHit = false, ttMove = NOMOVE, ttScore = NOSCORE, ttEval = NOSCORE;
 
     // Trust TT if not a pvnode
     if (   !pvNode
@@ -107,6 +108,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
 
     // Do a static evaluation for pruning considerations
     eval = history(-1).move == NOMOVE ? -(ss-1)->eval + 2 * Tempo
+         : ttEval != NOSCORE          ? ttEval
                                       : EvalPosition(pos, thread->pawnCache);
 
     // If we are at max depth, return static eval

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -38,7 +38,7 @@ TTEntry* ProbeTT(const Key key, bool *ttHit) {
     TTEntry* first = GetTTBucket(key)->entries;
 
     for (TTEntry *entry = first; entry < first + BUCKET_SIZE; ++entry)
-        if (entry->key == key || !Bound(entry)) {
+        if (entry->key == (int32_t)key || !Bound(entry)) {
             entry->genBound = TT.generation | Bound(entry);
             return *ttHit = Bound(entry), entry;
         }
@@ -55,20 +55,22 @@ TTEntry* ProbeTT(const Key key, bool *ttHit) {
 void StoreTTEntry(TTEntry *tte, const Key key,
                                 const Move move,
                                 const int score,
+                                const int eval,
                                 const Depth depth,
                                 const int bound) {
 
     assert(ValidBound(bound));
     assert(ValidScore(score));
 
-    if (move || key != tte->key)
+    if (move || (int32_t)key != tte->key)
         tte->move = move;
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if (key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT)
+    if ((int32_t)key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT)
         tte->key   = key,
         tte->score = score,
+        tte->eval  = eval,
         tte->depth = depth,
         tte->genBound = TT.generation | bound;
 }

--- a/src/transposition.h
+++ b/src/transposition.h
@@ -47,9 +47,10 @@ enum {
 };
 
 typedef struct {
-    Key key;
+    int32_t key;
     Move move;
     int16_t score;
+    int16_t eval;
     uint8_t depth;
     uint8_t genBound;
 } TTEntry;
@@ -116,7 +117,7 @@ INLINE void TTNewSearch() {
 }
 
 TTEntry* ProbeTT(Key key, bool *ttHit);
-void StoreTTEntry(TTEntry *tte, Key key, Move move, int score, Depth depth, int bound);
+void StoreTTEntry(TTEntry *tte, Key key, Move move, int score, int eval, Depth depth, int bound);
 int HashFull();
 void ClearTT();
 void InitTT();


### PR DESCRIPTION
ELO   | 5.89 +- 4.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 10264 W: 2766 L: 2592 D: 4906

ELO   | 4.28 +- 3.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 14600 W: 3541 L: 3361 D: 7698

Bench: 18855972