### PR TITLE
Negative extension for non-singular cutnodes

### DIFF
--- a/src/search.c
+++ b/src/search.c
@@ -508,8 +508,8 @@ move_loop:
             // MultiCut - ttMove as well as at least one other move seem good enough to beat beta
             } else if (singularBeta >= beta)
                 return singularBeta;
-            // Negative extension - not singular but likely still good enough to beat beta
-            else if (ttScore >= beta)
+            // Negative extension - not singular but likely still good enough to beat beta or cutnode
+            else if (ttScore >= beta || cutnode)
                 extension = -1;
         }
 


### PR DESCRIPTION
Elo   | 3.25 +- 2.36 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 32388 W: 9246 L: 8943 D: 14199
Penta | [559, 3841, 7174, 3978, 642]
https://chess.grantnet.us/test/40715/

Elo   | 3.55 +- 2.42 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 23770 W: 6318 L: 6075 D: 11377
Penta | [165, 2750, 5837, 2943, 190]
https://chess.grantnet.us/test/40718/

Bench: 10408355
