### PR TITLE
Properly handle checkmate occuring exactly when reaching the 50 move rule

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -187,3 +187,10 @@ void GenLegalMoves(Position *pos, MoveList *list) {
     }
     pos->nodes = 0;
 }
+
+int LegalMoveCount(Position *pos) {
+    MoveList list;
+    list.count = list.next = 0;
+    GenLegalMoves(pos, &list);
+    return list.count;
+}

--- a/src/movegen.h
+++ b/src/movegen.h
@@ -38,3 +38,4 @@ void GenNoisyMoves(const Position *pos, MoveList *list);
 void GenQuietMoves(const Position *pos, MoveList *list);
 void GenAllMoves(const Position *pos, MoveList *list);
 void GenLegalMoves(Position *pos, MoveList *list);
+int LegalMoveCount(Position *pos);


### PR DESCRIPTION
Elo   | 0.18 +- 2.84 (95%)
Conf  | 8.0+0.08s Threads=1 Hash=32MB
Games | N: 21244 W: 5800 L: 5789 D: 9655
Penta | [369, 2456, 4950, 2489, 358]
http://chess.grantnet.us/test/38610/

Bench: 26587524
