### PR TITLE
Simplify away LMR depth adjustment for killers

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -498,8 +498,6 @@ skip_extensions:
             r -= pvNode;
             // Reduce less when improving
             r -= improving;
-            // Reduce less for killers
-            r -= move == mp.kill1 || move == mp.kill2;
             // Reduce more for the side that was last null moved against
             r += opponent == thread->nullMover;
             // Reduce quiets more if ttMove is a capture


### PR DESCRIPTION
ELO   | 0.74 +- 2.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 42464 W: 11090 L: 11000 D: 20374

ELO   | 3.95 +- 3.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 15552 W: 3784 L: 3607 D: 8161

Bench: 19982072