### PR TITLE
Fix node counts for root moves

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -579,9 +579,10 @@ skip_extensions:
                 if (rm->move == move)
                     break;
 
+            rm->nodes += pos->nodes - startingNodes;
+
             if (moveCount == 1 || score > alpha) {
                 rm->score = score;
-                rm->nodes += pos->nodes - startingNodes;
                 rm->pv.length = 1 + (ss+1)->pv.length;
                 rm->pv.line[0] = move;
                 memcpy(rm->pv.line+1, (ss+1)->pv.line, sizeof(Move) * (ss+1)->pv.length);


### PR DESCRIPTION
Impacts the time management tweak that was added alongside this, but seems more or less neutral and tuning will surely fix it at a later point even if it is a loss right now.

Elo   | -0.58 +- 1.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 0.68 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 51172 W: 13920 L: 14006 D: 23246
Penta | [854, 6055, 11836, 6005, 836]
http://chess.grantnet.us/test/38611/

Bench: 26587524