### PR TITLE
Only count pawns in the center for bad pawns with bishops

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -290,7 +290,8 @@ INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const
         if (pt == BISHOP) {
             Bitboard bishopSquares   = (BB(sq) & BlackSquaresBB) ? BlackSquaresBB : ~BlackSquaresBB;
             Bitboard badPawns        = colorPieceBB(color, PAWN) & bishopSquares;
-            Bitboard blockedBadPawns = ShiftBB(pieceBB(ALL), down) & colorPieceBB(color, PAWN);
+            Bitboard centralFiles    = fileCBB | fileDBB | fileEBB | fileFBB;
+            Bitboard blockedBadPawns = ShiftBB(pieceBB(ALL), down) & colorPieceBB(color, PAWN) & centralFiles;
 
             int count = PopCount(badPawns) * PopCount(blockedBadPawns);
             eval += count * BishopBadP;


### PR DESCRIPTION
Elo   | 2.38 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 53310 W: 14695 L: 14330 D: 24285
Penta | [987, 6431, 11527, 6650, 1060]
http://chess.grantnet.us/test/38169/

Elo   | 2.67 +- 2.00 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 36584 W: 9157 L: 8876 D: 18551
Penta | [324, 4296, 8797, 4525, 350]
http://chess.grantnet.us/test/38198/

Bench: 24215677
