### PR TITLE
Add eval correction based on continuation history [-5][-1]

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -120,6 +120,7 @@ INLINE void UpdateCorrectionHistory(Thread *thread, Stack *ss, int bestScore, in
     ContCorrHistoryUpdate(2, bonus);
     ContCorrHistoryUpdate(3, bonus);
     ContCorrHistoryUpdate(4, bonus);
+    ContCorrHistoryUpdate(5, bonus);
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
@@ -143,5 +144,6 @@ INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
           + *MatCorrEntry() / 25
           + *ContCorrEntry(2) / 50
           + *ContCorrEntry(3) / 44
-          + *ContCorrEntry(4) / 47;
+          + *ContCorrEntry(4) / 47
+          + *ContCorrEntry(5) / 48;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -91,7 +91,7 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
         t->rootMoveCount = rootMoveCount;
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
-        for (Depth d = -4; d < 0; ++d)
+        for (Depth d = -5; d < 0; ++d)
             (t->ss+SS_OFFSET+d)->continuation = &t->continuation[0][0][EMPTY][0],
             (t->ss+SS_OFFSET+d)->contCorr = &t->contCorrHistory[EMPTY][0];
     }


### PR DESCRIPTION
Elo   | 1.90 +- 1.53 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 77364 W: 21201 L: 20779 D: 35384
Penta | [1342, 9377, 16952, 9539, 1472]
http://chess.grantnet.us/test/38501/

Elo   | 1.98 +- 1.57 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 56852 W: 14287 L: 13963 D: 28602
Penta | [405, 6796, 13767, 6986, 472]
http://chess.grantnet.us/test/38508/

Bench: 27491945
