### PR TITLE
Remove aspiration window adjustment for extreme scores

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -608,9 +608,6 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
     // Repeatedly search and adjust the window until the score is inside the window
     while (true) {
 
-        if (alpha < -3500) alpha = -INFINITE;
-        if (beta  >  3500) beta  =  INFINITE;
-
         thread->doPruning =
             Limits.infinite ? TimeSince(Limits.start) > 1000
                             :   TimeSince(Limits.start) >= Limits.optimalUsage / 64


### PR DESCRIPTION
ELO   | -0.72 +- 1.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 186496 W: 47953 L: 48339 D: 90204

Bench: 20323233