### PR TITLE
ProbCut: Only try moves which SEE allow it to beat probCutBeta

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -97,7 +97,7 @@ Move NextMove(MovePicker *mp) {
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
                 if (    mp->list.moves[mp->list.next-1].score > 12000
-                    || (mp->list.moves[mp->list.next-1].score > -8000 && SEE(pos, move, 0)))
+                    || (mp->list.moves[mp->list.next-1].score > -8000 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;
@@ -157,6 +157,7 @@ void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move t
     mp->kill1     = kill1;
     mp->kill2     = kill2;
     mp->bads      = 0;
+    mp->threshold = 0;
     mp->onlyNoisy = false;
 }
 
@@ -164,4 +165,9 @@ void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move t
 void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss, Move ttMove) {
     InitNormalMP(mp, thread, ss, 0, ttMove, NOMOVE, NOMOVE);
     mp->onlyNoisy = true;
+}
+
+void InitProbcutMP(MovePicker *mp, Thread *thread, Stack *ss, int threshold) {
+    InitNoisyMP(mp, thread, ss, NOMOVE);
+    mp->threshold = threshold;
 }

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -33,6 +33,7 @@ typedef struct MovePicker {
     Depth depth;
     Move ttMove, kill1, kill2;
     int bads;
+    int threshold;
     bool onlyNoisy;
 } MovePicker;
 
@@ -40,3 +41,4 @@ typedef struct MovePicker {
 Move NextMove(MovePicker *mp);
 void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move kill1, Move kill2);
 void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss, Move ttMove);
+void InitProbcutMP(MovePicker *mp, Thread *thread, Stack *ss, int threshold);

--- a/src/search.c
+++ b/src/search.c
@@ -355,7 +355,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (   depth >= 5
         && (!ttHit || ttBound == BOUND_LOWER || ttScore >= probCutBeta)) {
 
-        InitNoisyMP(&mp, thread, ss, NOMOVE);
+        InitProbcutMP(&mp, thread, ss, probCutBeta - ss->eval);
 
         Move move;
         while ((move = NextMove(&mp))) {


### PR DESCRIPTION
ELO   | 5.37 +- 4.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 11528 W: 3012 L: 2834 D: 5682

ELO   | 2.05 +- 2.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 47688 W: 11303 L: 11021 D: 25364