### PR TITLE
SPSA tune search, king safety, history updates, tempo

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 15;
+const int Tempo = 19;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);
@@ -137,9 +137,9 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 35, 18, 31, 81 };
-const int CheckPower[4]  = { 85, 39, 72, 68 };
-const int CountModifier[8] = { 0, 0, 65, 124, 96, 124, 123, 128 };
+const int AttackPower[4] = { 36, 19, 22, 72 };
+const int CheckPower[4]  = { 71, 39, 80, 74 };
+const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
 
 
 // Evaluates pawns

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6000))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16900))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 21250))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5885))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 14500))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 23930))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,7 +40,7 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2135, 400 * depth - 280);
+    return MIN(2300, 315 * depth - 255);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1000 * mp->depth);
+    SortMoves(list, -1280 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 13450
-                    || (mp->list.moves[mp->list.next-1].score > -9000 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score > 13470
+                    || (mp->list.moves[mp->list.next-1].score > -8830 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;


### PR DESCRIPTION
Elo   | 5.67 +- 2.46 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=32MB
Games | N: 40006 W: 10812 L: 10159 D: 19035
Penta | [592, 4628, 9013, 5075, 695]
http://chess.grantnet.us/test/34396/

Elo   | 2.14 +- 2.15 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 48152 W: 11690 L: 11393 D: 25069
Penta | [364, 5618, 11799, 5947, 348]
http://chess.grantnet.us/test/34392/

Bench: 34121414