### PR TITLE
Simplify QS futility pruning to only skip on promotions instead of advanced pawn pushes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -179,8 +179,7 @@ moveloop:
 
         // Futility pruning
         if (    futility + PieceValue[EG][capturing(move)] <= alpha
-            && !(   PieceTypeOf(piece(move)) == PAWN
-                 && RelativeRank(sideToMove, RankOf(toSq(move))) > RANK_6)) {
+            && !promotion(move)) {
             bestScore = MAX(bestScore, futility + PieceValue[EG][capturing(move)]);
             continue;
         }


### PR DESCRIPTION
Elo   | -0.28 +- 1.24 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.00 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 115826 W: 31239 L: 31334 D: 53253
Penta | [2064, 14132, 25617, 14035, 2065]
http://chess.grantnet.us/test/38542/

Elo   | 1.87 +- 2.41 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 24340 W: 6101 L: 5970 D: 12269
Penta | [176, 2935, 5837, 3026, 196]
http://chess.grantnet.us/test/38548/

Bench: 25023530