### PR TITLE
Return exact terminal scores from probcut

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -382,9 +382,9 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
             TakeMove(pos);
 
-            // Cut if the reduced depth search beats the threshold
+            // Cut if the reduced depth search beats the threshold, terminal scores are exact
             if (score >= probCutBeta)
-                return score - 160;
+                return score < TBWIN_IN_MAX ? score - 160 : score;
         }
     }
 


### PR DESCRIPTION
While a normal score found through probcut is less reliable due to the reduced depth, a terminal score found through probcut is proven despite reduced depth.

Elo   | 1.24 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 33400 W: 9206 L: 9087 D: 15107
Penta | [531, 3852, 7851, 3899, 567]
http://chess.grantnet.us/test/38370/

Bench: 25382999