### PR TITLE
Separate formula for history bonus/malus and SPSA tuning

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 19;
+const int Tempo = 18;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);
@@ -137,9 +137,9 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 36, 19, 22, 72 };
-const int CheckPower[4]  = { 71, 39, 80, 74 };
-const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
+const int AttackPower[4] = { 32, 20, 22, 69 };
+const int CheckPower[4]  = { 70, 42, 91, 68 };
+const int CountModifier[8] = { 0, 0, 63, 120, 95, 124, 124, 128 };
 
 
 // Evaluates pawns
@@ -335,7 +335,7 @@ INLINE int EvalKings(const Position *pos, EvalInfo *ei, const Color color) {
     }
 
     // King safety
-    ei->attackPower[!color] += (count - 3) * 8;
+    ei->attackPower[!color] += (count - 3) * 9;
 
     int danger =  ei->attackPower[!color]
                 * CountModifier[MIN(7, ei->attackCount[!color])];
@@ -505,7 +505,7 @@ static int ScaleFactor(const Position *pos, const int eval) {
 
     int strongPawnCount = PopCount(strongPawns);
     int x = 8 - strongPawnCount;
-    int pawnScale = 128 - x * x;
+    int pawnScale = 133 + 2 * x - x * x;
 
     // Scale down when there aren't pawns on both sides of the board
     if (!(strongPawns & QueenSideBB) || !(strongPawns & KingSideBB))

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 18;
+const int Tempo = 19;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);
@@ -137,9 +137,9 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 32, 20, 22, 69 };
-const int CheckPower[4]  = { 70, 42, 91, 68 };
-const int CountModifier[8] = { 0, 0, 63, 120, 95, 124, 124, 128 };
+const int AttackPower[4] = { 36, 19, 22, 72 };
+const int CheckPower[4]  = { 71, 39, 80, 74 };
+const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
 
 
 // Evaluates pawns
@@ -335,7 +335,7 @@ INLINE int EvalKings(const Position *pos, EvalInfo *ei, const Color color) {
     }
 
     // King safety
-    ei->attackPower[!color] += (count - 3) * 9;
+    ei->attackPower[!color] += (count - 3) * 8;
 
     int danger =  ei->attackPower[!color]
                 * CountModifier[MIN(7, ei->attackCount[!color])];
@@ -505,7 +505,7 @@ static int ScaleFactor(const Position *pos, const int eval) {
 
     int strongPawnCount = PopCount(strongPawns);
     int x = 8 - strongPawnCount;
-    int pawnScale = 133 + 2 * x - x * x;
+    int pawnScale = 128 - x * x;
 
     // Scale down when there aren't pawns on both sides of the board
     if (!(strongPawns & QueenSideBB) || !(strongPawns & KingSideBB))

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1280 * mp->depth);
+    SortMoves(list, -1380 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 13470
-                    || (mp->list.moves[mp->list.next-1].score > -8830 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score > 13540
+                    || (mp->list.moves[mp->list.next-1].score > -9135 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;


### PR DESCRIPTION
Elo   | 0.55 +- 1.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -0.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 65634 W: 17356 L: 17252 D: 31026
Penta | [1090, 7901, 14721, 8025, 1080]
http://chess.grantnet.us/test/34493/

Elo   | 5.78 +- 4.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 13174 W: 3246 L: 3027 D: 6901
Penta | [96, 1485, 3216, 1684, 106]
http://chess.grantnet.us/test/34494/

Bench: 28419588