### PR TITLE
Add eval correction based on pawn structure eval history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -36,7 +36,7 @@
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8192))
 #define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
 #define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 30000))
-#define CorrectionHistoryUpdate(bonus) (HistoryBonus(CorrectionEntry(), bonus, 1024))
+#define CorrectionHistoryUpdate(bonus)         (HistoryBonus(CorrectionEntry(),       bonus,  1024))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {

--- a/src/history.h
+++ b/src/history.h
@@ -30,11 +30,13 @@
 #define PawnEntry(move)         (&thread->pawnHistory[PawnStructure(&thread->pos)][piece(move)][toSq(move)])
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
+#define CorrectionEntry()       (&thread->correctionHistory[thread->pos.stm][CorrectionIndex(&thread->pos)])
 
 #define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6880))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8192))
 #define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
 #define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 30000))
+#define CorrectionHistoryUpdate(bonus) (HistoryBonus(CorrectionEntry(), bonus, 1024))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -47,6 +49,10 @@ INLINE int Bonus(Depth depth) {
 
 INLINE int Malus(Depth depth) {
     return -MIN(1435, 455 * depth - 213);
+}
+
+INLINE int CorrectionBonus(int score, int eval, Depth depth) {
+    return CLAMP((score - eval) * depth / 8, -1024 / 4, 1024 / 4);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {
@@ -99,6 +105,10 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
     // Penalize noisy moves that failed to produce a cut
     for (Move *move = noisys; move < noisys + nCount; ++move)
         NoisyHistoryUpdate(*move, malus);
+}
+
+INLINE void UpdateCorrectionHistory(Thread *thread, int bestScore, int eval, Depth depth) {
+    CorrectionHistoryUpdate(CorrectionBonus(bestScore, eval, depth));
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {

--- a/src/search.c
+++ b/src/search.c
@@ -577,8 +577,9 @@ skip_extensions:
                      : pvNode && bestMove ? BOUND_EXACT
                                           : BOUND_UPPER);
 
+    // Update correction history
     if (   !inCheck
-        && (!bestMove || !capturing(bestMove))
+        && !capturing(bestMove)
         && !(bestScore >= beta && bestScore <= ss->staticEval)
         && !(!bestMove && bestScore >= ss->staticEval))
         UpdateCorrectionHistory(thread, bestScore, ss->staticEval, depth);

--- a/src/search.c
+++ b/src/search.c
@@ -59,6 +59,10 @@ static bool AlreadySearchedMultiPV(Thread *thread, Move move) {
     return false;
 }
 
+static int ScoreToEval(int score) {
+    return CLAMP(score, -TBWIN_IN_MAX + 1, TBWIN_IN_MAX - 1);
+}
+
 // Small positive score with some random variance
 static int DrawScore(Position *pos) {
     return 8 - (pos->nodes & 0x7);
@@ -106,6 +110,9 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     eval = history(-1).move == NOMOVE ? -(ss-1)->staticEval + 2 * Tempo
          : ttEval != NOSCORE          ? ttEval
                                       : EvalPosition(pos, thread->pawnCache);
+
+    int unadjustedEval = eval;
+    eval = ScoreToEval(eval + *CorrectionEntry() / 32);
 
     // If we are at max depth, return static eval
     if (ss->ply >= MAX_PLY)
@@ -183,7 +190,7 @@ search:
     if (inCheck && bestScore == -INFINITE)
         return -MATE + ss->ply;
 
-    StoreTTEntry(tte, pos->key, bestMove, ScoreToTT(bestScore, ss->ply), eval, 0,
+    StoreTTEntry(tte, pos->key, bestMove, ScoreToTT(bestScore, ss->ply), unadjustedEval, 0,
                  bestScore >= beta ? BOUND_LOWER : BOUND_UPPER);
 
     return bestScore;
@@ -290,6 +297,9 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
                                : lastMoveNullMove  ? -(ss-1)->staticEval + 2 * Tempo
                                : ttEval != NOSCORE ? ttEval
                                                    : EvalPosition(pos, thread->pawnCache);
+
+    int unadjustedEval = eval;
+    ss->staticEval = eval = ScoreToEval(eval + *CorrectionEntry() / 32);
 
     // Use ttScore as eval if it is more informative
     if (ttScore != NOSCORE && TTScoreIsMoreInformative(ttBound, ttScore, eval))
@@ -562,10 +572,16 @@ skip_extensions:
 
     // Store in TT
     if (!ss->excluded && (!root || !thread->multiPV))
-        StoreTTEntry(tte, pos->key, bestMove, ScoreToTT(bestScore, ss->ply), ss->staticEval, depth,
+        StoreTTEntry(tte, pos->key, bestMove, ScoreToTT(bestScore, ss->ply), unadjustedEval, depth,
                        bestScore >= beta  ? BOUND_LOWER
                      : pvNode && bestMove ? BOUND_EXACT
                                           : BOUND_UPPER);
+
+    if (   !inCheck
+        && (!bestMove || !capturing(bestMove))
+        && !(bestScore >= beta && bestScore <= ss->staticEval)
+        && !(!bestMove && bestScore >= ss->staticEval))
+        UpdateCorrectionHistory(thread, bestScore, ss->staticEval, depth);
 
     return bestScore;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -128,7 +128,8 @@ void ResetThreads() {
         memset(Threads[i].history,        0, sizeof(Threads[i].history)),
         memset(Threads[i].pawnHistory,    0, sizeof(Threads[i].pawnHistory)),
         memset(Threads[i].captureHistory, 0, sizeof(Threads[i].captureHistory)),
-        memset(Threads[i].continuation,   0, sizeof(Threads[i].continuation));
+        memset(Threads[i].continuation,   0, sizeof(Threads[i].continuation)),
+        memset(Threads[i].correctionHistory, 0, sizeof(Threads[i].correctionHistory));
 }
 
 // Run the given function once in each thread

--- a/src/threads.h
+++ b/src/threads.h
@@ -28,9 +28,14 @@
 #define SS_OFFSET 10
 #define MULTI_PV_MAX 64
 #define PAWN_HISTORY_SIZE 512
+#define CORRECTION_HISTORY_SIZE 16384
 
 INLINE int PawnStructure(const Position *pos) {
     return pos->pawnKey & (PAWN_HISTORY_SIZE - 1);
+}
+
+INLINE int CorrectionIndex(const Position *pos) {
+    return pos->pawnKey & (CORRECTION_HISTORY_SIZE - 1);
 }
 
 typedef int16_t ButterflyHistory[COLOR_NB][64][64];
@@ -38,6 +43,7 @@ typedef int16_t PawnHistory[PAWN_HISTORY_SIZE][PIECE_NB][64];
 typedef int16_t CaptureToHistory[PIECE_NB][64][TYPE_NB];
 typedef int16_t PieceToHistory[PIECE_NB][64];
 typedef PieceToHistory ContinuationHistory[PIECE_NB][64];
+typedef int16_t CorrectionHistory[2][CORRECTION_HISTORY_SIZE];
 
 
 typedef struct {
@@ -76,6 +82,7 @@ typedef struct Thread {
     PawnHistory pawnHistory;
     CaptureToHistory captureHistory;
     ContinuationHistory continuation[2][2];
+    CorrectionHistory correctionHistory;
 
     int index;
     int count;


### PR DESCRIPTION
Original idea from Caissa, implementation mainly inspired by Stockfish.

Elo   | 4.87 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19484 W: 5549 L: 5276 D: 8659
Penta | [365, 2281, 4245, 2418, 433]
http://chess.grantnet.us/test/38269/

Elo   | 11.70 +- 4.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6092 W: 1632 L: 1427 D: 3033
Penta | [37, 655, 1482, 810, 62]
http://chess.grantnet.us/test/38270/

Bench: 24198920
