### PR TITLE
Report short commit id of HEAD in the id string

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -25,6 +25,14 @@ CC     = gcc
 POPCNT = -msse3 -mpopcnt
 PEXT   = $(POPCNT) -DUSE_PEXT -mbmi2
 
+# Short commit id of HEAD
+GIT_HEAD_COMMIT_ID_RAW := $(shell git rev-parse --short HEAD)
+ifneq ($(GIT_HEAD_COMMIT_ID_RAW),)
+GIT_HEAD_COMMIT_ID_DEF := -DGIT_HEAD_COMMIT_ID=\""$(GIT_HEAD_COMMIT_ID_RAW)"\"
+else
+GIT_HEAD_COMMIT_ID_DEF :=
+endif
+
 # Flags
 STD    = -std=gnu11
 LIBS   = -pthread -lm
@@ -32,7 +40,7 @@ WARN   = -Wall -Wextra -Wshadow -Werror -Wmissing-declarations
 NDEBUG = -DNDEBUG
 
 FLAGS  = $(STD) $(WARN) -O3 -flto=auto
-CFLAGS = $(FLAGS) -march=native
+CFLAGS = $(FLAGS) -march=native $(GIT_HEAD_COMMIT_ID_DEF)
 RFLAGS = $(FLAGS) -static
 
 # Use pext if supported and not a ryzen 1/2 cpu

--- a/src/uci.c
+++ b/src/uci.c
@@ -128,7 +128,16 @@ static void SetOption(char *str) {
 
 // Prints UCI info
 static void Info() {
-    printf("id name %s\n", NAME);
+
+    printf("id name %s%s\n",
+           NAME,
+#if defined(GIT_HEAD_COMMIT_ID)
+           " (" GIT_HEAD_COMMIT_ID ")"
+#else
+           ""
+#endif
+        );
+
     printf("id author Terje Kirstihagen\n");
     printf("option name Hash type spin default %d min %d max %d\n", HASH_DEFAULT, HASH_MIN, HASH_MAX);
     printf("option name Threads type spin default %d min %d max %d\n", 1, 1, 2048);


### PR DESCRIPTION
And if 'git rev-parse --short HEAD' fails for any reason, handle this case gracefully by not reporting anything. This could plausibly happen when building from zip-packaged sources.

Bench: 27237021

-----
The output is as follows:

```
boombox:~/projects-git/weiss/src % ./weiss
uci
id name Weiss 2.1-dev (1c8d8c3)
...
```
and in case `git` fails, the output is as is used to be:
```
boombox:~/projects-git/weiss/src % ./weiss
uci
id name Weiss 2.1-dev
...
```
This will make it easy to check the exact version of weiss in TCEC chat with `!he weiss id`, for example.
