### PR TITLE
Add eval correction based on continuation history [-6][-1] and [-7][-1]

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -121,6 +121,8 @@ INLINE void UpdateCorrectionHistory(Thread *thread, Stack *ss, int bestScore, in
     ContCorrHistoryUpdate(3, bonus);
     ContCorrHistoryUpdate(4, bonus);
     ContCorrHistoryUpdate(5, bonus);
+    ContCorrHistoryUpdate(6, bonus);
+    ContCorrHistoryUpdate(7, bonus);
 }
 
 INLINE int GetQuietHistory(const Thread *thread, Stack *ss, Move move) {
@@ -145,5 +147,7 @@ INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
           + *ContCorrEntry(2) / 50
           + *ContCorrEntry(3) / 44
           + *ContCorrEntry(4) / 47
-          + *ContCorrEntry(5) / 48;
+          + *ContCorrEntry(5) / 48
+          + *ContCorrEntry(6) / 48
+          + *ContCorrEntry(7) / 48;
 }

--- a/src/threads.c
+++ b/src/threads.c
@@ -91,7 +91,7 @@ void PrepareSearch(Position *pos, Move searchmoves[]) {
         t->rootMoveCount = rootMoveCount;
         for (Depth d = 0; d <= MAX_PLY; ++d)
             (t->ss+SS_OFFSET+d)->ply = d;
-        for (Depth d = -5; d < 0; ++d)
+        for (Depth d = -7; d < 0; ++d)
             (t->ss+SS_OFFSET+d)->continuation = &t->continuation[0][0][EMPTY][0],
             (t->ss+SS_OFFSET+d)->contCorr = &t->contCorrHistory[EMPTY][0];
     }


### PR DESCRIPTION
Elo   | 3.29 +- 2.39 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31726 W: 8816 L: 8516 D: 14394
Penta | [569, 3715, 7073, 3859, 647]
http://chess.grantnet.us/test/38511/

Elo   | 3.95 +- 2.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21038 W: 5434 L: 5195 D: 10409
Penta | [155, 2438, 5130, 2605, 191]
http://chess.grantnet.us/test/38512/

Bench: 25653283
