### PR TITLE
Generate under-promotions as noisy

### DIFF
--- a/src/movegen.c
+++ b/src/movegen.c
@@ -30,19 +30,15 @@ INLINE void AddMove(const Position *pos, MoveList *list, const Square from, cons
 }
 
 // Adds promotions
-INLINE void AddPromotions(const Position *pos, MoveList *list, const Color color, const int type, Bitboard moves, const Direction dir) {
+INLINE void AddPromotions(const Position *pos, MoveList *list, const Color color, Bitboard moves, const Direction dir) {
     while (moves) {
         Square to = PopLsb(&moves);
         Square from = to - dir;
 
-        if (type == NOISY)
-            AddMove(pos, list, from, to, MakePiece(color, QUEEN), FLAG_NONE);
-
-        if (type == QUIET) {
-            AddMove(pos, list, from, to, MakePiece(color, KNIGHT), FLAG_NONE);
-            AddMove(pos, list, from, to, MakePiece(color, ROOK  ), FLAG_NONE);
-            AddMove(pos, list, from, to, MakePiece(color, BISHOP), FLAG_NONE);
-        }
+        AddMove(pos, list, from, to, MakePiece(color, QUEEN ), FLAG_NONE);
+        AddMove(pos, list, from, to, MakePiece(color, KNIGHT), FLAG_NONE);
+        AddMove(pos, list, from, to, MakePiece(color, ROOK  ), FLAG_NONE);
+        AddMove(pos, list, from, to, MakePiece(color, BISHOP), FLAG_NONE);
     }
 }
 
@@ -103,15 +99,13 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const Color color, cons
         AddPawnMoves(pos, list, doubles, up * 2, FLAG_PAWNSTART);
     }
 
-    // Promotions
-    AddPromotions(pos, list, color, type, lCap & promo, up+left);
-    AddPromotions(pos, list, color, type, rCap & promo, up+right);
-    Bitboard pushPromos = push & promo;
-    if (pos->checkers) pushPromos &= BetweenBB[kingSq(color)][Lsb(pos->checkers)];
-    AddPromotions(pos, list, color, type, pushPromos, up);
-
-    // Captures
+    // Promotions & Captures
     if (type == NOISY) {
+        AddPromotions(pos, list, color, lCap & promo, up+left);
+        AddPromotions(pos, list, color, rCap & promo, up+right);
+        Bitboard pushPromos = push & promo;
+        if (pos->checkers) pushPromos &= BetweenBB[kingSq(color)][Lsb(pos->checkers)];
+        AddPromotions(pos, list, color, pushPromos, up);
 
         AddPawnMoves(pos, list, lCap & normal, up+left,  FLAG_NONE);
         AddPawnMoves(pos, list, rCap & normal, up+right, FLAG_NONE);


### PR DESCRIPTION
Retire the split between queen promos and the rest.

Elo   | 0.02 +- 1.50 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 79908 W: 22509 L: 22505 D: 34894
Penta | [1492, 9606, 17745, 9628, 1483]
https://chess.grantnet.us/test/40709/

Elo   | 2.25 +- 2.57 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 21602 W: 5735 L: 5595 D: 10272
Penta | [176, 2538, 5250, 2644, 193]
https://chess.grantnet.us/test/40711/

Bench: 10721483
