### PR TITLE
Simplify movepicker noisy move valuation formula

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -97,7 +97,7 @@ Move NextMove(MovePicker *mp) {
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
                 if (    mp->list.moves[mp->list.next-1].score >  14270 - 296 * mp->depth
-                    || (mp->list.moves[mp->list.next-1].score > -10700 -  27 * mp->depth && SEE(pos, move, mp->threshold)))
+                    || (mp->list.moves[mp->list.next-1].score > -11000 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;


### PR DESCRIPTION
Elo   | 3.83 +- 3.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 15606 W: 4341 L: 4169 D: 7096
Penta | [264, 1862, 3428, 1936, 313]
http://chess.grantnet.us/test/38502/

Elo   | 5.98 +- 3.81 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 9592 W: 2476 L: 2311 D: 4805
Penta | [64, 1084, 2353, 1213, 82]
http://chess.grantnet.us/test/38505/

Bench: 27857429
