### PR TITLE
SPSA tune search and history

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -34,13 +34,13 @@
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry(offset)   (&(*(ss-offset)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5425))
-#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8325))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 14750))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 23000))
-#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1475))
-#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1060))
-#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1150))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5150))
+#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8825))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16650))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 21345))
+#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1590))
+#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,   965))
+#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1145))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -53,15 +53,15 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2535, 275 * depth - 318);
+    return MIN(2490, 273 * depth - 325);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(890, 538 * depth - 159);
+    return -MIN(836, 523 * depth - 159);
 }
 
 INLINE int CorrectionBonus(int score, int eval, Depth depth) {
-    return CLAMP((score - eval) * depth / 4, -197, 240);
+    return CLAMP((score - eval) * depth / 4, -193, 253);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {
@@ -142,12 +142,12 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
-    return  *PawnCorrEntry() / 26
-          + *MatCorrEntry() / 25
-          + *ContCorrEntry(2) / 50
-          + *ContCorrEntry(3) / 44
-          + *ContCorrEntry(4) / 47
-          + *ContCorrEntry(5) / 48
-          + *ContCorrEntry(6) / 48
-          + *ContCorrEntry(7) / 48;
+    return  *PawnCorrEntry() / 20
+          + *MatCorrEntry() / 26
+          + *ContCorrEntry(2) / 46
+          + *ContCorrEntry(3) / 45
+          + *ContCorrEntry(4) / 46
+          + *ContCorrEntry(5) / 43
+          + *ContCorrEntry(6) / 45
+          + *ContCorrEntry(7) / 43;
 }

--- a/src/history.h
+++ b/src/history.h
@@ -34,13 +34,13 @@
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry(offset)   (&(*(ss-offset)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
 
-#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5150))
-#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  8825))
-#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16650))
-#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 21345))
-#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1590))
-#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,   965))
-#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1145))
+#define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5280))
+#define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  9275))
+#define NoisyHistoryUpdate(move, bonus)        (HistoryBonus(NoisyEntry(move),        bonus, 16000))
+#define ContHistoryUpdate(offset, move, bonus) (HistoryBonus(ContEntry(offset, move), bonus, 21250))
+#define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1662))
+#define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1077))
+#define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1220))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
@@ -53,15 +53,15 @@ INLINE void HistoryBonus(int16_t *cur, int bonus, int div) {
 }
 
 INLINE int Bonus(Depth depth) {
-    return MIN(2490, 273 * depth - 325);
+    return MIN(2410, 268 * depth - 310);
 }
 
 INLINE int Malus(Depth depth) {
-    return -MIN(836, 523 * depth - 159);
+    return -MIN(834, 531 * depth - 148);
 }
 
 INLINE int CorrectionBonus(int score, int eval, Depth depth) {
-    return CLAMP((score - eval) * depth / 4, -193, 253);
+    return CLAMP((score - eval) * depth / 4, -212, 254);
 }
 
 INLINE void UpdateContHistories(Stack *ss, Move move, int bonus) {
@@ -143,11 +143,11 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
     return  *PawnCorrEntry() / 20
-          + *MatCorrEntry() / 26
-          + *ContCorrEntry(2) / 46
-          + *ContCorrEntry(3) / 45
+          + *MatCorrEntry() / 29
+          + *ContCorrEntry(2) / 42
+          + *ContCorrEntry(3) / 44
           + *ContCorrEntry(4) / 46
-          + *ContCorrEntry(5) / 43
-          + *ContCorrEntry(6) / 45
-          + *ContCorrEntry(7) / 43;
+          + *ContCorrEntry(5) / 42
+          + *ContCorrEntry(6) / 47
+          + *ContCorrEntry(7) / 44;
 }

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -96,7 +96,7 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  12000
+                if (    mp->list.moves[mp->list.next-1].score >  11400
                     || (mp->list.moves[mp->list.next-1].score > -11000 && SEE(pos, move, mp->threshold)))
                     return move;
                 else

--- a/src/movepicker.c
+++ b/src/movepicker.c
@@ -69,7 +69,7 @@ static void ScoreMoves(MovePicker *mp, const int stage) {
                                : GetCaptureHistory(thread, move) + PieceValue[MG][capturing(move)];
     }
 
-    SortMoves(list, -750 * mp->depth);
+    SortMoves(list, -1000 * mp->depth);
 }
 
 // Returns the next move to try in a position
@@ -96,8 +96,8 @@ Move NextMove(MovePicker *mp) {
         case NOISY_GOOD:
             // Save seemingly bad noisy moves for later
             while ((move = PickNextMove(mp)))
-                if (    mp->list.moves[mp->list.next-1].score >  11400
-                    || (mp->list.moves[mp->list.next-1].score > -11000 && SEE(pos, move, mp->threshold)))
+                if (    mp->list.moves[mp->list.next-1].score >  11300
+                    || (mp->list.moves[mp->list.next-1].score > -11100 && SEE(pos, move, mp->threshold)))
                     return move;
                 else
                     mp->list.moves[mp->bads++].move = move;

--- a/src/search.c
+++ b/src/search.c
@@ -47,8 +47,8 @@ static int Reductions[2][32][32];
 CONSTR(1) InitReductions() {
     for (int depth = 1; depth < 32; ++depth)
         for (int moves = 1; moves < 32; ++moves)
-            Reductions[0][depth][moves] = 0.44 + log(depth) * log(moves) / 3.54, // capture
-            Reductions[1][depth][moves] = 1.92 + log(depth) * log(moves) / 2.49; // quiet
+            Reductions[0][depth][moves] = 0.48 + log(depth) * log(moves) / 3.43, // capture
+            Reductions[1][depth][moves] = 1.92 + log(depth) * log(moves) / 2.46; // quiet
 }
 
 // Checks whether a move was already searched in multi-pv mode
@@ -158,7 +158,7 @@ static int Quiescence(Thread *thread, Stack *ss, int alpha, int beta) {
     if (eval > alpha)
         alpha = eval;
 
-    futility = eval + 136;
+    futility = eval + 132;
     bestScore = eval;
 
 moveloop:
@@ -357,18 +357,18 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
     // Reverse Futility Pruning
     if (   depth < 7
         && eval >= beta
-        && eval - 68 * (depth - improving) - (ss-1)->histScore / 107 >= beta
-        && (!ttMove || GetHistory(thread, ss, ttMove) > 7500))
+        && eval - 76 * (depth - improving) - (ss-1)->histScore / 119 >= beta
+        && (!ttMove || GetHistory(thread, ss, ttMove) > 7600))
         return eval;
 
     // Null Move Pruning
     if (   eval >= beta
         && eval >= ss->staticEval
-        && ss->staticEval >= beta + 160 - 18 * depth
-        && (ss-1)->histScore < 26500
+        && ss->staticEval >= beta + 158 - 19 * depth
+        && (ss-1)->histScore < 26300
         && pos->nonPawnCount[sideToMove] > (depth > 8)) {
 
-        Depth reduction = 4 + depth / 4 + MIN(3, (eval - beta) / 230);
+        Depth reduction = 4 + depth / 4 + MIN(3, (eval - beta) / 224);
 
         ss->move = NOMOVE;
         ss->continuation = &thread->continuation[0][0][EMPTY][0];
@@ -449,7 +449,7 @@ move_loop:
             && thread->doPruning
             && bestScore > -TBWIN_IN_MAX) {
 
-            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9330;
+            int R = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)] - ss->histScore / 9050;
             Depth lmrDepth = depth - 1 - R;
 
             // Quiet late move pruning
@@ -461,7 +461,7 @@ move_loop:
                 continue;
 
             // SEE pruning
-            if (lmrDepth < 7 && !SEE(pos, move, -60 * depth))
+            if (lmrDepth < 7 && !SEE(pos, move, -63 * depth))
                 continue;
         }
 
@@ -531,7 +531,7 @@ skip_extensions:
             // Base reduction
             int r = Reductions[quiet][MIN(31, depth)][MIN(31, moveCount)];
             // Adjust reduction by move history
-            r -= ss->histScore / 10225;
+            r -= ss->histScore / 10135;
             // Reduce less in pv nodes
             r -= pvNode;
             // Reduce less when improving
@@ -550,7 +550,7 @@ skip_extensions:
 
             // Re-search with the same window at full depth if the reduced search failed high
             if (score > alpha && lmrDepth < newDepth) {
-                bool deeper = score > bestScore + 2 + 6 * (newDepth - lmrDepth);
+                bool deeper = score > bestScore + 1 + 7 * (newDepth - lmrDepth);
 
                 newDepth += deeper;
 
@@ -740,7 +740,7 @@ static void *IterativeDeepening(void *voidThread) {
             Limits.optimalUsage = MIN(500, Limits.optimalUsage);
 
         double nodeRatio = 1.0 - (double)thread->rootMoves[0].nodes / (MAX(1, pos->nodes));
-        double timeRatio = 0.52 + 2.87 * nodeRatio;
+        double timeRatio = 0.55 + 3.01 * nodeRatio;
 
         // If an iteration finishes after optimal time usage, stop the search
         if (   Limits.timelimit


### PR DESCRIPTION
5k vs master
Elo   | 4.88 +- 2.93 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 15870 W: 4019 L: 3796 D: 8055
Penta | [99, 1831, 3854, 2050, 101]
http://chess.grantnet.us/test/38607/

10k vs 5k
Elo   | 1.94 +- 1.54 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 57448 W: 14464 L: 14144 D: 28840
Penta | [370, 6759, 14185, 7001, 409]
http://chess.grantnet.us/test/38612/

Bench: 23851500
