### PR TITLE
Reduce depth of NMP searches more

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -355,7 +355,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         && (ss-1)->histScore < 24400
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 3 + depth / 4 + MIN(3, (eval - beta) / 231);
+        Depth reduction = 4 + depth / 5 + MIN(3, (eval - beta) / 231);
 
         ss->move = NOMOVE;
         ss->continuation = &thread->continuation[0][0][EMPTY][0];

--- a/src/search.c
+++ b/src/search.c
@@ -355,7 +355,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         && (ss-1)->histScore < 24400
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 4 + depth / 5 + MIN(3, (eval - beta) / 231);
+        Depth reduction = 4 + depth / 4 + MIN(3, (eval - beta) / 231);
 
         ss->move = NOMOVE;
         ss->continuation = &thread->continuation[0][0][EMPTY][0];


### PR DESCRIPTION
Elo   | 3.86 +- 2.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25486 W: 7128 L: 6845 D: 11513
Penta | [446, 3016, 5562, 3247, 472]
http://chess.grantnet.us/test/38535/

Elo   | 1.49 +- 1.20 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 98118 W: 24626 L: 24205 D: 49287
Penta | [793, 11557, 23866, 12122, 721]
http://chess.grantnet.us/test/38536/

Bench: 22540657
