### PR TITLE
Adjust the history thresholds for good noisy moves based on depth

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 13540
-                    || (mp->list.moves[mp->list.next-1].score > -9135 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score > 14540 - 200 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -9935 + 200 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;


### PR DESCRIPTION
Elo   | 1.61 +- 1.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 103528 W: 27279 L: 26799 D: 49450
Penta | [1652, 12341, 23313, 12791, 1667]
http://chess.grantnet.us/test/34528/

Elo   | 2.50 +- 2.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 38830 W: 9345 L: 9066 D: 20419
Penta | [294, 4504, 9520, 4823, 274]
http://chess.grantnet.us/test/34539/

Bench: 29925582
