### PR TITLE
Revert to using 2-fold repetition for all nodes

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -113,13 +113,9 @@ INLINE void SqToStr(Square sq, char *str) {
     str[1] = '1' + RankOf(sq);
 }
 
-INLINE bool IsRepetition(const Position *pos, int count) {
-    int c = 0;
-    for (int i = 4; i <= pos->rule50 && i <= pos->histPly; i += 2) {
+INLINE bool IsRepetition(const Position *pos) {
+    for (int i = 4; i <= pos->rule50 && i <= pos->histPly; i += 2)
         if (pos->key == history(-i).key)
-            c++;
-        if (c == count)
             return true;
-    }
     return false;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -83,7 +83,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
         longjmp(thread->jumpBuffer, true);
 
     // Position is drawn
-    if (IsRepetition(pos, 1 + pvNode) || pos->rule50 >= 100)
+    if (IsRepetition(pos) || pos->rule50 >= 100)
         return DrawScore(pos);
 
     // Probe transposition table
@@ -218,7 +218,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         }
 
         // Position is drawn
-        if (IsRepetition(pos, 1 + pvNode) || pos->rule50 >= 100)
+        if (IsRepetition(pos) || pos->rule50 >= 100)
             return DrawScore(pos);
 
         // Max depth reached


### PR DESCRIPTION
ELO   | -0.20 +- 1.58 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
GAMES | N: 88408 W: 21063 L: 21115 D: 46230

Bench: 20282767
