### PR TITLE
Change the formula for combining correction histories

### DIFF
--- a/src/history.h
+++ b/src/history.h
@@ -142,12 +142,14 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 }
 
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
-    return  *PawnCorrEntry() / 20
-          + *MatCorrEntry() / 29
-          + *ContCorrEntry(2) / 42
-          + *ContCorrEntry(3) / 44
-          + *ContCorrEntry(4) / 46
-          + *ContCorrEntry(5) / 42
-          + *ContCorrEntry(6) / 47
-          + *ContCorrEntry(7) / 44;
+    int c =  6554 * *PawnCorrEntry()
+           + 4520 * *MatCorrEntry()
+           + 3121 * *ContCorrEntry(2)
+           + 2979 * *ContCorrEntry(3)
+           + 2849 * *ContCorrEntry(4)
+           + 3121 * *ContCorrEntry(5)
+           + 2789 * *ContCorrEntry(6)
+           + 2979 * *ContCorrEntry(7);
+
+    return c / 131072;
 }


### PR DESCRIPTION
Elo   | 1.50 +- 2.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 31520 W: 8838 L: 8702 D: 13980
Penta | [594, 3833, 6835, 3839, 659]
http://chess.grantnet.us/test/38638/

Bench: 24311257