### PR TITLE
Spend more time each turn

### DIFF
--- a/src/time.c
+++ b/src/time.c
@@ -45,7 +45,7 @@ void InitTimeManagement() {
 
     // Basetime for the whole game
     if (!Limits.movestogo) {
-        double scale = 0.02;
+        double scale = 0.021;
         Limits.optimalUsage = MIN(timeLeft * scale, 0.2 * Limits.time);
 
     // X moves in Y time

--- a/src/time.c
+++ b/src/time.c
@@ -45,7 +45,7 @@ void InitTimeManagement() {
 
     // Basetime for the whole game
     if (!Limits.movestogo) {
-        double scale = 0.021;
+        double scale = 0.022;
         Limits.optimalUsage = MIN(timeLeft * scale, 0.2 * Limits.time);
 
     // X moves in Y time


### PR DESCRIPTION
0.21 vs 0.2

ELO   | 2.23 +- 1.79 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 69088 W: 16739 L: 16295 D: 36054

0.22 vs 0.21

ELO   | 4.75 +- 3.21 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 21288 W: 5209 L: 4918 D: 11161

Bench: 20282767