### PR TITLE
Simplify SEE pruning to use same threshold for quiet and noisy moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -442,7 +442,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, quiet ? -54 * depth : -62 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, -60 * depth))
                 continue;
         }
 


### PR DESCRIPTION
Elo   | 1.44 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 31112 W: 8485 L: 8356 D: 14271
Penta | [538, 3731, 6918, 3802, 567]
http://chess.grantnet.us/test/38503/

Elo   | 0.46 +- 1.67 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 50914 W: 12704 L: 12637 D: 25573
Penta | [396, 6127, 12359, 6164, 411]
http://chess.grantnet.us/test/38506/

Bench: 30209528
