### PR TITLE
Adjust aspi window delta by previous depth's score

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -595,13 +595,12 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
     const int multiPV = thread->multiPV;
     int depth = thread->depth;
 
-    const int initialWindow = 12;
-    int delta = 16;
-
     int prevScore = thread->rootMoves[multiPV].score;
 
-    int alpha = MAX(prevScore - initialWindow, -INFINITE);
-    int beta  = MIN(prevScore + initialWindow,  INFINITE);
+    int delta = 12 + prevScore * prevScore / 16384;
+
+    int alpha = MAX(prevScore - delta, -INFINITE);
+    int beta  = MIN(prevScore + delta,  INFINITE);
 
     int x = CLAMP(prevScore / 2, -35, 35);
     pos->trend = sideToMove == WHITE ? S(x, x/2) : -S(x, x/2);


### PR DESCRIPTION
ELO   | 1.56 +- 1.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-0.00, 3.00]
GAMES | N: 198752 W: 52044 L: 51152 D: 95556

ELO   | 1.70 +- 1.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 127176 W: 30571 L: 29948 D: 66657

Bench: 20323233