### PR TITLE
SPSA tune search, king safety, history updates, tempo

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 19;
+const int Tempo = 17;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);
@@ -137,8 +137,8 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 35, 18, 23, 77 };
-const int CheckPower[4]  = { 74, 42, 90, 82 };
+const int AttackPower[4] = { 36, 19, 23, 80 };
+const int CheckPower[4]  = { 74, 45, 88, 89 };
 const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
 
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 17;
+const int Tempo = 18;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);
@@ -137,8 +137,8 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 36, 19, 23, 80 };
-const int CheckPower[4]  = { 74, 45, 88, 89 };
+const int AttackPower[4] = { 36, 22, 23, 78 };
+const int CheckPower[4]  = { 68, 44, 88, 92 };
 const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
 
 

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -137,8 +137,8 @@ const int Mobility[4][28] = {
 };
 
 // KingSafety [pt-2]
-const int AttackPower[4] = { 36, 19, 22, 72 };
-const int CheckPower[4]  = { 71, 39, 80, 74 };
+const int AttackPower[4] = { 35, 18, 23, 77 };
+const int CheckPower[4]  = { 74, 42, 90, 82 };
 const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
 
 

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6500))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 15200))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 26850))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6750))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 17200))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 28650))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,11 +40,11 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2560, 333 * depth - 285);
+    return MIN(2530, 310 * depth - 300);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(1900, 367 * depth - 252);
+    return -MIN(1770, 435 * depth - 205);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6750))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 17200))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 28650))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  7200))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16900))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 29000))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,11 +40,11 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2530, 310 * depth - 300);
+    return MIN(2545, 321 * depth - 295);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(1770, 435 * depth - 205);
+    return -MIN(1760, 460 * depth - 200);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/history.h
+++ b/src/history.h
@@ -30,9 +30,9 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  7200))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16900))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 29000))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  7180))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 28650))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -40,11 +40,11 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2545, 321 * depth - 295);
+    return MIN(2545, 315 * depth - 300);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(1760, 460 * depth - 200);
+    return -MIN(1700, 480 * depth - 205);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1380 * mp->depth);
+    SortMoves(list, -1340 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score > 14540 - 200 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -9935 + 200 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14300 - 180 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -10075 + 150 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1340 * mp->depth);
+    SortMoves(list, -1350 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14300 - 180 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -10075 + 150 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14435 - 190 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -10185 + 157 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1350 * mp->depth);
+    SortMoves(list, -1500 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14435 - 190 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -10185 + 157 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14350 - 197 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -10085 + 155 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.13 + log(depth) * log(moves) / 3.45, // capture
-            Reductions[1][depth][moves] = 1.30 + log(depth) * log(moves) / 2.80; // quiet
+            Reductions[0][depth][moves] = 0.19 + log(depth) * log(moves) / 3.37, // capture
+            Reductions[1][depth][moves] = 1.45 + log(depth) * log(moves) / 2.80; // quiet
 }
 
 // Checks whether a move was already searched in multi-pv mode
@@ -310,15 +310,15 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 78 * (depth - improving) - (ss-1)->histScore / 200 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 6950))
+        && eval - 88 * (depth - improving) - (ss-1)->histScore / 173 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7350))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->staticEval
-        && ss->staticEval >= beta + 146 - 20 * depth
-        && (ss-1)->histScore < 27150
+        && ss->staticEval >= beta + 157 - 20 * depth
+        && (ss-1)->histScore < 26500
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
         Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
@@ -363,7 +363,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             // Cut if the reduced depth search beats the threshold
             if (score >= probCutBeta)
-                return score - 176;
+                return score - 167;
         }
     }
 
@@ -396,7 +396,7 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
-            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9600;
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9500;
             Depth lmrDepth = depth - 1 - R;
 
             // Quiet late move pruning
@@ -408,7 +408,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -47 * depth : -72 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -44 * depth : -73 * depth))
                 continue;
         }
 
@@ -444,7 +444,7 @@ move_loop:
             // Singular - extend by 1 or 2 ply
             if (score < singularBeta) {
                 extension = 1;
-                if (!pvNode && score < singularBeta - 17 && ss->doubleExtensions <= 5)
+                if (!pvNode && score < singularBeta - 13 && ss->doubleExtensions <= 5)
                     extension = 2;
             // MultiCut - ttMove as well as at least one other move seem good enough to beat beta
             } else if (singularBeta >= beta)
@@ -476,7 +476,7 @@ skip_extensions:
             // Base reduction
             int r = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Adjust reduction by move history
-            r -= ss->histScore / 9600;
+            r -= ss->histScore / 9500;
             // Reduce less in pv nodes
             r -= pvNode;
             // Reduce less when improving
@@ -495,7 +495,7 @@ skip_extensions:
 
             // Re-search with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 49 + 16 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 40 + 16 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 

--- a/src/search.c
+++ b/src/search.c
@@ -47,7 +47,7 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.19 + log(depth) * log(moves) / 3.37, // capture
+            Reductions[0][depth][moves] = 0.25 + log(depth) * log(moves) / 3.33, // capture
             Reductions[1][depth][moves] = 1.45 + log(depth) * log(moves) / 2.80; // quiet
 }
 
@@ -310,15 +310,15 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 88 * (depth - improving) - (ss-1)->histScore / 173 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 7350))
+        && eval - 88 * (depth - improving) - (ss-1)->histScore / 165 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7600))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->staticEval
-        && ss->staticEval >= beta + 157 - 20 * depth
-        && (ss-1)->histScore < 26500
+        && ss->staticEval >= beta + 163 - 21 * depth
+        && (ss-1)->histScore < 27000
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
         Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
@@ -363,7 +363,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             // Cut if the reduced depth search beats the threshold
             if (score >= probCutBeta)
-                return score - 167;
+                return score - 160;
         }
     }
 
@@ -396,7 +396,7 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
-            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9500;
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9333;
             Depth lmrDepth = depth - 1 - R;
 
             // Quiet late move pruning
@@ -408,7 +408,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -44 * depth : -73 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -45 * depth : -73 * depth))
                 continue;
         }
 
@@ -495,7 +495,7 @@ skip_extensions:
 
             // Re-search with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 40 + 16 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 36 + 15 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 


### PR DESCRIPTION
Elo   | 4.29 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21624 W: 5807 L: 5540 D: 10277
Penta | [331, 2545, 4844, 2710, 382]
http://chess.grantnet.us/test/34629/

Elo   | 15.51 +- 7.13 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4394 W: 1158 L: 962 D: 2274
Penta | [18, 462, 1061, 618, 38]
http://chess.grantnet.us/test/34630/

Bench: 22405804