### PR TITLE
Use history Malus formula when penalizing bad LMR re-search

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -502,8 +502,8 @@ skip_extensions:
                 score = -AlphaBeta(thread, ss+1, -alpha-1, -alpha, newDepth, !cutnode);
 
                 if (quiet && (score <= alpha || score >= beta)) {
-                    int bonus = score >= beta ?  Bonus(depth)
-                                              : -Bonus(depth);
+                    int bonus = score >= beta ? Bonus(depth)
+                                              : Malus(depth);
 
                     UpdateContHistories(ss, move, bonus);
                 }


### PR DESCRIPTION
Elo   | 1.77 +- 2.98 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 27542 W: 7336 L: 7196 D: 13010
Penta | [435, 3333, 6129, 3405, 469]
http://chess.grantnet.us/test/34547/

Elo   | 0.64 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 44394 W: 10748 L: 10666 D: 22980
Penta | [313, 5264, 10978, 5312, 330]
http://chess.grantnet.us/test/34551/

Bench: 32148915
