### PR TITLE
SPSA tune search, king safety, and history update

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -137,9 +137,9 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 34, 19, 30, 74 };
-const int CheckPower[4]  = { 89, 41, 71, 64 };
-const int CountModifier[8] = { 0, 0, 68, 118, 100, 127, 123, 128 };
+const int AttackPower[4] = { 35, 18, 31, 81 };
+const int CheckPower[4]  = { 85, 39, 72, 68 };
+const int CountModifier[8] = { 0, 0, 65, 124, 96, 124, 123, 128 };
 
 
 // Evaluates pawns

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -137,9 +137,9 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = {  35, 20, 40, 80 };
-const int CheckPower[4]  = { 100, 35, 65, 65 };
-const int CountModifier[8] = { 0, 0, 64, 96, 113, 120, 124, 128 };
+const int AttackPower[4] = { 36, 19, 33, 74 };
+const int CheckPower[4]  = { 88, 38, 67, 63 };
+const int CountModifier[8] = { 0, 0, 67, 119, 99, 125, 126, 128 };
 
 
 // Evaluates pawns

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -137,9 +137,9 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 36, 19, 33, 74 };
-const int CheckPower[4]  = { 88, 38, 67, 63 };
-const int CountModifier[8] = { 0, 0, 67, 119, 99, 125, 126, 128 };
+const int AttackPower[4] = { 34, 19, 30, 74 };
+const int CheckPower[4]  = { 89, 41, 71, 64 };
+const int CountModifier[8] = { 0, 0, 68, 118, 100, 127, 123, 128 };
 
 
 // Evaluates pawns

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6750))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 17500))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 20000))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6000))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16900))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 21250))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,7 +40,7 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2170, 390 * depth - 280);
+    return MIN(2135, 400 * depth - 280);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  8192))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 16384))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6910))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 17250))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 19742))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,7 +40,7 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2100, 350 * depth - 350);
+    return MIN(2225, 378 * depth - 300);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6910))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 17250))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 19742))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6750))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 17500))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 20000))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,7 +40,7 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2225, 378 * depth - 300);
+    return MIN(2170, 390 * depth - 280);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 12000
-                    || (mp->list.moves[mp->list.next-1].score > -8000 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score > 13000
+                    || (mp->list.moves[mp->list.next-1].score > -8666 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 13000
-                    || (mp->list.moves[mp->list.next-1].score > -8666 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score > 13500
+                    || (mp->list.moves[mp->list.next-1].score > -8800 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 13500
-                    || (mp->list.moves[mp->list.next-1].score > -8800 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score > 13450
+                    || (mp->list.moves[mp->list.next-1].score > -9000 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.00, // capture
-            Reductions[1][depth][moves] = 1.50 + log(depth) * log(moves) / 2.05; // quiet
+            Reductions[0][depth][moves] = 0.10 + log(depth) * log(moves) / 3.00, // capture
+            Reductions[1][depth][moves] = 1.50 + log(depth) * log(moves) / 2.10; // quiet
 }
 
 // Checks if the move is in the list of searchmoves if any were given
@@ -318,17 +318,17 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (   depth < 7
         && eval >= beta
         && eval - 100 * depth - (ss-1)->histScore / 300 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 7500))
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7700))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->eval
         && ss->eval >= beta + 140 - 15 * depth
-        && (ss-1)->histScore < 27500
+        && (ss-1)->histScore < 26000
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 270);
+        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
 
         // Remember who last null-moved
         Color nullMoverTemp = thread->nullMover;
@@ -510,7 +510,7 @@ skip_extensions:
 
             // Research with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 60 + 12 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 55 + 13 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 

--- a/src/search.c
+++ b/src/search.c
@@ -48,7 +48,7 @@ CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
             Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.00, // capture
-            Reductions[1][depth][moves] = 1.40 + log(depth) * log(moves) / 2.00; // quiet
+            Reductions[1][depth][moves] = 1.50 + log(depth) * log(moves) / 2.05; // quiet
 }
 
 // Checks if the move is in the list of searchmoves if any were given
@@ -125,7 +125,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     if (eval > alpha)
         alpha = eval;
 
-    futility = eval + 55;
+    futility = eval + 60;
     bestScore = eval;
 
 moveloop:
@@ -317,18 +317,18 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 100 * depth - (ss-1)->histScore / 320 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 8500))
+        && eval - 100 * depth - (ss-1)->histScore / 300 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7500))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->eval
-        && ss->eval >= beta + 130 - 16 * depth
-        && (ss-1)->histScore < 32500
+        && ss->eval >= beta + 140 - 15 * depth
+        && (ss-1)->histScore < 27500
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 274);
+        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 270);
 
         // Remember who last null-moved
         Color nullMoverTemp = thread->nullMover;
@@ -348,10 +348,10 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
             return score >= TBWIN_IN_MAX ? beta : score;
     }
 
