### PR TITLE
Clean up LMR cont history updates

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -518,11 +518,12 @@ skip_extensions:
             if (score > alpha && lmrDepth < newDepth) {
                 score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, newDepth, !cutnode);
 
-                int bonus = score <= alpha ? -Bonus(depth)
-                          : score >= beta  ?  Bonus(depth)
-                                           :  0;
+                if (quiet && (score <= alpha || score >= beta)) {
+                    int bonus = score >= beta ?  Bonus(depth)
+                                              : -Bonus(depth);
 
-                UpdateContHistories(ss, move, bonus);
+                    UpdateContHistories(ss, move, bonus);
+                }
             }
         }
 


### PR DESCRIPTION
ELO   | 0.34 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 32248 W: 8345 L: 8313 D: 15590

ELO   | 0.34 +- 2.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 32752 W: 7755 L: 7723 D: 17274