### PR TITLE
LMR earlier for quiet moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -483,7 +483,7 @@ skip_extensions:
 
         // Reduced depth zero-window search
         if (   depth > 2
-            && moveCount > 1 + pvNode + !ttMove + root
+            && moveCount > MAX(1, pvNode + !ttMove + root + !quiet)
             && thread->doPruning) {
 
             // Base reduction


### PR DESCRIPTION
ELO   | 6.10 +- 3.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 16232 W: 4374 L: 4089 D: 7769

ELO   | 2.38 +- 1.90 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
GAMES | N: 60800 W: 14660 L: 14244 D: 31896

Bench: 21253689
