### PR TITLE
Add eval correction based on continuation history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -137,7 +137,7 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
-    return  *PawnCorrEntry() / 23
-          + *MatCorrEntry() / 22
-          + *ContCorrEntry() / 32;
+    return  *PawnCorrEntry() / 27
+          + *MatCorrEntry() / 26
+          + *ContCorrEntry() / 40;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -32,6 +32,7 @@
 #define ContEntry(offset, move) (&(*(ss-offset)->continuation)[piece(move)][toSq(move)])
 #define PawnCorrEntry()         (&thread->pawnCorrHistory[thread->pos.stm][PawnCorrIndex(&thread->pos)])
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
+#define ContCorrEntry()         (&(*(ss-2)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
 #define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5650))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8250))
@@ -39,6 +40,7 @@
 #define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 25500))
 #define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1430))
 #define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1100))
+#define ContCorrHistoryUpdate(bonus)           (HistoryBonus(ContCorrEntry(),         bonus,  1024))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -111,10 +113,11 @@ INLINE void UpdateHistory(Thread *thread, Stack *ss, Move bestMove, Depth depth,
         NoisyHistoryUpdate(*move, malus);
 }
 
-INLINE void UpdateCorrectionHistory(Thread *thread, int bestScore, int eval, Depth depth) {
+INLINE void UpdateCorrectionHistory(Thread *thread, Stack *ss, int bestScore, int eval, Depth depth) {
     int bonus = CorrectionBonus(bestScore, eval, depth);
     PawnCorrHistoryUpdate(bonus);
     MatCorrHistoryUpdate(bonus);
+    ContCorrHistoryUpdate(bonus);
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
@@ -133,7 +136,8 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
     return moveIsQuiet(move) ? GetQuietHistory(thread, ss, move) : GetCaptureHistory(thread, move);
 }
 
-INLINE int GetCorrectionHistory(const Thread *thread) {
+INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
     return  *PawnCorrEntry() / 23
-          + *MatCorrEntry() / 22;
+          + *MatCorrEntry() / 22
+          + *ContCorrEntry() / 32;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -94,7 +94,8 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
         for (Depth d = -4; d < 0; ++d)
-            (t->ss+SS_OFFSET+d)->continuation = &t->continuation[0][0][EMPTY][0];
+            (t->ss+SS_OFFSET+d)->continuation = &t->continuation[0][0][EMPTY][0],
+            (t->ss+SS_OFFSET+d)->contCorr = &t->contCorrHistory[EMPTY][0];
     }
 }
 
@@ -130,7 +131,8 @@ void ResetThreads() {
         memset(Threads[i].captureHistory,  0, sizeof(Threads[i].captureHistory)),
         memset(Threads[i].continuation,    0, sizeof(Threads[i].continuation)),
         memset(Threads[i].pawnCorrHistory, 0, sizeof(Threads[i].pawnCorrHistory)),
-        memset(Threads[i].matCorrHistory,  0, sizeof(Threads[i].matCorrHistory));
+        memset(Threads[i].matCorrHistory,  0, sizeof(Threads[i].matCorrHistory)),
+        memset(Threads[i].contCorrHistory, 0, sizeof(Threads[i].contCorrHistory));
 }
 
 // Run the given function once in each thread

--- a/src/threads.h
+++ b/src/threads.h
@@ -36,14 +36,17 @@ typedef int16_t CaptureToHistory[PIECE_NB][64][TYPE_NB];
 typedef int16_t PieceToHistory[PIECE_NB][64];
 typedef PieceToHistory ContinuationHistory[PIECE_NB][64];
 typedef int16_t CorrectionHistory[2][CORRECTION_HISTORY_SIZE];
+typedef PieceToHistory ContiuationCorrectionHistory[PIECE_NB][64];
 
 
 typedef struct {
     PieceToHistory *continuation;
+    PieceToHistory *contCorr;
     int staticEval;
     int histScore;
     int doubleExtensions;
     Depth ply;
+    Move move;
     Move excluded;
     Move killer;
     PV pv;
@@ -76,6 +79,7 @@ typedef struct Thread {
     ContinuationHistory continuation[2][2];
     CorrectionHistory pawnCorrHistory;
     CorrectionHistory matCorrHistory;
+    ContiuationCorrectionHistory contCorrHistory;
 
     int index;
     int count;


### PR DESCRIPTION
Elo   | 1.79 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 88644 W: 24280 L: 23823 D: 40541
Penta | [1632, 10637, 19381, 10986, 1686]
http://chess.grantnet.us/test/38443/

Elo   | 1.72 +- 1.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 74734 W: 18763 L: 18394 D: 37577
Penta | [610, 8865, 18046, 9238, 608]
http://chess.grantnet.us/test/38444/

Bench: 23375239