### PR TITLE
Clear the killer move for child nodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -335,6 +335,8 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
         }
     }
 
+    (ss+1)->killer = NOMOVE;
+
     // Do a static evaluation for pruning considerations
     int eval = ss->staticEval =  inCheck           ? NOSCORE
                                : lastMoveNullMove  ? -(ss-1)->staticEval + 2 * Tempo


### PR DESCRIPTION
Elo   | 1.32 +- 0.96 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 194686 W: 54098 L: 53358 D: 87230
Penta | [3590, 23161, 43118, 23867, 3607]
http://chess.grantnet.us/test/38655/

Elo   | 2.21 +- 1.72 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 46386 W: 11960 L: 11665 D: 22761
Penta | [304, 5454, 11418, 5677, 340]
http://chess.grantnet.us/test/38659/

Bench: 25584908