### PR TITLE
Reintroduce improving into the RFP condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -311,7 +311,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 80 * depth - (ss-1)->histScore / 230 >= beta
+        && eval - 80 * (depth - improving) - (ss-1)->histScore / 230 >= beta
         && (!ttMove || GetHistory(thread, ss, ttMove) > 7300))
         return eval;
 


### PR DESCRIPTION
Elo   | 1.73 +- 1.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 87720 W: 23345 L: 22907 D: 41468
Penta | [1400, 10534, 19626, 10828, 1472]
http://chess.grantnet.us/test/34414/

Elo   | 1.68 +- 1.72 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 74682 W: 18022 L: 17661 D: 38999
Penta | [533, 8844, 18281, 9095, 588]
http://chess.grantnet.us/test/34418/

Bench: 30658368