### PR TITLE
Double singular extension in non-pv nodes when other moves are much worse

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -456,9 +456,16 @@ move_loop:
             ss->excluded = NOMOVE;
 
             // Extend as this move seems forced
-            if (score < singularBeta)
+            if (score < singularBeta) {
+
                 extension = 1;
-            else if (singularBeta >= beta)
+
+                if (!pvNode
+                    && score < singularBeta - 25
+                    && ss->doubleExtensions <= 5)
+                    extension = 2;
+
+            } else if (singularBeta >= beta)
                 return singularBeta;
             else if (ttScore >= beta)
                 extension = -1;
@@ -469,7 +476,9 @@ move_loop:
 
         // Extend when in check
         if (inCheck)
-            extension = 1;
+            extension = MIN(extension, 1);
+
+        ss->doubleExtensions = (ss-1)->doubleExtensions + (extension == 2);
 
 skip_extensions:
 

--- a/src/search.c
+++ b/src/search.c
@@ -476,7 +476,7 @@ move_loop:
 
         // Extend when in check
         if (inCheck)
-            extension = MIN(extension, 1);
+            extension = MAX(extension, 1);
 
         ss->doubleExtensions = (ss-1)->doubleExtensions + (extension == 2);
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -39,6 +39,7 @@ typedef struct {
     PieceToHistory *continuation;
     int eval;
     int histScore;
+    int doubleExtensions;
     Depth ply;
     Move excluded;
     Move killers[2];


### PR DESCRIPTION
ELO   | 11.52 +- 7.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 4648 W: 1269 L: 1115 D: 2264

ELO   | 11.18 +- 6.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 4664 W: 1173 L: 1023 D: 2468