### PR TITLE
Move prefetching of TT-entries to MakeMove

### DIFF
--- a/src/makemove.c
+++ b/src/makemove.c
@@ -22,6 +22,7 @@
 #include "makemove.h"
 #include "move.h"
 #include "psqt.h"
+#include "transposition.h"
 
 
 #define HASH_PCE(piece, sq) (pos->key ^= PieceKeys[(piece)][(sq)])
@@ -195,6 +196,8 @@ done:
 // Make a move - take it back and return false if move was illegal
 bool MakeMove(Position *pos, const Move move) {
 
+    TTPrefetch(KeyAfter(pos, move));
+
     // Save position
     history(0).key            = pos->key;
     history(0).materialKey    = pos->materialKey;
@@ -307,6 +310,8 @@ void MakeNullMove(Position *pos) {
     // Hash out en passant if there was one, and unset it
     HASH_EP;
     pos->epSquare = 0;
+
+    TTPrefetch(pos->key);
 
     assert(PositionOk(pos));
 }

--- a/src/search.c
+++ b/src/search.c
@@ -159,8 +159,6 @@ moveloop:
         }
 
 search:
-        TTPrefetch(KeyAfter(pos, move));
-
         ss->continuation = &thread->continuation[inCheck][moveIsCapture(move)][piece(move)][toSq(move)];
 
         // Recursively search the positions after making the moves, skipping illegal ones
@@ -426,8 +424,6 @@ move_loop:
             if (lmrDepth < 7 && !SEE(pos, move, quiet ? -50 * depth : -90 * depth))
                 continue;
         }
-
-        TTPrefetch(KeyAfter(pos, move));
 
         // Make the move, skipping to the next if illegal
         if (!MakeMove(pos, move)) continue;


### PR DESCRIPTION
This results in prefetching also for ProbCut moves. Also added prefetching to null moves.

ELO   | 0.59 +- 2.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 46224 W: 12026 L: 11947 D: 22251

Bench: 21057596