### PR TITLE
Remove null mover LMR adjustment

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -330,17 +330,11 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
         Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
 
-        // Remember who last null-moved
-        Color nullMoverTemp = thread->nullMover;
-        thread->nullMover = sideToMove;
-
         ss->continuation = &thread->continuation[0][0][EMPTY][0];
 
         MakeNullMove(pos);
         int score = -AlphaBeta(thread, ss+1, -beta, -alpha, depth - reduction, !cutnode);
         TakeNullMove(pos);
-
-        thread->nullMover = nullMoverTemp;
 
         // Cutoff
         if (score >= beta)
@@ -494,8 +488,6 @@ skip_extensions:
             r -= pvNode;
             // Reduce less when improving
             r -= improving;
-            // Reduce more for the side that was last null moved against
-            r += opponent == thread->nullMover;
             // Reduce quiets more if ttMove is a capture
             r += moveIsCapture(ttMove);
             // Reduce more when opponent has few pieces

--- a/src/threads.c
+++ b/src/threads.c
@@ -117,7 +117,6 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
     for (Thread *t = threads; t < threads + threads->count; ++t) {
         memset(t, 0, offsetof(Thread, pos));
         memcpy(&t->pos, pos, sizeof(Position));
-        t->nullMover = -1;
         t->rootMoveCount = rootMoveCount;
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;

--- a/src/threads.h
+++ b/src/threads.h
@@ -59,7 +59,6 @@ typedef struct Thread {
     uint64_t tbhits;
     RootMove rootMoves[MULTI_PV_MAX];
     Depth depth;
-    Color nullMover;
     int rootMoveCount;
     bool doPruning;
     bool uncertain;


### PR DESCRIPTION
Elo   | 1.75 +- 2.94 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 24822 W: 5834 L: 5709 D: 13279
Penta | [180, 2920, 6096, 3025, 190]
http://chess.grantnet.us/test/34274/

Bench: 21963671
