### PR TITLE
Add pawn structure history

### DIFF
--- a/src/threads.c
+++ b/src/threads.c
@@ -126,6 +126,7 @@ void ResetThreads() {
     for (int i = 0; i < threads->count; ++i)
         memset(threads[i].pawnCache,      0, sizeof(PawnCache)),
         memset(threads[i].history,        0, sizeof(threads[i].history)),
+        memset(threads[i].pawnHistory,    0, sizeof(threads[i].pawnHistory)),
         memset(threads[i].captureHistory, 0, sizeof(threads[i].captureHistory)),
         memset(threads[i].continuation,   0, sizeof(threads[i].continuation));
 }

--- a/src/threads.h
+++ b/src/threads.h
@@ -27,9 +27,14 @@
 
 #define SS_OFFSET 10
 #define MULTI_PV_MAX 64
+#define PAWN_HISTORY_SIZE 512
 
+INLINE int PawnStructure(const Position *pos) {
+    return pos->pawnKey & (PAWN_HISTORY_SIZE - 1);
+}
 
 typedef int16_t ButterflyHistory[COLOR_NB][64][64];
+typedef int16_t PawnHistory[PAWN_HISTORY_SIZE][PIECE_NB][64];
 typedef int16_t CaptureToHistory[PIECE_NB][64][TYPE_NB];
 typedef int16_t PieceToHistory[PIECE_NB][64];
 typedef PieceToHistory ContinuationHistory[PIECE_NB][64];
@@ -68,6 +73,7 @@ typedef struct Thread {
     Position pos;
     PawnCache pawnCache;
     ButterflyHistory history;
+    PawnHistory pawnHistory;
     CaptureToHistory captureHistory;
     ContinuationHistory continuation[2][2];
 


### PR DESCRIPTION
Elo   | 4.30 +- 3.35 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21672 W: 5826 L: 5558 D: 10288
Penta | [339, 2546, 4823, 2764, 364]
http://chess.grantnet.us/test/34696/

Elo   | 1.89 +- 1.92 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 59734 W: 14432 L: 14107 D: 31195
Penta | [378, 7041, 14763, 7248, 437]
http://chess.grantnet.us/test/34702/

Bench: 21514164