### PR TITLE
SPSA tune search, history updates

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -31,10 +31,10 @@
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  7180))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6880))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8192))
 #define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 28650))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 30000))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -42,11 +42,11 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2545, 315 * depth - 300);
+    return MIN(2645, 285 * depth - 305);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(1700, 480 * depth - 205);
+    return -MIN(1435, 455 * depth - 213);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1500 * mp->depth);
+    SortMoves(list, -1835 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14350 - 197 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -10085 + 155 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14600 - 270 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -10470 +  68 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;


### PR DESCRIPTION
Elo   | -2.83 +- 3.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | -2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19368 W: 5024 L: 5182 D: 9162
Penta | [312, 2473, 4268, 2323, 308]
http://chess.grantnet.us/test/34887/

Elo   | 3.41 +- 3.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 24736 W: 6083 L: 5840 D: 12813
Penta | [160, 2858, 6109, 3061, 180]
http://chess.grantnet.us/test/34874/

Bench: 23621947