### PR TITLE
Simplify the condition for doing the full-depth full-window re-search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -530,7 +530,7 @@ skip_extensions:
             score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, newDepth, !cutnode);
 
         // Full depth alpha-beta window search
-        if (pvNode && ((score > alpha && score < beta) || moveCount == 1))
+        if (pvNode && (score > alpha || moveCount == 1))
             score = -AlphaBeta(thread, ss+1, -beta, -alpha, newDepth, false);
 
         // Undo the move


### PR DESCRIPTION
This means a re-search will now also be triggered when the previous searches indicate a fail high.

ELO   | -0.18 +- 1.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 86016 W: 20398 L: 20443 D: 45175

Bench: 22069011
