### PR TITLE
Fix mixed-signedness comparison

### DIFF
--- a/src/pyrrhic/tbchess.c
+++ b/src/pyrrhic/tbchess.c
@@ -106,7 +106,7 @@ static uint64_t pyrrhic_pieces_by_type(const PyrrhicPosition *pos, int colour, i
 
 static int pyrrhic_char_to_piece_type(char c) {
 
-    for (int i = PYRRHIC_PAWN; i <= PYRRHIC_KING; i++)
+    for (int i = PYRRHIC_PAWN; i <= (int)PYRRHIC_KING; i++)
         if (c == pyrrhic_piece_to_char[i])
             return i;
     return 0;

--- a/src/pyrrhic/tbprobe.c
+++ b/src/pyrrhic/tbprobe.c
@@ -445,13 +445,13 @@ static void prt_str(const PyrrhicPosition *pos, char *str, int flip) {
 
     int color = flip ? PYRRHIC_BLACK : PYRRHIC_WHITE;
 
-    for (int pt = PYRRHIC_KING; pt >= PYRRHIC_PAWN; pt--)
+    for (int pt = PYRRHIC_KING; pt >= (int)PYRRHIC_PAWN; pt--)
         for (int i = PYRRHIC_POPCOUNT(pyrrhic_pieces_by_type(pos, color, pt)); i > 0; i--)
             *str++ = pyrrhic_piece_to_char[pt];
 
     *str++ = 'v';
 
-    for (int pt = PYRRHIC_KING; pt >= PYRRHIC_PAWN; pt--)
+    for (int pt = PYRRHIC_KING; pt >= (int)PYRRHIC_PAWN; pt--)
         for (int i = PYRRHIC_POPCOUNT(pyrrhic_pieces_by_type(pos, color^1, pt)); i > 0; i--)
             *str++ = pyrrhic_piece_to_char[pt];
     *str++ = 0;


### PR DESCRIPTION
GCC 13 has made checks for mixed-signedness comparisons more stringent, causing a build failure on Ubuntu 23.10 (pre-release). Workaround this by adding some casts in the Pyrrhic code.

Fixes #677

No functional change.

**

Note: This is perhaps not the cleanest possible fix, but it is the smallest one. Possibly, a better fix would be something such as:

```
typedef enum {

    PYRRHIC_BLACK   = 0, PYRRHIC_WHITE   = 1,
    PYRRHIC_PAWN    = 1, PYRRHIC_KNIGHT  = 2,
    PYRRHIC_BISHOP  = 3, PYRRHIC_ROOK    = 4,
    PYRRHIC_QUEEN   = 5, PYRRHIC_KING    = 6

} PyrrhicPieces;

for (PyrrhicPieces i = PYRRHIC_PAWN; i <= PYRRHIC_KING; i++)
{
   ...
}
```

That is, break the big anonymous enum type to smaller enum types of related values. That would allow for more consistent use of types in expressions. However, I'm not entirely sure what is the intended direction here, and you could also argue that the code is just fine as it is and GCC is just overly stringent here.

Bench: 22069011