-    int probCutBeta = beta + 200;
+    int probCutBeta = beta + 180;
 
     // ProbCut
-    if (   depth >= 4
+    if (   depth >= 5
         && (!ttHit || ttBound == BOUND_LOWER || ttScore >= probCutBeta)) {
 
         InitProbcutMP(&mp, thread, ss, probCutBeta - ss->eval);
@@ -376,7 +376,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             // Cut if the reduced depth search beats the threshold
             if (score >= probCutBeta)
-                return score - 120;
+                return score - 115;
         }
     }
 
@@ -421,7 +421,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 8 && !SEE(pos, move, quiet ? -50 * depth : -90 * depth))
+            if (lmrDepth < 8 && !SEE(pos, move, quiet ? -50 * depth : -95 * depth))
                 continue;
         }
 
@@ -510,7 +510,7 @@ skip_extensions:
 
             // Research with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 62 + 11 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 60 + 12 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 
@@ -602,7 +602,7 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
     int alpha = MAX(prevScore - delta, -INFINITE);
     int beta  = MIN(prevScore + delta,  INFINITE);
 
-    int x = CLAMP(prevScore / 2, -35, 35);
+    int x = CLAMP(prevScore / 2, -33, 33);
     pos->trend = sideToMove == WHITE ? S(x, x/2) : -S(x, x/2);
 
     // Repeatedly search and adjust the window until the score is inside the window

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.25, // capture
-            Reductions[1][depth][moves] = 1.50 + log(depth) * log(moves) / 1.75; // quiet
+            Reductions[0][depth][moves] = 0.00 + log(depth) * log(moves) / 3.00, // capture
+            Reductions[1][depth][moves] = 1.40 + log(depth) * log(moves) / 2.00; // quiet
 }
 
 // Checks if the move is in the list of searchmoves if any were given
@@ -125,7 +125,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     if (eval > alpha)
         alpha = eval;
 
-    futility = eval + 60;
+    futility = eval + 55;
     bestScore = eval;
 
 moveloop:
@@ -307,7 +307,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (pvNode && depth >= 4 && !ttMove)
         depth--;
 
-    if (cutnode && depth >= 7 && !ttMove)
+    if (cutnode && depth >= 8 && !ttMove)
         depth--;
 
     // Skip pruning in check, pv nodes, early iterations, when proving singularity, looking for terminal scores, or after a null move
@@ -317,18 +317,18 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 100 * depth - (ss-1)->histScore / 400 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 10000))
+        && eval - 100 * depth - (ss-1)->histScore / 320 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 8500))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->eval
-        && ss->eval >= beta + 120 - 15 * depth
-        && (ss-1)->histScore < 35000
+        && ss->eval >= beta + 130 - 16 * depth
+        && (ss-1)->histScore < 32500
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 5 + MIN(3, (eval - beta) / 256);
+        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 274);
 
         // Remember who last null-moved
         Color nullMoverTemp = thread->nullMover;
@@ -351,7 +351,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     int probCutBeta = beta + 200;
 
     // ProbCut
-    if (   depth >= 5
+    if (   depth >= 4
         && (!ttHit || ttBound == BOUND_LOWER || ttScore >= probCutBeta)) {
 
         InitProbcutMP(&mp, thread, ss, probCutBeta - ss->eval);
@@ -376,7 +376,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             // Cut if the reduced depth search beats the threshold
             if (score >= probCutBeta)
-                return score - 100;
+                return score - 120;
         }
     }
 
@@ -421,7 +421,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -50 * depth : -90 * depth))
+            if (lmrDepth < 8 && !SEE(pos, move, quiet ? -50 * depth : -90 * depth))
                 continue;
         }
 
@@ -510,7 +510,7 @@ skip_extensions:
 
             // Research with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 70 + 12 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 62 + 11 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 
@@ -597,7 +597,7 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
 
     int prevScore = thread->rootMoves[multiPV].score;
 
-    int delta = 12 + prevScore * prevScore / 16384;
+    int delta = 10 + prevScore * prevScore / 16384;
 
     int alpha = MAX(prevScore - delta, -INFINITE);
     int beta  = MIN(prevScore + delta,  INFINITE);


### PR DESCRIPTION
STC 80k vs master
Elo   | 9.96 +- 3.47 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=32MB
Games | N: 20000 W: 5506 L: 4933 D: 9561
Penta | [263, 2248, 4501, 2629, 359]
http://chess.grantnet.us/test/34247/

LTC 38k vs master
Elo   | 7.29 +- 4.71 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 9770 W: 2393 L: 2188 D: 5189
Penta | [52, 1107, 2392, 1252, 82]
http://chess.grantnet.us/test/34217/

LTC 80k vs 38k
Elo   | 3.02 +- 2.73 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29264 W: 7003 L: 6749 D: 15512
Penta | [192, 3480, 7077, 3648, 235]
http://chess.grantnet.us/test/34244/

Bench: 21740192