### PR TITLE
Remove influence of open lines to the king on king safety

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -335,8 +335,6 @@ INLINE int EvalKings(const Position *pos, EvalInfo *ei, const Color color) {
     }
 
     // King safety
-    ei->attackPower[!color] += (count - 3) * 8;
-
     int danger =  ei->attackPower[!color]
                 * CountModifier[MIN(7, ei->attackCount[!color])];
 


### PR DESCRIPTION
Elo   | 1.19 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 34614 W: 9130 L: 9011 D: 16473
Penta | [573, 4142, 7743, 4291, 558]
http://chess.grantnet.us/test/34511/

Elo   | 1.19 +- 2.62 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 32284 W: 7808 L: 7697 D: 16779
Penta | [242, 3834, 7866, 3971, 229]
http://chess.grantnet.us/test/34514/

Bench: 27258264
