### PR TITLE
Add eval correction based on continuation history [-3][-1], and tweak TT replacement and singular extension beta

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -33,6 +33,7 @@
 #define PawnCorrEntry()         (&thread->pawnCorrHistory[thread->pos.stm][PawnCorrIndex(&thread->pos)])
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry()         (&(*(ss-2)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
+#define ContCorrEntry2()        (&(*(ss-3)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
 #define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5650))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8250))
@@ -41,6 +42,7 @@
 #define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1430))
 #define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1100))
 #define ContCorrHistoryUpdate(bonus)           (HistoryBonus(ContCorrEntry(),         bonus,  1024))
+#define ContCorrHistoryUpdate2(bonus)          (HistoryBonus(ContCorrEntry2(),        bonus,  1024))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -118,6 +120,7 @@ INLINE void UpdateCorrectionHistory(Thread *thread, Stack *ss, int bestScore, in
     PawnCorrHistoryUpdate(bonus);
     MatCorrHistoryUpdate(bonus);
     ContCorrHistoryUpdate(bonus);
+    ContCorrHistoryUpdate2(bonus);
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
@@ -137,7 +140,8 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
-    return  *PawnCorrEntry() / 27
-          + *MatCorrEntry() / 26
-          + *ContCorrEntry() / 40;
+    return  *PawnCorrEntry() / 32
+          + *MatCorrEntry() / 32
+          + *ContCorrEntry() / 48
+          + *ContCorrEntry2() / 48;
 }

--- a/src/search.c
+++ b/src/search.c
@@ -470,7 +470,7 @@ move_loop:
             TakeMove(pos);
 
             // Search to reduced depth with a zero window a bit lower than ttScore
-            int singularBeta = ttScore - depth * 2;
+            int singularBeta = ttScore - depth * (2 - pvNode);
             ss->excluded = move;
             score = AlphaBeta(thread, ss, singularBeta-1, singularBeta, depth/2, cutnode);
             ss->excluded = NOMOVE;

--- a/src/transposition.c
+++ b/src/transposition.c
@@ -38,10 +38,8 @@ TTEntry* ProbeTT(const Key key, bool *ttHit) {
     TTEntry* first = GetTTBucket(key)->entries;
 
     for (TTEntry *entry = first; entry < first + BUCKET_SIZE; ++entry)
-        if (entry->key == (int32_t)key || EntryEmpty(entry)) {
-            entry->genBound = TT.generation | Bound(entry);
+        if (entry->key == (int32_t)key || EntryEmpty(entry))
             return *ttHit = !EntryEmpty(entry), entry;
-        }
 
     TTEntry *replace = first;
     for (TTEntry *entry = first + 1; entry < first + BUCKET_SIZE; ++entry)
@@ -62,7 +60,7 @@ void StoreTTEntry(TTEntry *tte, Key key, Move move, int score, int eval, Depth d
 
     // Store new data unless it would overwrite data about the same
     // position searched to a higher depth.
-    if ((int32_t)key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT)
+    if ((int32_t)key != tte->key || depth + 4 >= tte->depth || bound == BOUND_EXACT || Age(tte))
         tte->key   = key,
         tte->score = score,
         tte->eval  = eval,


### PR DESCRIPTION
Elo   | 2.95 +- 2.20 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 37080 W: 10197 L: 9882 D: 17001
Penta | [642, 4398, 8207, 4589, 704]
http://chess.grantnet.us/test/38471/

Elo   | 4.64 +- 2.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 17154 W: 4375 L: 4146 D: 8633
Penta | [131, 1922, 4250, 2135, 139]
http://chess.grantnet.us/test/38480/

Bench: 23040214