### PR TITLE
Adjust lmrDepth used for pruning by the history score

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -411,7 +411,8 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
-            Depth lmrDepth = depth - Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 8192;
+            Depth lmrDepth = depth - 1 - R;
 
             // Quiet late move pruning
             if (moveCount > (improving ? depth * depth : depth * depth / 2))


### PR DESCRIPTION
ELO   | 0.10 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 45920 W: 11760 L: 11747 D: 22413

ELO   | 9.21 +- 6.14 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 5848 W: 1468 L: 1313 D: 3067

Bench: 20229272