### PR TITLE
Evaluate backward pawns

### DIFF
--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -39,7 +39,6 @@ Bitboard PseudoAttacks[TYPE_NB][64];
 Bitboard PawnAttacks[COLOR_NB][64];
 
 Bitboard PassedMask[COLOR_NB][64];
-Bitboard IsolatedMask[64];
 
 
 // Returns a bitboard with the landing square of the step,
@@ -134,8 +133,6 @@ CONSTR(2) InitBitboards() {
                     BetweenBB[sq1][sq2] = AttackBB(pt, sq1, BB(sq2)) & AttackBB(pt, sq2, BB(sq1));
 
     for (Square sq = A1; sq <= H8; ++sq) {
-
-        IsolatedMask[sq] = AdjacentFilesBB(sq);
 
         PassedMask[WHITE][sq] = ShiftBB(~rank1BB, NORTH * RelativeRank(WHITE, RankOf(sq)))
                               & (FileBB[FileOf(sq)] | AdjacentFilesBB(sq));

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -118,7 +118,6 @@ extern Bitboard PseudoAttacks[TYPE_NB][64];
 extern Bitboard PawnAttacks[COLOR_NB][64];
 
 extern Bitboard PassedMask[COLOR_NB][64];
-extern Bitboard IsolatedMask[64];
 
 
 // Shifts a bitboard (protonspring version)
@@ -143,6 +142,24 @@ INLINE Bitboard Fill(Bitboard bb, const Direction dir) {
     bb |= ShiftBB(bb, dir * 2);
     bb |= ShiftBB(bb, dir * 4);
     return bb;
+}
+
+INLINE Bitboard FileMask(int file) {
+    assert(file >= 0 && file <= 7);
+    return (Bitboard)0x0101010101010101 << file;
+}
+
+INLINE Bitboard RankMask(int rank) {
+    assert(rank >= 0 && rank <= 7);
+    return ((Bitboard)0xFF) << (8 * rank);
+}
+
+// Fills a bitboard in both vertical directions
+INLINE Bitboard FillFiles(Bitboard bb) {
+    bb |= bb >>  8;
+    bb |= bb >> 16;
+    bb |= bb >> 32;
+    return (bb & RankMask(RANK_1)) * FileMask(FILE_A);
 }
 
 // Returns a bitboard of adjacent files

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -60,8 +60,9 @@ const int PawnIsolated = S( -8,-16);
 const int PawnSupport  = S( 22, 17);
 const int PawnThreat   = S( 80, 34);
 const int PushThreat   = S( 25,  6);
-const int PawnOpen     = S(-14,-19);
-const int PawnBackward = S( -9,-19);
+const int PawnOpen     = S(-10,-15);
+const int PawnBackward = S( -1,-12);
+const int PawnBackOpen = S(-28,-12);
 const int BishopPair   = S( 33,110);
 const int KingAtkPawn  = S(-16, 45);
 const int OpenForward  = S( 28, 31);
@@ -190,10 +191,15 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard advanceThreatened = pawns & ShiftBB(theirPawnAttacks, down);
     Bitboard stuck = blocked | advanceThreatened;
     Bitboard defendable = Fill(ShiftBB(pawnAttacks, down), up);
-    Bitboard backward = stuck & pawnAdjacentFiles & ~defendable & open;
+    Bitboard backward = stuck & pawnAdjacentFiles & ~defendable;
     count = PopCount(backward);
     eval += PawnBackward * count;
     TraceCount(PawnBackward);
+
+    Bitboard backwardOpenPawns = backward & open;
+    count = PopCount(backwardOpenPawns);
+    eval += PawnBackOpen * count;
+    TraceCount(PawnBackOpen);
 
     // Phalanx
     Bitboard phalanx = pawns & ShiftBB(pawns, WEST);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -61,6 +61,7 @@ const int PawnSupport  = S( 22, 17);
 const int PawnThreat   = S( 80, 34);
 const int PushThreat   = S( 25,  6);
 const int PawnOpen     = S(-14,-19);
+const int PawnBackward = S( -9,-19);
 const int BishopPair   = S( 33,110);
 const int KingAtkPawn  = S(-16, 45);
 const int OpenForward  = S( 28, 31);
@@ -146,15 +147,19 @@ const int CountModifier[8] = { 0, 0, 63, 126, 96, 124, 124, 128 };
 INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
 
     const Direction down = color == WHITE ? SOUTH : NORTH;
+    const Direction   up = color == WHITE ? NORTH : SOUTH;
 
     int count, eval = 0;
 
     Bitboard pawns = colorPieceBB(color, PAWN);
+    Bitboard theirPawns = colorPieceBB(!color, PAWN);
     Bitboard pawnAttacks = PawnBBAttackBB(pawns, color);
+    Bitboard theirPawnAttacks = PawnBBAttackBB(theirPawns, !color);
+    Bitboard pawnFiles = FillFiles(pawns);
+    Bitboard pawnAdjacentFiles = ShiftBB(pawnFiles, WEST) | ShiftBB(pawnFiles, EAST);
 
     // Isolated pawns (no friendly pawns on adjacent files)
-    Bitboard pawnFiles = FillFiles(pawns);
-    Bitboard isolated = pawns & ~ShiftBB(pawnFiles, WEST) & ~ShiftBB(pawnFiles, EAST);
+    Bitboard isolated = pawns & ~pawnAdjacentFiles;
     count = PopCount(isolated);
     eval += PawnIsolated * count;
     TraceCount(PawnIsolated);
@@ -179,6 +184,16 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     count = PopCount(pawns & open & ~pawnAttacks);
     eval += PawnOpen * count;
     TraceCount(PawnOpen);
+
+    // Backward
+    Bitboard blocked = pawns & ShiftBB(theirPawns, down);
+    Bitboard advanceThreatened = pawns & ShiftBB(theirPawnAttacks, down);
+    Bitboard stuck = blocked | advanceThreatened;
+    Bitboard defendable = Fill(ShiftBB(pawnAttacks, down), up);
+    Bitboard backward = stuck & pawnAdjacentFiles & ~defendable;
+    count = PopCount(backward);
+    eval += PawnBackward * count;
+    TraceCount(PawnBackward);
 
     // Phalanx
     Bitboard phalanx = pawns & ShiftBB(pawns, WEST);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -190,7 +190,7 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard advanceThreatened = pawns & ShiftBB(theirPawnAttacks, down);
     Bitboard stuck = blocked | advanceThreatened;
     Bitboard defendable = Fill(ShiftBB(pawnAttacks, down), up);
-    Bitboard backward = stuck & pawnAdjacentFiles & ~defendable;
+    Bitboard backward = stuck & pawnAdjacentFiles & ~defendable & open;
     count = PopCount(backward);
     eval += PawnBackward * count;
     TraceCount(PawnBackward);

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -152,6 +152,13 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
     Bitboard pawns = colorPieceBB(color, PAWN);
     Bitboard pawnAttacks = PawnBBAttackBB(pawns, color);
 
+    // Isolated pawns (no friendly pawns on adjacent files)
+    Bitboard pawnFiles = FillFiles(pawns);
+    Bitboard isolated = pawns & ~ShiftBB(pawnFiles, WEST) & ~ShiftBB(pawnFiles, EAST);
+    count = PopCount(isolated);
+    eval += PawnIsolated * count;
+    TraceCount(PawnIsolated);
+
     // Doubled pawns (one directly in front of the other)
     count = PopCount(pawns & ShiftBB(pawns, NORTH));
     eval += PawnDoubled * count;
@@ -188,12 +195,6 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
 
         TraceIncr(PieceValue[PAWN-1]);
         TraceIncr(PSQT[PAWN-1][BlackRelativeSquare(color, sq)]);
-
-        // Isolated pawns
-        if (!(IsolatedMask[sq] & colorPieceBB(color, PAWN))) {
-            eval += PawnIsolated;
-            TraceIncr(PawnIsolated);
-        }
 
         // Passed pawns
         if (!((PassedMask[color][sq]) & colorPieceBB(!color, PAWN))) {

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -50,6 +50,7 @@ extern const int PawnThreat;
 extern const int PushThreat;
 extern const int PawnOpen;
 extern const int PawnBackward;
+extern const int PawnBackOpen;
 extern const int BishopPair;
 extern const int KingAtkPawn;
 extern const int OpenForward;
@@ -178,6 +179,7 @@ static void InitBaseParams(TVector tparams) {
     InitBaseSingle(PushThreat);
     InitBaseSingle(PawnOpen);
     InitBaseSingle(PawnBackward);
+    InitBaseSingle(PawnBackOpen);
     InitBaseSingle(BishopPair);
     InitBaseSingle(KingAtkPawn);
     InitBaseSingle(OpenForward);
@@ -251,6 +253,7 @@ static void PrintParameters(TVector updates, TVector base) {
     PrintSingle(PushThreat, "  ");
     PrintSingle(PawnOpen, "    ");
     PrintSingle(PawnBackward, "");
+    PrintSingle(PawnBackOpen, "");
     PrintSingle(BishopPair, "  ");
     PrintSingle(KingAtkPawn, " ");
     PrintSingle(OpenForward, " ");
@@ -319,6 +322,7 @@ static void InitCoefficients(TCoeffs coeffs) {
     InitCoeffSingle(PushThreat);
     InitCoeffSingle(PawnOpen);
     InitCoeffSingle(PawnBackward);
+    InitCoeffSingle(PawnBackOpen);
     InitCoeffSingle(BishopPair);
     InitCoeffSingle(KingAtkPawn);
     InitCoeffSingle(OpenForward);

--- a/src/tuner/tuner.c
+++ b/src/tuner/tuner.c
@@ -49,6 +49,7 @@ extern const int PawnSupport;
 extern const int PawnThreat;
 extern const int PushThreat;
 extern const int PawnOpen;
+extern const int PawnBackward;
 extern const int BishopPair;
 extern const int KingAtkPawn;
 extern const int OpenForward;
@@ -176,6 +177,7 @@ static void InitBaseParams(TVector tparams) {
     InitBaseSingle(PawnThreat);
     InitBaseSingle(PushThreat);
     InitBaseSingle(PawnOpen);
+    InitBaseSingle(PawnBackward);
     InitBaseSingle(BishopPair);
     InitBaseSingle(KingAtkPawn);
     InitBaseSingle(OpenForward);
@@ -248,6 +250,7 @@ static void PrintParameters(TVector updates, TVector base) {
     PrintSingle(PawnThreat, "  ");
     PrintSingle(PushThreat, "  ");
     PrintSingle(PawnOpen, "    ");
+    PrintSingle(PawnBackward, "");
     PrintSingle(BishopPair, "  ");
     PrintSingle(KingAtkPawn, " ");
     PrintSingle(OpenForward, " ");
@@ -315,6 +318,7 @@ static void InitCoefficients(TCoeffs coeffs) {
     InitCoeffSingle(PawnThreat);
     InitCoeffSingle(PushThreat);
     InitCoeffSingle(PawnOpen);
+    InitCoeffSingle(PawnBackward);
     InitCoeffSingle(BishopPair);
     InitCoeffSingle(KingAtkPawn);
     InitCoeffSingle(OpenForward);

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -49,7 +49,7 @@
 // #define NPOSITIONS   (14669229) // Total FENS in the book
 
 
-#define NTERMS       (     552) // Number of terms being tuned
+#define NTERMS       (     553) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -78,6 +78,7 @@ typedef struct EvalTrace {
     int PawnThreat[COLOR_NB];
     int PushThreat[COLOR_NB];
     int PawnOpen[COLOR_NB];
+    int PawnBackward[COLOR_NB];
     int BishopPair[COLOR_NB];
     int KingAtkPawn[COLOR_NB];
     int OpenForward[COLOR_NB];

--- a/src/tuner/tuner.h
+++ b/src/tuner/tuner.h
@@ -49,7 +49,7 @@
 // #define NPOSITIONS   (14669229) // Total FENS in the book
 
 
-#define NTERMS       (     553) // Number of terms being tuned
+#define NTERMS       (     554) // Number of terms being tuned
 #define MAXEPOCHS    (   10000) // Max number of epochs allowed
 #define REPORTING    (      50) // How often to print the new parameters
 #define NPARTITIONS  (      64) // Total thread partitions
@@ -79,6 +79,7 @@ typedef struct EvalTrace {
     int PushThreat[COLOR_NB];
     int PawnOpen[COLOR_NB];
     int PawnBackward[COLOR_NB];
+    int PawnBackOpen[COLOR_NB];
     int BishopPair[COLOR_NB];
     int KingAtkPawn[COLOR_NB];
     int OpenForward[COLOR_NB];


### PR DESCRIPTION
Also switch from evaluating isolated status on a per-pawn basis to all at once.

Elo   | 2.87 +- 2.17 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 38590 W: 11094 L: 10775 D: 16721
Penta | [709, 4543, 8521, 4764, 758]
https://chess.grantnet.us/test/40723/

Elo   | 1.25 +- 0.96 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 153080 W: 40252 L: 39701 D: 73127
Penta | [1136, 18242, 37232, 18795, 1135]
https://chess.grantnet.us/test/40724/

Bench: 10625614