### PR TITLE
Only prune quiets based on history

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -471,7 +471,7 @@ move_loop:
                 mp.onlyNoisy = true;
 
             // History pruning
-            if (lmrDepth < 3 && ss->histScore < -1024 * depth)
+            if (quiet && lmrDepth < 3 && ss->histScore < -1024 * depth)
                 continue;
 
             // SEE pruning


### PR DESCRIPTION
Elo   | 1.46 +- 1.13 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 145398 W: 41797 L: 41184 D: 62417
Penta | [2856, 17148, 32123, 17671, 2901]
http://chess.grantnet.us/test/38748/

Elo   | 1.61 +- 1.29 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 83740 W: 22044 L: 21656 D: 40040
Penta | [620, 9936, 20405, 10254, 655]
http://chess.grantnet.us/test/38752/

Bench: 27558865