### PR TITLE
Update continuation histories after LMR

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -522,9 +522,7 @@ skip_extensions:
                           : score >= beta  ?  Bonus(depth)
                                            :  0;
 
-                ContHistoryUpdate(1, bestMove, bonus);
-                ContHistoryUpdate(2, bestMove, bonus);
-                ContHistoryUpdate(4, bestMove, bonus);
+                UpdateContHistories(ss, move, bonus);
             }
         }
 

--- a/src/search.c
+++ b/src/search.c
@@ -515,8 +515,17 @@ skip_extensions:
             score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, lmrDepth, true);
 
             // Research with the same window at full depth if the reduced search failed high
-            if (score > alpha && lmrDepth < newDepth)
+            if (score > alpha && lmrDepth < newDepth) {
                 score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, newDepth, !cutnode);
+
+                int bonus = score <= alpha ? -Bonus(depth)
+                          : score >= beta  ?  Bonus(depth)
+                                           :  0;
+
+                ContHistoryUpdate(1, bestMove, bonus);
+                ContHistoryUpdate(2, bestMove, bonus);
+                ContHistoryUpdate(4, bestMove, bonus);
+            }
         }
 
         // Full depth zero-window search


### PR DESCRIPTION
ELO   | 2.61 +- 2.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 32712 W: 8544 L: 8298 D: 15870

ELO   | 8.92 +- 6.02 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6040 W: 1508 L: 1353 D: 3179