### PR TITLE
Use TT score as eval when it is more informative

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -126,6 +126,10 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, const int beta) {
     int unadjustedEval = eval;
     eval = CorrectEval(thread, ss, eval, pos->rule50);
 
+    // Use ttScore as eval if it is more informative
+    if (abs(ttScore) < TBWIN_IN_MAX && TTScoreIsMoreInformative(ttBound, ttScore, eval))
+        eval = ttScore;
+
     // If we are at max depth, return static eval
     if (ss->ply >= MAX_PLY)
         return eval;


### PR DESCRIPTION
Elo   | 2.42 +- 1.90 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 50044 W: 13792 L: 13443 D: 22809
Penta | [871, 6033, 10950, 6212, 956]
http://chess.grantnet.us/test/38515/

Elo   | 2.75 +- 2.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 34018 W: 8636 L: 8367 D: 17015
Penta | [258, 3962, 8324, 4183, 282]
http://chess.grantnet.us/test/38517/

Bench: 25107463
