### PR TITLE
Singular Extension negative extensions

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -460,6 +460,8 @@ move_loop:
                 extension = 1;
             else if (singularBeta >= beta)
                 return singularBeta;
+            else if (ttScore >= beta)
+                extension = -1;
 
             // Replay ttMove
             MakeMove(pos, move);


### PR DESCRIPTION
Reduce search depth if not singular, not able to multi-cut and ttScore is higher than beta.

ELO   | 2.66 +- 2.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 31912 W: 8333 L: 8089 D: 15490

ELO   | 3.14 +- 3.10 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 22768 W: 5496 L: 5290 D: 11982

Bench: 18662912