### PR TITLE
Lower the returned score from ProbCut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -376,7 +376,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             // Cut if the reduced depth search beats the threshold
             if (score >= probCutBeta)
-                return score - 200;
+                return score - 100;
         }
     }
 

--- a/src/search.c
+++ b/src/search.c
@@ -376,7 +376,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             // Cut if the reduced depth search beats the threshold
             if (score >= probCutBeta)
-                return score;
+                return score - 200;
         }
     }
 


### PR DESCRIPTION
Elo   | 1.66 +- 1.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 155362 W: 40426 L: 39682 D: 75254
http://chess.grantnet.us/test/34079/

Elo   | 1.53 +- 1.55 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 88130 W: 20407 L: 20018 D: 47705
Penta | [557, 10485, 21670, 10718, 635]
http://chess.grantnet.us/test/34098/

Bench: 18586766
