### PR TITLE
Add eval correction based on continuation history [-4][-1]

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -34,6 +34,7 @@
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry()         (&(*(ss-2)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 #define ContCorrEntry2()        (&(*(ss-3)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
+#define ContCorrEntry3()        (&(*(ss-4)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
 #define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5650))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8250))
@@ -43,6 +44,7 @@
 #define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1100))
 #define ContCorrHistoryUpdate(bonus)           (HistoryBonus(ContCorrEntry(),         bonus,  1024))
 #define ContCorrHistoryUpdate2(bonus)          (HistoryBonus(ContCorrEntry2(),        bonus,  1024))
+#define ContCorrHistoryUpdate3(bonus)          (HistoryBonus(ContCorrEntry3(),        bonus,  1024))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -121,6 +123,7 @@ INLINE void UpdateCorrectionHistory(Thread *thread, Stack *ss, int bestScore, in
     MatCorrHistoryUpdate(bonus);
     ContCorrHistoryUpdate(bonus);
     ContCorrHistoryUpdate2(bonus);
+    ContCorrHistoryUpdate3(bonus);
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
@@ -143,5 +146,6 @@ INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
     return  *PawnCorrEntry() / 32
           + *MatCorrEntry() / 32
           + *ContCorrEntry() / 48
-          + *ContCorrEntry2() / 48;
+          + *ContCorrEntry2() / 48
+          + *ContCorrEntry3() / 48;
 }


### PR DESCRIPTION
Elo   | 1.41 +- 1.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 156536 W: 42759 L: 42125 D: 71652
Penta | [2782, 18776, 34643, 19160, 2907]
http://chess.grantnet.us/test/38482/

Elo   | 4.14 +- 2.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 19460 W: 4913 L: 4681 D: 9866
Penta | [122, 2247, 4803, 2393, 165]
http://chess.grantnet.us/test/38486/

Bench: 22789257