### PR TITLE
Add more Bitboard helper functions

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
         expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
         echo "Expected: $expected"
-        bench=$(./weiss bench | tail -n 1)
+        bench=$(./weiss bench | tail -n 1) || { echo "Benchmark failed"; exit 1; }
         echo "Bench: $bench"
         actual=$(echo $bench | grep -Po '(?<=\s)\d+(?=\s+nodes)')
         echo "Actual: $actual"

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -50,6 +50,7 @@ jobs:
       run: |
         expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
         echo "Expected: $expected"
+        ./weiss bench
         bench=$(./weiss bench | tail -n 1) || { echo "Benchmark failed"; exit 1; }
         echo "Bench: $bench"
         actual=$(echo $bench | grep -Po '(?<=\s)\d+(?=\s+nodes)')

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -50,8 +50,7 @@ jobs:
       run: |
         expected=$(git show --summary | grep -Po '(?<=Bench: )[0-9]+?(?=$)')
         echo "Expected: $expected"
-        ./weiss bench
-        bench=$(./weiss bench | tail -n 1) || { echo "Benchmark failed"; exit 1; }
+        bench=$(./weiss bench | tail -n 1)
         echo "Bench: $bench"
         actual=$(echo $bench | grep -Po '(?<=\s)\d+(?=\s+nodes)')
         echo "Actual: $actual"

--- a/src/bitboard.c
+++ b/src/bitboard.c
@@ -20,14 +20,6 @@
 #include "board.h"
 
 
-const Bitboard FileBB[FILE_NB] = {
-    fileABB, fileBBB, fileCBB, fileDBB, fileEBB, fileFBB, fileGBB, fileHBB
-};
-
-const Bitboard RankBB[RANK_NB] = {
-    rank1BB, rank2BB, rank3BB, rank4BB, rank5BB, rank6BB, rank7BB, rank8BB
-};
-
 Bitboard BetweenBB[64][64];
 
 static Bitboard BishopAttacks[5248];
