### PR TITLE
Remove depth condition for using aspiration window and trend

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -599,19 +599,13 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
     const int initialWindow = 12;
     int delta = 16;
 
-    int alpha = -INFINITE;
-    int beta  =  INFINITE;
+    int prevScore = thread->rootMoves[multiPV].score;
 
-    // Shrink the window after the first few iterations
-    if (depth > 6) {
-        int prevScore = thread->rootMoves[multiPV].score;
+    int alpha = MAX(prevScore - initialWindow, -INFINITE);
+    int beta  = MIN(prevScore + initialWindow,  INFINITE);
 
-        alpha = MAX(prevScore - initialWindow, -INFINITE);
-        beta  = MIN(prevScore + initialWindow,  INFINITE);
-
-        int x = CLAMP(prevScore / 2, -35, 35);
-        pos->trend = sideToMove == WHITE ? S(x, x/2) : -S(x, x/2);
-    }
+    int x = CLAMP(prevScore / 2, -35, 35);
+    pos->trend = sideToMove == WHITE ? S(x, x/2) : -S(x, x/2);
 
     // Repeatedly search and adjust the window until the score is inside the window
     while (true) {


### PR DESCRIPTION
ELO   | 0.56 +- 2.89 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 28496 W: 7374 L: 7328 D: 13794

ELO   | -0.63 +- 1.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 102904 W: 24299 L: 24486 D: 54119

Bench: 20747862