### PR TITLE
Improve UCI compliance: remove extra newline after 'bestmove'

### DIFF
--- a/src/uci.c
+++ b/src/uci.c
@@ -268,6 +268,6 @@ void PrintThinking(const Thread *thread, int alpha, int beta) {
 
 // Print conclusion of search
 void PrintConclusion(const Thread *thread) {
-    printf("bestmove %s\n\n", MoveToStr(thread->rootMoves[0].move));
+    printf("bestmove %s\n", MoveToStr(thread->rootMoves[0].move));
     fflush(stdout);
 }


### PR DESCRIPTION
Before this patch, Weiss adds an extra newline after 'bestmove'. For example:
```
$ ./weiss
> go depth 1
< info depth 1 seldepth 1 multipv 1 score cp 68 time 0 nodes 49 nps 49000 tbhits 0 hashfull 0 pv b1c3
< bestmove b1c3
<
```
where:
```
>  input to engine
<  output from engine
```
However, the additional empty line after bestmove makes python-chess unhappy. With this simple repro:
```
$ python3
import chess.engine
engine = chess.engine.SimpleEngine.popen_uci('./weiss') board = chess.Board()
result = engine.analyse(board, chess.engine.Limit(time=1)) # triggers the assert result['score']
engine.quit()
```
I get:
```
Exception in callback Protocol._line_received('')
handle: <Handle Protocol._line_received('')>
Traceback (most recent call last):
  File "/usr/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/home/skiminki/.local/lib/python3.11/site-packages/chess/engine.py", line 1040, in _line_received
    self.command._line_received(self, line)
  File "/home/skiminki/.local/lib/python3.11/site-packages/chess/engine.py", line 1289, in _line_received
    assert self.state in [CommandState.ACTIVE, CommandState.CANCELLING]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
PovScore(Cp(+77), WHITE)
```

Technically, the UCI protocol does not list the empty output line from the engine as an option. So, remove it to improve conformance. This also makes the python-chess assert spam go away.

No functional change.

Bench: 19891416


***

The additional context here is that I added !hoover-eval in TCEC chat. While python-chess continues to be functional while spamming these asserts, I'd need to add additional output filtering to remove the assert in order to support Weiss. The way !hoover-eval is implemented is that the chat bot does not invoke python-chess directly for security reasons. Instead, it spawns another process to run python-chess + engine and posts the captured output back to chat.