### PR TITLE
SPSA tune search and history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -33,12 +33,12 @@
 #define PawnCorrEntry()         (&thread->pawnCorrHistory[thread->pos.stm][PawnCorrIndex(&thread->pos)])
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6444))
-#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8650))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 15200))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 26250))
-#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1365))
-#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1127))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5650))
+#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8250))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 25500))
+#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1430))
+#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1100))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -51,15 +51,15 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2615, 273 * depth - 289);
+    return MIN(2620, 280 * depth - 306);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(1012, 535 * depth - 168);
+    return -MIN(975, 537 * depth - 161);
 }
 
 INLINE int CorrectionBonus(int score, int eval, Depth depth) {
-    return CLAMP((score - eval) * depth / 5, -246, 230);
+    return CLAMP((score - eval) * depth / 4, -215, 237);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {
@@ -134,6 +134,6 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread) {
-    return  *PawnCorrEntry() / 28
+    return  *PawnCorrEntry() / 23
           + *MatCorrEntry() / 22;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -33,12 +33,12 @@
 #define PawnCorrEntry()         (&thread->pawnCorrHistory[thread->pos.stm][PawnCorrIndex(&thread->pos)])
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6666))
-#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  7250))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 15400))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 27000))
-#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1270))
-#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1200))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  6444))
+#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8650))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 15200))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 26250))
+#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1365))
+#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1127))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -51,15 +51,15 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2620, 269 * depth - 292);
+    return MIN(2615, 273 * depth - 289);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(1075, 489 * depth - 220);
+    return -MIN(1012, 535 * depth - 168);
 }
 
 INLINE int CorrectionBonus(int score, int eval, Depth depth) {
-    return CLAMP((score - eval) * depth / 5, -230, 220);
+    return CLAMP((score - eval) * depth / 5, -246, 230);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {
@@ -134,6 +134,6 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread) {
-    return  *PawnCorrEntry() / 32
-          + *MatCorrEntry() / 32;
+    return  *PawnCorrEntry() / 28
+          + *MatCorrEntry() / 22;
 }

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -888 * mp->depth);
+    SortMoves(list, -660 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14750 - 285 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -11000 +   1 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14900 - 295 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -11200 -  23 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1337 * mp->depth);
+    SortMoves(list, -888 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14400 - 297 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -10730 +  30 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14750 - 285 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -11000 +   1 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.38 + log(depth) * log(moves) / 2.93, // capture
-            Reductions[1][depth][moves] = 1.82 + log(depth) * log(moves) / 2.68; // quiet
+            Reductions[0][depth][moves] = 0.43 + log(depth) * log(moves) / 3.31, // capture
+            Reductions[1][depth][moves] = 1.86 + log(depth) * log(moves) / 2.70; // quiet
 }
 
 // Checks whether a move was already searched in multi-pv mode
@@ -62,8 +62,8 @@ static bool AlreadySearchedMultiPV(Thread *thread, Move move) {
 // Correct the evaluation based on historic differences between eval and final score
 static int CorrectEval(Thread *thread, int eval, int rule50) {
     int correctedEval = eval + GetCorrectionHistory(thread);
-    if (rule50 > 12)
-        correctedEval *= (256 - rule50) / 256.0;
+    if (rule50 > 9)
+        correctedEval *= (265 - rule50) / 265.0;
     return CLAMP(correctedEval, -TBWIN_IN_MAX + 1, TBWIN_IN_MAX - 1);
 }
 
@@ -133,7 +133,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     if (eval > alpha)
         alpha = eval;
 
-    futility = eval + 75;
+    futility = eval + 82;
     bestScore = eval;
 
 moveloop:
@@ -334,18 +334,18 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 74 * (depth - improving) - (ss-1)->histScore / 120 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 7600))
+        && eval - 75 * (depth - improving) - (ss-1)->histScore / 111 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7850))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->staticEval
-        && ss->staticEval >= beta + 168 - 23 * depth
-        && (ss-1)->histScore < 26500
+        && ss->staticEval >= beta + 152 - 22 * depth
+        && (ss-1)->histScore < 24750
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 256);
+        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 249);
 
         ss->continuation = &thread->continuation[0][0][EMPTY][0];
 
@@ -420,7 +420,7 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
-            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 10000;
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9500;
             Depth lmrDepth = depth - 1 - R;
 
             // Quiet late move pruning
@@ -432,7 +432,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -48 * depth : -66 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -48 * depth : -61 * depth))
                 continue;
         }
 
@@ -468,7 +468,7 @@ move_loop:
             // Singular - extend by 1 or 2 ply
             if (score < singularBeta) {
                 extension = 1;
-                if (!pvNode && score < singularBeta - 5 && ss->doubleExtensions <= 5)
+                if (!pvNode && score < singularBeta - 3 && ss->doubleExtensions <= 5)
                     extension = 2;
             // MultiCut - ttMove as well as at least one other move seem good enough to beat beta
             } else if (singularBeta >= beta)
@@ -500,7 +500,7 @@ skip_extensions:
             // Base reduction
             int r = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Adjust reduction by move history
-            r -= ss->histScore / 9500;
+            r -= ss->histScore / 10250;
             // Reduce less in pv nodes
             r -= pvNode;
             // Reduce less when improving
@@ -519,7 +519,7 @@ skip_extensions:
 
             // Re-search with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 22 + 7 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 20 + 7 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 


### PR DESCRIPTION
Elo   | 6.20 +- 3.56 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14520 W: 4098 L: 3839 D: 6583
Penta | [251, 1683, 3204, 1800, 322]
http://chess.grantnet.us/test/38430/

Elo   | 5.61 +- 3.22 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 13880 W: 3598 L: 3374 D: 6908
Penta | [112, 1575, 3362, 1759, 132]
http://chess.grantnet.us/test/38424/

Bench: 22947774