### PR TITLE
Add non-pawn evaluation correction history

### DIFF
--- a/src/board.c
+++ b/src/board.c
@@ -128,6 +128,18 @@ static Key GenMaterialKey(const Position *pos) {
     return key;
 }
 
+// Generates a hash key from scratch
+static Key GenNonPawnKey(const Position *pos, const Color color) {
+
+    Key key = 0;
+
+    for (Square sq = A1; sq <= H8; ++sq)
+        if (pieceOn(sq) != EMPTY && ColorOf(pieceOn(sq)) == color && PieceTypeOf(pieceOn(sq)) != PAWN)
+            key ^= PieceKeys[pieceOn(sq)][sq];
+
+    return key;
+}
+
 // Calculates the position key after a move. Fails
 // for special moves.
 Key KeyAfter(const Position *pos, const Move move) {
@@ -241,6 +253,8 @@ void ParseFen(const char *fen, Position *pos) {
     pos->checkers = Checkers(pos);
     pos->key = GenPosKey(pos);
     pos->materialKey = GenMaterialKey(pos);
+    pos->nonPawnKey[WHITE] = GenNonPawnKey(pos, WHITE);
+    pos->nonPawnKey[BLACK] = GenNonPawnKey(pos, BLACK);
     pos->phase = UpdatePhase(pos->phaseValue);
 
     free(copy);
@@ -528,6 +542,8 @@ bool PositionOk(const Position *pos) {
     assert(GenPosKey(pos)      == pos->key);
     assert(GenMaterialKey(pos) == pos->materialKey);
     assert(GenPawnKey(pos)     == pos->pawnKey);
+    assert(GenNonPawnKey(pos, WHITE) == pos->nonPawnKey[WHITE]);
+    assert(GenNonPawnKey(pos, BLACK) == pos->nonPawnKey[BLACK]);
 
     assert(!KingAttacked(pos, !sideToMove));
 

--- a/src/board.h
+++ b/src/board.h
@@ -53,6 +53,7 @@ typedef struct Position {
     Key key;
     Key materialKey;
     Key pawnKey;
+    Key nonPawnKey[COLOR_NB];
 
     uint64_t nodes;
     int trend;

--- a/src/history.h
+++ b/src/history.h
@@ -33,6 +33,7 @@
 #define PawnCorrEntry()         (&thread->pawnCorrHistory[thread->pos.stm][PawnCorrIndex(&thread->pos)])
 #define MatCorrEntry()          (&thread->matCorrHistory[thread->pos.stm][MatCorrIndex(&thread->pos)])
 #define ContCorrEntry(offset)   (&(*(ss-offset)->contCorr)[piece((ss-1)->move)][toSq((ss-1)->move)])
+#define NonPawnCorrEntry(color) (&thread->nonPawnCorrHistory[color][thread->pos.stm][NonPawnCorrIndex(&thread->pos, color)])
 
 #define QuietHistoryUpdate(move, bonus)        (HistoryBonus(QuietEntry(move),        bonus,  5280))
 #define PawnHistoryUpdate(move, bonus)         (HistoryBonus(PawnEntry(move),         bonus,  9275))
@@ -41,11 +42,13 @@
 #define PawnCorrHistoryUpdate(bonus)           (HistoryBonus(PawnCorrEntry(),         bonus,  1662))
 #define MatCorrHistoryUpdate(bonus)            (HistoryBonus(MatCorrEntry(),          bonus,  1077))
 #define ContCorrHistoryUpdate(offset, bonus)   (HistoryBonus(ContCorrEntry(offset),   bonus,  1220))
+#define NonPawnCorrHistoryUpdate(bonus, color) (HistoryBonus(NonPawnCorrEntry(color), bonus,  1024))
 
 
 INLINE int PawnStructure(const Position *pos) { return pos->pawnKey & (PAWN_HISTORY_SIZE - 1); }
 INLINE int PawnCorrIndex(const Position *pos) { return pos->pawnKey & (CORRECTION_HISTORY_SIZE - 1); }
 INLINE int MatCorrIndex(const Position *pos) { return pos->materialKey & (CORRECTION_HISTORY_SIZE - 1); }
+INLINE int NonPawnCorrIndex(const Position *pos, Color c) { return pos->nonPawnKey[c] & (CORRECTION_HISTORY_SIZE - 1); }
 
 
 INLINE void HistoryBonus(int16_t *entry, int bonus, int div) {
@@ -119,6 +122,8 @@ INLINE void UpdateCorrectionHistory(Thread *thread, Stack *ss, int bestScore, in
     int bonus = CorrectionBonus(bestScore, eval, depth);
     PawnCorrHistoryUpdate(bonus);
     MatCorrHistoryUpdate(bonus);
+    NonPawnCorrHistoryUpdate(bonus, WHITE);
+    NonPawnCorrHistoryUpdate(bonus, BLACK);
     ContCorrHistoryUpdate(2, bonus);
     ContCorrHistoryUpdate(3, bonus);
     ContCorrHistoryUpdate(4, bonus);
@@ -146,6 +151,7 @@ INLINE int GetHistory(const Thread *thread, Stack *ss, Move move) {
 INLINE int GetCorrectionHistory(const Thread *thread, const Stack *ss) {
     int c =  6554 * *PawnCorrEntry()
            + 4520 * *MatCorrEntry()
+           + 7000 * (*NonPawnCorrEntry(WHITE) + *NonPawnCorrEntry(BLACK))
            + 3121 * *ContCorrEntry(2)
            + 2979 * *ContCorrEntry(3)
            + 2849 * *ContCorrEntry(4)

--- a/src/makemove.c
+++ b/src/makemove.c
@@ -46,6 +46,8 @@ static void ClearPiece(Position *pos, const Square sq, const bool hash) {
 
     if (PieceTypeOf(piece) == PAWN)
         pos->pawnKey ^= PieceKeys[piece][sq];
+    else
+        pos->nonPawnKey[color] ^= PieceKeys[piece][sq];
 
     // Set square to empty
     pieceOn(sq) = EMPTY;
@@ -82,6 +84,8 @@ static void AddPiece(Position *pos, const Square sq, const Piece piece, const bo
 
     if (PieceTypeOf(piece) == PAWN)
         pos->pawnKey ^= PieceKeys[piece][sq];
+    else
+        pos->nonPawnKey[color] ^= PieceKeys[piece][sq];
 
     // Update square
     pieceOn(sq) = piece;
@@ -119,6 +123,8 @@ static void MovePiece(Position *pos, const Square from, const Square to, const b
 
     if (PieceTypeOf(piece) == PAWN)
         pos->pawnKey ^= PieceKeys[piece][from] ^ PieceKeys[piece][to];
+    else
+        pos->nonPawnKey[color] ^= PieceKeys[piece][from] ^ PieceKeys[piece][to];
 
     // Set old square to empty, new to piece
     pieceOn(from) = EMPTY;

--- a/src/threads.h
+++ b/src/threads.h
@@ -80,6 +80,7 @@ typedef struct Thread {
     ContinuationHistory continuation[2][2];
     CorrectionHistory pawnCorrHistory;
     CorrectionHistory matCorrHistory;
+    CorrectionHistory nonPawnCorrHistory[COLOR_NB];
     ContiuationCorrectionHistory contCorrHistory;
 
     int index;


### PR DESCRIPTION
Elo   | 2.80 +- 2.13 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 40336 W: 11397 L: 11072 D: 17867
Penta | [729, 4797, 8884, 4936, 822]
http://chess.grantnet.us/test/38662/

Elo   | 6.84 +- 3.57 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10726 W: 2797 L: 2586 D: 5343
Penta | [62, 1204, 2645, 1365, 87]
http://chess.grantnet.us/test/38665/

Bench: 24875792
