### PR TITLE
Check that the king doesn't end in check for pseudo-legality of castling

### DIFF
--- a/src/move.h
+++ b/src/move.h
@@ -82,10 +82,10 @@ INLINE bool CastlePseudoLegal(const Position *pos, Square to) {
         || pieceBB(ALL) & CastlePath[castle])
         return false;
 
-    Bitboard intercept = BetweenBB[kingSq(color)][to];
+    Bitboard kingPath = BetweenBB[kingSq(color)][to] | BB(to);
 
-    while (intercept)
-        if (SqAttacked(pos, PopLsb(&intercept), !color))
+    while (kingPath)
+        if (SqAttacked(pos, PopLsb(&kingPath), !color))
             return false;
 
     return true;


### PR DESCRIPTION
Avoids generating some illegal castling moves, as well as slightly lowering the chance of using illegal moves from TT and killers.

Bench:  19389515