### PR TITLE
Fix root move sorting

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -682,6 +682,8 @@ static void AspirationWindow(Thread *thread, Stack *ss) {
 
         int score = AlphaBeta(thread, ss, alpha, beta, depth, false);
 
+        SortRootMoves(thread, multiPV);
+
         // Give an update when failing high/low in longer searches
         if (   mainThread
             && Limits.multiPV == 1
@@ -732,7 +734,7 @@ static void *IterativeDeepening(void *voidThread) {
             AspirationWindow(thread, ss);
 
         // Sort root moves so they are printed in the right order in multi-pv mode
-        SortRootMoves(thread, multiPV);
+        SortRootMoves(thread, 0);
 
         // Only the main thread concerns itself with the rest
         if (!mainThread) continue;

--- a/src/threads.c
+++ b/src/threads.c
@@ -48,20 +48,14 @@ void InitThreads(int count) {
         Threads[i].count = count;
 }
 
-// Sorts all rootmoves searched by multiPV
-void SortRootMoves(Thread *thread, int multiPV) {
-    for (int i = 0; i < multiPV; ++i) {
-
-        int bestIdx = i;
-        int bestScore = thread->rootMoves[i].score;
-
-        for (int k = i + 1; k < thread->rootMoveCount; ++k)
-            if (thread->rootMoves[k].score > bestScore)
-                bestScore = thread->rootMoves[bestIdx = k].score;
-
-        RootMove best = thread->rootMoves[bestIdx];
-        thread->rootMoves[bestIdx] = thread->rootMoves[i];
-        thread->rootMoves[i] = best;
+// Sorts all rootmoves beginning from the given index
+void SortRootMoves(Thread *thread, int begin) {
+    for (int i = begin + 1; i < thread->rootMoveCount; ++i) {
+        RootMove temp = thread->rootMoves[i];
+        int j = i - 1;
+        while (j >= 0 && thread->rootMoves[j].score < temp.score)
+            thread->rootMoves[j+1] = thread->rootMoves[j], --j;
+        thread->rootMoves[j+1] = temp;
     }
 }
 

--- a/src/threads.h
+++ b/src/threads.h
@@ -92,7 +92,7 @@ extern Thread *Threads;
 
 
 void InitThreads(int threadCount);
-void SortRootMoves(Thread *thread, int multiPV);
+void SortRootMoves(Thread *thread, int begin);
 uint64_t TotalNodes();
 uint64_t TotalTBHits();
 void PrepareSearch(Position *pos, Move searchmoves[]);


### PR DESCRIPTION
The old sort was meant to work with the previous way root moves were handled, they are now significantly different and so the sorting failed.

Elo   | 5.09 +- 3.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 12366 W: 3589 L: 3408 D: 5369
Penta | [221, 1378, 2837, 1493, 254]
http://chess.grantnet.us/test/38616/

Bench: 23851500