### PR TITLE
Simplify down to only 1 killer move

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -74,11 +74,8 @@ INLINE void UpdateQuietHistory(Thread *thread, Stack *ss, Move bestMove, Depth d
     int bonus = Bonus(depth);
     int malus = Malus(depth);
 
-    // Update killers
-    if (ss->killers[0] != bestMove) {
-        ss->killers[1] = ss->killers[0];
-        ss->killers[0] = bestMove;
-    }
+    // Update killer
+    ss->killer = bestMove;
 
     // Bonus to the move that caused the beta cutoff
     if (depth > 2) {

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -33,7 +33,7 @@ static Move PickNextMove(MovePicker *mp) {
     Move bestMove = list->moves[list->next++].move;
 
     // Avoid returning the TT or killer moves again
-    if (bestMove == mp->ttMove || bestMove == mp->kill1 || bestMove == mp->kill2)
+    if (bestMove == mp->ttMove || bestMove == mp->killer)
         return PickNextMove(mp);
 
     return bestMove;
@@ -105,18 +105,11 @@ Move NextMove(MovePicker *mp) {
             mp->stage++;
 
             // fall through
-        case KILLER1:
+        case KILLER:
             mp->stage++;
-            if (   mp->kill1 != mp->ttMove
-                && MoveIsPseudoLegal(pos, mp->kill1))
-                return mp->kill1;
-
-            // fall through
-        case KILLER2:
-            mp->stage++;
-            if (   mp->kill2 != mp->ttMove
-                && MoveIsPseudoLegal(pos, mp->kill2))
-                return mp->kill2;
+            if (   mp->killer != mp->ttMove
+                && MoveIsPseudoLegal(pos, mp->killer))
+                return mp->killer;
 
             // fall through
         case GEN_QUIET:
@@ -147,15 +140,14 @@ Move NextMove(MovePicker *mp) {
 }
 
 // Init normal movepicker
-void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move kill1, Move kill2) {
+void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move killer) {
     mp->list.count = mp->list.next = 0;
     mp->thread    = thread;
     mp->ss        = ss;
     mp->ttMove    = ttMove;
     mp->stage     = ttMove ? TTMOVE : GEN_NOISY;
     mp->depth     = depth;
-    mp->kill1     = kill1;
-    mp->kill2     = kill2;
+    mp->killer    = killer;
     mp->bads      = 0;
     mp->threshold = 0;
     mp->onlyNoisy = false;
@@ -163,7 +155,7 @@ void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move t
 
 // Init noisy movepicker
 void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss, Move ttMove) {
-    InitNormalMP(mp, thread, ss, 0, ttMove, NOMOVE, NOMOVE);
+    InitNormalMP(mp, thread, ss, 0, ttMove, NOMOVE);
     mp->onlyNoisy = true;
 }
 

--- a/src/movepicker.h
+++ b/src/movepicker.h
@@ -22,7 +22,7 @@
 
 
 typedef enum MPStage {
-    TTMOVE, GEN_NOISY, NOISY_GOOD, KILLER1, KILLER2, GEN_QUIET, QUIET, NOISY_BAD
+    TTMOVE, GEN_NOISY, NOISY_GOOD, KILLER, GEN_QUIET, QUIET, NOISY_BAD
 } MPStage;
 
 typedef struct MovePicker {
@@ -31,7 +31,7 @@ typedef struct MovePicker {
     MoveList list;
     MPStage stage;
     Depth depth;
-    Move ttMove, kill1, kill2;
+    Move ttMove, killer;
     int bads;
     int threshold;
     bool onlyNoisy;
@@ -39,6 +39,6 @@ typedef struct MovePicker {
 
 
 Move NextMove(MovePicker *mp);
-void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move kill1, Move kill2);
+void InitNormalMP(MovePicker *mp, Thread *thread, Stack *ss, Depth depth, Move ttMove, Move killer);
 void InitNoisyMP(MovePicker *mp, Thread *thread, Stack *ss, Move ttMove);
 void InitProbcutMP(MovePicker *mp, Thread *thread, Stack *ss, int threshold);

--- a/src/search.c
+++ b/src/search.c
@@ -135,7 +135,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
 moveloop:
 
     if (!inCheck) InitNoisyMP(&mp, thread, ss, ttMove);
-    else          InitNormalMP(&mp, thread, ss, 0, ttMove, NOMOVE, NOMOVE);
+    else          InitNormalMP(&mp, thread, ss, 0, ttMove, NOMOVE);
 
     // Move loop
     Move bestMove = NOMOVE;
@@ -382,7 +382,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
 move_loop:
 
-    InitNormalMP(&mp, thread, ss, depth, ttMove, ss->killers[0], ss->killers[1]);
+    InitNormalMP(&mp, thread, ss, depth, ttMove, ss->killer);
 
     Move quiets[32];
     Move noisys[32];

--- a/src/threads.h
+++ b/src/threads.h
@@ -45,7 +45,7 @@ typedef struct {
     int doubleExtensions;
     Depth ply;
     Move excluded;
-    Move killers[2];
+    Move killer;
     PV pv;
 } Stack;
 


### PR DESCRIPTION
Elo   | 1.64 +- 2.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 29006 W: 7952 L: 7815 D: 13239
Penta | [585, 3429, 6284, 3674, 531]
http://chess.grantnet.us/test/38358/

Elo   | 2.25 +- 2.60 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 21662 W: 5474 L: 5334 D: 10854
Penta | [172, 2633, 5107, 2721, 198]
http://chess.grantnet.us/test/38363/

Bench: 23301226
