### PR TITLE
Widen aspiration window less for each fail-high/low

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -644,7 +644,7 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
             return;
         }
 
-        delta += delta * 2 / 3;
+        delta += delta / 2;
     }
 }
 

--- a/src/search.c
+++ b/src/search.c
@@ -644,7 +644,7 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
             return;
         }
 
-        delta += delta / 2;
+        delta += delta / 3;
     }
 }
 


### PR DESCRIPTION
ELO   | 3.75 +- 2.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 30800 W: 8127 L: 7795 D: 14878

ELO   | 1.85 +- 1.46 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 102384 W: 24582 L: 24037 D: 53765