### PR TITLE
Increase search depth for a move if the initial LMR search gives a very good score

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -479,7 +479,7 @@ skip_extensions:
         ss->doubleExtensions = (ss-1)->doubleExtensions + (extension == 2);
         ss->continuation = &thread->continuation[inCheck][moveIsCapture(move)][piece(move)][toSq(move)];
 
-        const Depth newDepth = depth - 1 + extension;
+        Depth newDepth = depth - 1 + extension;
 
         // Reduced depth zero-window search
         if (   depth > 2
@@ -510,6 +510,10 @@ skip_extensions:
 
             // Research with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
+                bool deeper = score > bestScore + 70 + 12 * (newDepth - lmrDepth);
+
+                newDepth += deeper;
+
                 score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, newDepth, !cutnode);
 
                 if (quiet && (score <= alpha || score >= beta)) {


### PR DESCRIPTION
ELO   | 2.36 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 66384 W: 17466 L: 17015 D: 31903

ELO   | 3.65 +- 2.69 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 30496 W: 7435 L: 7115 D: 15946

Bench: 21093788