### PR TITLE
Simplify ProbCut condition

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -398,7 +398,7 @@ static int AlphaBeta(Thread *thread, Stack *ss, int alpha, int beta, Depth depth
 
     // ProbCut
     if (   depth >= 5
-        && (!ttHit || ttBound == BOUND_LOWER || ttScore >= probCutBeta)) {
+        && (!ttHit || ttScore >= probCutBeta)) {
 
         InitProbcutMP(&mp, thread, ss, probCutBeta - ss->staticEval);
 


### PR DESCRIPTION
Ignore the bound of the tt entry, so also lower bound scores can prevent trying ProbCut.

Elo   | 4.99 +- 3.82 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 12752 W: 3782 L: 3599 D: 5371
Penta | [250, 1451, 2812, 1592, 271]
http://chess.grantnet.us/test/38771/

Elo   | 0.13 +- 1.43 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 68478 W: 17959 L: 17933 D: 32586
Penta | [503, 8341, 16558, 8301, 536]
http://chess.grantnet.us/test/38774/

Bench: 27237021
