### PR TITLE
SPSA tune search and history 

### DIFF
--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 17;
+const int Tempo = 18;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -51,7 +51,7 @@ const int PieceValue[2][PIECE_NB] = {
 };
 
 // Bonus for being the side to move
-const int Tempo = 18;
+const int Tempo = 17;
 
 // Misc bonuses and maluses
 const int PawnDoubled  = S(-11,-48);

--- a/src/history.h
+++ b/src/history.h
@@ -34,13 +34,13 @@
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry(offset)   (&(*(ss-offset)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5650))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5000))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8250))
 #define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 25500))
-#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1430))
-#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1100))
-#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1024))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 24000))
+#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1515))
+#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1145))
+#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1160))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -53,15 +53,15 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2620, 280 * depth - 306);
+    return MIN(2610, 269 * depth - 281);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(975, 537 * depth - 161);
+    return -MIN(935, 531 * depth - 177);
 }
 
 INLINE int CorrectionBonus(int score, int eval, Depth depth) {
-    return CLAMP((score - eval) * depth / 4, -215, 237);
+    return CLAMP((score - eval) * depth / 4, -197, 240);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {
@@ -139,9 +139,9 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
-    return  *PawnCorrEntry() / 32
-          + *MatCorrEntry() / 32
-          + *ContCorrEntry(2) / 48
-          + *ContCorrEntry(3) / 48
+    return  *PawnCorrEntry() / 30
+          + *MatCorrEntry() / 25
+          + *ContCorrEntry(2) / 51
+          + *ContCorrEntry(3) / 44
           + *ContCorrEntry(4) / 48;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -34,13 +34,13 @@
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry(offset)   (&(*(ss-offset)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5000))
-#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8250))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16384))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 24000))
-#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1515))
-#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1145))
-#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1160))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5425))
+#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8325))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 14750))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 23000))
+#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1475))
+#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1060))
+#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1150))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -53,11 +53,11 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2610, 269 * depth - 281);
+    return MIN(2535, 275 * depth - 318);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(935, 531 * depth - 177);
+    return -MIN(890, 538 * depth - 159);
 }
 
 INLINE int CorrectionBonus(int score, int eval, Depth depth) {
@@ -139,9 +139,9 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
-    return  *PawnCorrEntry() / 30
+    return  *PawnCorrEntry() / 26
           + *MatCorrEntry() / 25
-          + *ContCorrEntry(2) / 51
+          + *ContCorrEntry(2) / 50
           + *ContCorrEntry(3) / 44
-          + *ContCorrEntry(4) / 48;
+          + *ContCorrEntry(4) / 47;
 }

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -1000 * mp->depth);
+    SortMoves(list, -750 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14800 - 300 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -10675 -  17 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14270 - 296 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -10700 -  27 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -660 * mp->depth);
+    SortMoves(list, -1000 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14900 - 295 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -11200 -  23 * mp->depth && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  14800 - 300 * mp->depth
+                    || (mp->list.moves[mp->list.next-1].score > -10675 -  17 * mp->depth && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.32 + log(depth) * log(moves) / 3.38, // capture
-            Reductions[1][depth][moves] = 1.85 + log(depth) * log(moves) / 2.62; // quiet
+            Reductions[0][depth][moves] = 0.40 + log(depth) * log(moves) / 3.42, // capture
+            Reductions[1][depth][moves] = 1.83 + log(depth) * log(moves) / 2.54; // quiet
 }
 
 // Checks whether a move was already searched in multi-pv mode
@@ -140,7 +140,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     if (eval > alpha)
         alpha = eval;
 
-    futility = eval + 100;
+    futility = eval + 113;
     bestScore = eval;
 
 moveloop:
@@ -340,18 +340,18 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 76 * (depth - improving) - (ss-1)->histScore / 104 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 6900))
+        && eval - 76 * (depth - improving) - (ss-1)->histScore / 107 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7600))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->staticEval
-        && ss->staticEval >= beta + 139 - 19 * depth
-        && (ss-1)->histScore < 25000
+        && ss->staticEval >= beta + 145 - 17 * depth
+        && (ss-1)->histScore < 24400
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 215);
+        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 231);
 
         ss->move = NOMOVE;
         ss->continuation = &thread->continuation[0][0][EMPTY][0];
@@ -442,7 +442,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -54 * depth : -60 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -54 * depth : -62 * depth))
                 continue;
         }
 
@@ -512,7 +512,7 @@ skip_extensions:
             // Base reduction
             int r = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Adjust reduction by move history
-            r -= ss->histScore / 9650;
+            r -= ss->histScore / 9285;
             // Reduce less in pv nodes
             r -= pvNode;
             // Reduce less when improving
@@ -531,7 +531,7 @@ skip_extensions:
 
             // Re-search with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 6 + 7 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 5 + 7 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.40 + log(depth) * log(moves) / 3.40, // capture
-            Reductions[1][depth][moves] = 1.90 + log(depth) * log(moves) / 2.67; // quiet
+            Reductions[0][depth][moves] = 0.32 + log(depth) * log(moves) / 3.38, // capture
+            Reductions[1][depth][moves] = 1.85 + log(depth) * log(moves) / 2.62; // quiet
 }
 
 // Checks whether a move was already searched in multi-pv mode
@@ -140,7 +140,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     if (eval > alpha)
         alpha = eval;
 
-    futility = eval + 90;
+    futility = eval + 100;
     bestScore = eval;
 
 moveloop:
@@ -340,18 +340,18 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 78 * (depth - improving) - (ss-1)->histScore / 105 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 7400))
+        && eval - 76 * (depth - improving) - (ss-1)->histScore / 104 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 6900))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->staticEval
-        && ss->staticEval >= beta + 154 - 23 * depth
-        && (ss-1)->histScore < 24250
+        && ss->staticEval >= beta + 139 - 19 * depth
+        && (ss-1)->histScore < 25000
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 246);
+        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 215);
 
         ss->move = NOMOVE;
         ss->continuation = &thread->continuation[0][0][EMPTY][0];
@@ -430,7 +430,7 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
-            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9400;
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 8950;
             Depth lmrDepth = depth - 1 - R;
 
             // Quiet late move pruning
@@ -442,7 +442,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -50 * depth : -58 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -54 * depth : -60 * depth))
                 continue;
         }
 
@@ -512,7 +512,7 @@ skip_extensions:
             // Base reduction
             int r = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Adjust reduction by move history
-            r -= ss->histScore / 9888;
+            r -= ss->histScore / 9650;
             // Reduce less in pv nodes
             r -= pvNode;
             // Reduce less when improving
@@ -531,7 +531,7 @@ skip_extensions:
 
             // Re-search with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 17 + 7 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 6 + 7 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 


### PR DESCRIPTION
STC 10k vs master
Elo   | 2.36 +- 1.86 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 52918 W: 14493 L: 14134 D: 24291
Penta | [943, 6341, 11635, 6494, 1046]
http://chess.grantnet.us/test/38500/

LTC 5k vs master
Elo   | 4.46 +- 2.80 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18072 W: 4596 L: 4364 D: 9112
Penta | [131, 2101, 4359, 2295, 150]
http://chess.grantnet.us/test/38495/

LTC 10k vs 5k
Elo   | 1.91 +- 1.52 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 60484 W: 15163 L: 14831 D: 30490
Penta | [448, 7172, 14683, 7478, 461]
http://chess.grantnet.us/test/38498/

Bench: 27273376
