### PR TITLE
Increase LMR for all moves when TT move is a capture

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -501,7 +501,7 @@ skip_extensions:
             // Reduce more for the side that was last null moved against
             r += opponent == thread->nullMover;
             // Reduce quiets more if ttMove is a capture
-            r += quiet && moveIsCapture(ttMove);
+            r += moveIsCapture(ttMove);
             // Reduce more when opponent has few pieces
             r += pos->nonPawnCount[opponent] < 2;
             // Reduce more in cut nodes


### PR DESCRIPTION
ELO   | 2.87 +- 3.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 20088 W: 5363 L: 5197 D: 9528

ELO   | 1.65 +- 2.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 28496 W: 6847 L: 6712 D: 14937

Bench: 19339527