### PR TITLE
Fix incorrect mateIn(ply)

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -52,7 +52,7 @@
 #define isTerminal(score) (isWin(score) || isLoss(score))
 
 #define matedIn(ply) (-MATE + (ply))
-#define mateIn(ply)  (MATE + (ply))
+#define mateIn(ply)  (MATE - (ply))
 
 typedef uint64_t Bitboard;
 typedef uint64_t Key;


### PR DESCRIPTION
Affects only mate distance pruning. Thanks to @jherrera80 for pointing out the mistake.

Bench: 23851500
