### PR TITLE
Add eval correction based on material eval history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -30,13 +30,15 @@
 #define PawnEntry(move)         (&thread->pawnHistory[PawnStructure(&thread->pos)][piece(move)][toSq(move)])
 #define NoisyEntry(move)        (&thread->captureHistory[piece(move)][toSq(move)][PieceTypeOf(capturing(move))])
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
-#define CorrectionEntry()       (&thread->correctionHistory[thread->pos.stm][CorrectionIndex(&thread->pos)])
+#define PawnCorrectionEntry()   (&thread->pawnCorrectionHistory[thread->pos.stm][PawnCorrectionIndex(&thread->pos)])
+#define MaterialCorrectionEntry() (&thread->materialCorrectionHistory[thread->pos.stm][MaterialCorrectionIndex(&thread->pos)])
 
 #define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6880))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8192))
 #define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
 #define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 30000))
-#define CorrectionHistoryUpdate(bonus)         (HistoryBonus(CorrectionEntry(),       bonus,  1024))
+#define PawnCorrectionHistoryUpdate(bonus)     (HistoryBonus(PawnCorrectionEntry(),   bonus,  1024))
+#define MaterialCorrectionHistoryUpdate(bonus) (HistoryBonus(MaterialCorrectionEntry(), bonus,  1024))
 
 
 INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
@@ -108,7 +110,9 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
 }
 
 INLINE void UpdateCorrectionHistory(Thread *thread, int bestScore, int eval, Depth depth) {
-    CorrectionHistoryUpdate(CorrectionBonus(bestScore, eval, depth));
+    int bonus = CorrectionBonus(bestScore, eval, depth);
+    PawnCorrectionHistoryUpdate(bonus);
+    MaterialCorrectionHistoryUpdate(bonus);
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
@@ -128,5 +132,6 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread) {
-    return *CorrectionEntry() / 32;
+    return  *PawnCorrectionEntry() / 32
+          + *MaterialCorrectionEntry() / 32;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -129,7 +129,8 @@ void ResetThreads() {
         memset(Threads[i].pawnHistory,    0, sizeof(Threads[i].pawnHistory)),
         memset(Threads[i].captureHistory, 0, sizeof(Threads[i].captureHistory)),
         memset(Threads[i].continuation,   0, sizeof(Threads[i].continuation)),
-        memset(Threads[i].correctionHistory, 0, sizeof(Threads[i].correctionHistory));
+        memset(Threads[i].pawnCorrectionHistory, 0, sizeof(Threads[i].pawnCorrectionHistory)),
+        memset(Threads[i].materialCorrectionHistory, 0, sizeof(Threads[i].materialCorrectionHistory));
 }
 
 // Run the given function once in each thread

--- a/src/threads.h
+++ b/src/threads.h
@@ -34,8 +34,12 @@ INLINE int PawnStructure(const Position *pos) {
     return pos->pawnKey & (PAWN_HISTORY_SIZE - 1);
 }
 
-INLINE int CorrectionIndex(const Position *pos) {
+INLINE int PawnCorrectionIndex(const Position *pos) {
     return pos->pawnKey & (CORRECTION_HISTORY_SIZE - 1);
+}
+
+INLINE int MaterialCorrectionIndex(const Position *pos) {
+    return pos->materialKey & (CORRECTION_HISTORY_SIZE - 1);
 }
 
 typedef int16_t ButterflyHistory[COLOR_NB][64][64];
@@ -82,7 +86,8 @@ typedef struct Thread {
     PawnHistory pawnHistory;
     CaptureToHistory captureHistory;
     ContinuationHistory continuation[2][2];
-    CorrectionHistory correctionHistory;
+    CorrectionHistory pawnCorrectionHistory;
+    CorrectionHistory materialCorrectionHistory;
 
     int index;
     int count;


### PR DESCRIPTION
Original idea from Caissa, implementation mainly inspired by Stockfish.

Elo   | 3.02 +- 2.23 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [0.00, 3.00]
Games | N: 37948 W: 10612 L: 10282 D: 17054
Penta | [724, 4518, 8282, 4604, 846]
http://chess.grantnet.us/test/38271/

Elo   | 7.88 +- 3.89 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9520 W: 2477 L: 2261 D: 4782
Penta | [49, 1124, 2251, 1234, 102]
http://chess.grantnet.us/test/38277/

Bench: 26539847