@@ -98,8 +90,8 @@ static void InitSliderAttacks(PieceType pt, Bitboard table[]) {
         Magic *m = &Magics[sq][pt - BISHOP];
         (*m).attacks = table;
 
-        Bitboard edges = ((rank1BB | rank8BB) & ~RankBB[RankOf(sq)])
-                       | ((fileABB | fileHBB) & ~FileBB[FileOf(sq)]);
+        Bitboard edges = ((rank1BB | rank8BB) & ~RankBBOf(sq))
+                       | ((fileABB | fileHBB) & ~FileBBOf(sq));
 
         (*m).mask = MakeSliderAttackBB(sq, pt, 0) & ~edges;
 
@@ -135,10 +127,10 @@ CONSTR(2) InitBitboards() {
     for (Square sq = A1; sq <= H8; ++sq) {
 
         PassedMask[WHITE][sq] = ShiftBB(~rank1BB, NORTH * RelativeRank(WHITE, RankOf(sq)))
-                              & (FileBB[FileOf(sq)] | AdjacentFilesBB(sq));
+                              & (FileBBOf(sq) | AdjacentFilesBB(sq));
 
         PassedMask[BLACK][sq] = ShiftBB(~rank8BB, SOUTH * RelativeRank(BLACK, RankOf(sq)))
-                              & (FileBB[FileOf(sq)] | AdjacentFilesBB(sq));
+                              & (FileBBOf(sq) | AdjacentFilesBB(sq));
     }
 }
 

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -140,7 +140,7 @@ INLINE Bitboard BB(const Square sq) {
 
 INLINE Bitboard RankBB(const int r) {
     assert(r >= RANK_1 && r <= RANK_8);
-    return rank1BB << (FILE_NB * r);
+    return (Bitboard)rank1BB << (FILE_NB * r);
 }
 
 INLINE Bitboard RankBBOf(const Square sq) {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -82,7 +82,7 @@ typedef struct {
 #endif
 } Magic;
 
-enum {
+enum : Bitboard {
     fileABB = 0x0101010101010101,
     fileBBB = 0x0202020202020202,
     fileCBB = 0x0404040404040404,
@@ -140,7 +140,7 @@ INLINE Bitboard BB(const Square sq) {
 
 INLINE Bitboard RankBB(const int r) {
     assert(r >= RANK_1 && r <= RANK_8);
-    return (Bitboard)rank1BB << (FILE_NB * r);
+    return rank1BB << (FILE_NB * r);
 }
 
 INLINE Bitboard RankBBOf(const Square sq) {

--- a/src/bitboard.h
+++ b/src/bitboard.h
@@ -108,9 +108,6 @@ enum {
     CentralFilesBB = fileCBB | fileDBB | fileEBB | fileFBB,
 };
 
-extern const Bitboard FileBB[FILE_NB];
-extern const Bitboard RankBB[RANK_NB];
-
 extern Bitboard BetweenBB[64][64];
 
 extern Magic Magics[64][2];
@@ -141,6 +138,44 @@ INLINE Bitboard BB(const Square sq) {
     return 1ull << sq;
 }
 
+INLINE Bitboard RankBB(const int r) {
+    assert(r >= RANK_1 && r <= RANK_8);
+    return rank1BB << (FILE_NB * r);
+}
+
+INLINE Bitboard RankBBOf(const Square sq) {
+    assert(sq <= H8);
+    return RankBB(RankOf(sq));
+}
+
+INLINE Bitboard RelativeRankBB(const Color color, const int r) {
+    assert(r >= RANK_1 && r <= RANK_8);
+    return RankBB(RelativeRank(color, r));
+}
+
+INLINE Bitboard FileBB(const int f) {
+    assert(f >= FILE_A && f <= FILE_H);
+    return fileABB << f;
+}
+
+INLINE Bitboard FileBBOf(const Square sq) {
+    assert(sq <= H8);
+    return FileBB(FileOf(sq));
+}
+
+INLINE Bitboard ForwardRanksBB(const Color color, const Square sq) {
+    return color == WHITE ? ~rank1BB << FILE_NB * RelativeRank(color, RankOf(sq))
+                          : ~rank8BB >> FILE_NB * RelativeRank(color, RankOf(sq));
+}
+
+INLINE Bitboard ForwardFileBB(const Color color, const Square sq) {
+    return ForwardRanksBB(color, sq) & FileBBOf(sq);
+}
+
+INLINE Bitboard PassedPawnMask(const Color color, const Square sq) {
+    return PassedMask[color][sq];
+}
+
 // Fills a bitboard in either vertical direction
 INLINE Bitboard Fill(Bitboard bb, const Direction dir) {
     assert((dir & 7) == 0);
@@ -159,8 +194,8 @@ INLINE Bitboard FillFiles(Bitboard bb) {
 
 // Returns a bitboard of adjacent files
 INLINE Bitboard AdjacentFilesBB(const Square sq) {
-    return ShiftBB(FileBB[FileOf(sq)], WEST)
-         | ShiftBB(FileBB[FileOf(sq)], EAST);
+    return ShiftBB(FileBBOf(sq), WEST)
+         | ShiftBB(FileBBOf(sq), EAST);
 }
 
 // Population count/Hamming weight

--- a/src/evaluate.c
+++ b/src/evaluate.c
@@ -218,7 +218,7 @@ INLINE int EvalPawns(const Position *pos, EvalInfo *ei, const Color color) {
         TraceIncr(PSQT[PAWN-1][BlackRelativeSquare(color, sq)]);
 
         // Passed pawns
-        if (!((PassedMask[color][sq]) & colorPieceBB(!color, PAWN))) {
+        if (!(PassedPawnMask(color, sq) & colorPieceBB(!color, PAWN))) {
 
             int rank = RelativeRank(color, RankOf(sq));
 
@@ -258,7 +258,6 @@ static int ProbePawnCache(const Position *pos, EvalInfo *ei, PawnCache pc) {
 // Evaluates knights, bishops, rooks, or queens
 INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const PieceType pt) {
 
-    const Direction up   = color == WHITE ? NORTH : SOUTH;
     const Direction down = color == WHITE ? SOUTH : NORTH;
 
     int eval = 0;
@@ -321,7 +320,7 @@ INLINE int EvalPiece(const Position *pos, EvalInfo *ei, const Color color, const
 
         // Forward mobility for rooks
         if (pt == ROOK) {
-            Bitboard forward = Fill(BB(sq), up);
+            Bitboard forward = ForwardFileBB(color, sq);
             if (!(forward & pieceBB(PAWN))) {
                 eval += OpenForward;
                 TraceIncr(OpenForward);
@@ -345,7 +344,7 @@ INLINE int EvalKings(const Position *pos, EvalInfo *ei, const Color color) {
     TraceIncr(PSQT[KING-1][BlackRelativeSquare(color, kingSq)]);
 
     // Open lines from the king
-    Bitboard SafeLine = RankBB[RelativeRank(color, RANK_1)];
+    Bitboard SafeLine = RelativeRankBB(color, RANK_1);
     int count = PopCount(~SafeLine & AttackBB(QUEEN, kingSq, colorBB(color) | pieceBB(PAWN)));
     eval += KingLineDanger[count];
     TraceIncr(KingLineDanger[count]);
@@ -364,7 +363,7 @@ INLINE int EvalKings(const Position *pos, EvalInfo *ei, const Color color) {
     TraceDanger(S(danger / 128, 0));
 
     // Pawn shelter
-    Bitboard pawnsInFront = pieceBB(PAWN) & PassedMask[color][kingSq];
+    Bitboard pawnsInFront = pieceBB(PAWN) & PassedPawnMask(color, kingSq);
     Bitboard ourPawns = pawnsInFront & colorBB(color) & ~PawnBBAttackBB(colorPieceBB(!color, PAWN), !color);
 
     count = PopCount(ourPawns);
@@ -499,7 +498,7 @@ INLINE void InitEvalInfo(const Position *pos, EvalInfo *ei, const Color color) {
 
     // Mobility area is defined as any square not attacked by an enemy pawn, nor
     // occupied by our own pawn either on its starting square or blocked from advancing.
-    b = pawns & (RankBB[RelativeRank(color, RANK_2)] | ShiftBB(pieceBB(ALL), down));
+    b = pawns & (RelativeRankBB(color, RANK_2) | ShiftBB(pieceBB(ALL), down));
     ei->mobilityArea[color] = ~(b | PawnBBAttackBB(colorPieceBB(!color, PAWN), !color));
 
     // King Safety

--- a/src/movegen.c
+++ b/src/movegen.c
@@ -89,7 +89,7 @@ INLINE void GenPawn(const Position *pos, MoveList *list, const Color color, cons
     if (type == QUIET) {
 
         Bitboard moves = push & normal;
-        Bitboard doubles = ShiftBB(moves, up) & empty & RankBB[RelativeRank(color, RANK_4)];
+        Bitboard doubles = ShiftBB(moves, up) & empty & RelativeRankBB(color, RANK_4);
 
         if (pos->checkers)
             moves   &= BetweenBB[kingSq(color)][Lsb(pos->checkers)],


### PR DESCRIPTION
Replaces the FileBB and RankBB arrays with functions, and adds more related functions to simplify common use cases combining multiple old helpers like `FileBB(FileOf(sq))`.

Also specify that the Bitboard enum values should be of type Bitboard (uint64_t) to avoid potential bugs. Clang in GitHub Actions treated the small values as int leading to incorrect results and eventually segfault.

No functional change, possibly tiny slowdown.

Bench: 10625614