### PR TITLE
Give a bonus to pawn history of moves that cause a TT cut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -250,8 +250,10 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     if (!pvNode && ttHit && ttDepth >= depth && TTScoreIsMoreInformative(ttBound, ttScore, beta)) {
 
         // Give a history bonus to quiet tt moves that causes a cutoff
-        if (ttScore >= beta && moveIsQuiet(ttMove))
+        if (ttScore >= beta && moveIsQuiet(ttMove)) {
             QuietHistoryUpdate(ttMove, Bonus(depth));
+            PawnHistoryUpdate(ttMove, Bonus(depth));
+        }
 
         return ttScore;
     }


### PR DESCRIPTION
Elo   | 1.83 +- 1.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 78896 W: 20869 L: 20454 D: 37573
Penta | [1205, 9464, 17758, 9753, 1268]
http://chess.grantnet.us/test/34716/

Elo   | 1.17 +- 1.09 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 185070 W: 44541 L: 43920 D: 96609
Penta | [1259, 21981, 45468, 22534, 1293]
http://chess.grantnet.us/test/34726/

Bench: 21825554
