### PR TITLE
Adjust time spent based on how much of the search effort goes into the top move

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -740,7 +740,7 @@ static void *IterativeDeepening(void *voidThread) {
             Limits.optimalUsage = MIN(500, Limits.optimalUsage);
 
         double nodeRatio = (double)thread->rootMoves[0].nodes / (MAX(1, pos->nodes));
-        double timeRatio = CLAMP(1.5 - nodeRatio, 0.75, 1.00);
+        double timeRatio = CLAMP(1.25 - nodeRatio, 0.75, 1.00);
 
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit

--- a/src/search.c
+++ b/src/search.c
@@ -739,8 +739,8 @@ static void *IterativeDeepening(void *voidThread) {
         if (thread->rootMoveCount == 1 && Limits.timelimit && !Limits.movetime)
             Limits.optimalUsage = MIN(500, Limits.optimalUsage);
 
-        double nodeRatio = (double)thread->rootMoves[0].nodes / (MAX(1, pos->nodes));
-        double timeRatio = CLAMP(1.25 - nodeRatio, 0.75, 1.00);
+        double nodeRatio = 1.0 - (double)thread->rootMoves[0].nodes / (MAX(1, pos->nodes));
+        double timeRatio = 0.5 + 2.5 * nodeRatio;
 
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit

--- a/src/search.c
+++ b/src/search.c
@@ -440,6 +440,8 @@ move_loop:
 
         bool quiet = moveIsQuiet(move);
 
+        uint64_t startingNodes = pos->nodes;
+
         ss->histScore = GetHistory(thread, ss, move);
 
         // Misc pruning
@@ -579,6 +581,7 @@ skip_extensions:
 
             if (moveCount == 1 || score > alpha) {
                 rm->score = score;
+                rm->nodes += pos->nodes - startingNodes;
                 rm->pv.length = 1 + (ss+1)->pv.length;
                 rm->pv.line[0] = move;
                 memcpy(rm->pv.line+1, (ss+1)->pv.line, sizeof(Move) * (ss+1)->pv.length);
@@ -736,10 +739,13 @@ static void *IterativeDeepening(void *voidThread) {
         if (thread->rootMoveCount == 1 && Limits.timelimit && !Limits.movetime)
             Limits.optimalUsage = MIN(500, Limits.optimalUsage);
 
+        double nodeRatio = (double)thread->rootMoves[0].nodes / (MAX(1, pos->nodes));
+        double timeRatio = CLAMP(1.5 - nodeRatio, 0.75, 1.00);
+
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit
             && !thread->uncertain
-            && TimeSince(Limits.start) > Limits.optimalUsage)
+            && TimeSince(Limits.start) > Limits.optimalUsage * timeRatio)
             break;
 
         // Clear key history for seldepth calculation

--- a/src/threads.h
+++ b/src/threads.h
@@ -55,6 +55,7 @@ typedef struct {
 typedef struct RootMove {
     Move move;
     int score;
+    uint64_t nodes;
     PV pv;
 } RootMove;
 


### PR DESCRIPTION
Elo   | 11.37 +- 4.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7216 W: 2084 L: 1848 D: 3284
Penta | [102, 790, 1642, 918, 156]
http://chess.grantnet.us/test/38596/

Elo   | 11.76 +- 4.85 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 6178 W: 1638 L: 1429 D: 3111
Penta | [54, 657, 1451, 880, 47]
http://chess.grantnet.us/test/38598/

Bench: 26587524