### PR TITLE
Guard against using TB and mate scores as eval

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -311,7 +311,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     ss->staticEval = eval = CorrectEval(thread, eval);
 
     // Use ttScore as eval if it is more informative
-    if (ttScore != NOSCORE && TTScoreIsMoreInformative(ttBound, ttScore, eval))
+    if (abs(ttScore) < TBWIN_IN_MAX && TTScoreIsMoreInformative(ttBound, ttScore, eval))
         eval = ttScore;
 
     // Improving if not in check, and current eval is higher than 2 plies ago


### PR DESCRIPTION
Elo   | -0.38 +- 1.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 134820 W: 36505 L: 36654 D: 61661
Penta | [2445, 16374, 29890, 16287, 2414]
http://chess.grantnet.us/test/38360/

Bench: 25382999