### PR TITLE
Simplify away depth dependence in NoisyGood formula

### DIFF
--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -96,7 +96,7 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  14270 - 296 * mp->depth
+                if (    mp->list.moves[mp->list.next-1].score >  12000
                     || (mp->list.moves[mp->list.next-1].score > -11000 && SEE(pos, move, mp->threshold)))
                     return move;
                 else


### PR DESCRIPTION
Elo   | 0.93 +- 2.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 39600 W: 10746 L: 10640 D: 18214
Penta | [681, 4778, 8779, 4878, 684]
http://chess.grantnet.us/test/38573/

Elo   | 0.18 +- 1.47 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 64768 W: 16013 L: 15979 D: 32776
Penta | [469, 7861, 15709, 7857, 488]
http://chess.grantnet.us/test/38576/

Bench: 26587524
