### PR TITLE
LMR reduce more in cut nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -501,7 +501,7 @@ skip_extensions:
             // Reduce more when opponent has few pieces
             r += pos->nonPawnCount[opponent] < 2;
             // Reduce more in cut nodes
-            r += cutnode;
+            r += 2 * cutnode;
 
             // Depth after reductions, avoiding going straight to quiescence as well as extending
             Depth lmrDepth = CLAMP(newDepth - r, 1, newDepth);


### PR DESCRIPTION
Elo   | 1.06 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 144396 W: 37138 L: 36699 D: 70559
Penta | [2119, 17567, 32521, 17738, 2253]
http://chess.grantnet.us/test/34156/

Elo   | 6.22 +- 4.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11628 W: 2829 L: 2621 D: 6178
Penta | [71, 1293, 2890, 1477, 83]
http://chess.grantnet.us/test/34170/

Bench: 19885655
